### PR TITLE
Write playlist position to metadata track number

### DIFF
--- a/NickvisionTubeConverter.GNOME/Controls/MediaRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/MediaRow.cs
@@ -24,8 +24,8 @@ public class MediaRow : Adw.EntryRow
         //Build UI
         builder.Connect(this);
         SetText(_mediaInfo.Title);
-        SetTitle(_mediaInfo.IsPartOfPlaylist ? _mediaInfo.Url : _("File Name"));
-        _downloadCheck.GetParent().SetVisible(_mediaInfo.IsPartOfPlaylist);
+        SetTitle(_mediaInfo.PlaylistPosition > 0 ? _mediaInfo.Url : _("File Name"));
+        _downloadCheck.GetParent().SetVisible(_mediaInfo.PlaylistPosition > 0);
         _downloadCheck.SetActive(_mediaInfo.ToDownload);
         _downloadCheck.OnNotify += (sender, e) =>
         {
@@ -60,15 +60,7 @@ public class MediaRow : Adw.EntryRow
     public void UpdateTitle(bool numbered)
     {
         SetText(_mediaInfo.Title);
-        if (numbered)
-        {
-            var numberedRegex = new Regex(@"[0-9]+ - ", RegexOptions.None);
-            _numberString = numberedRegex.Match(_mediaInfo.Title).Value;
-        }
-        else
-        {
-            _numberString = "";
-        }
+        _numberString = numbered ? $"{_mediaInfo.PlaylistPosition} - " : "";
     }
 
     private bool OnKeyPressed(Gtk.EventControllerKey sender, Gtk.EventControllerKey.KeyPressedSignalArgs e)

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -48,8 +48,8 @@ public partial class Program
         _mainWindowController.AppInfo.Name = "Nickvision Tube Converter";
         _mainWindowController.AppInfo.ShortName = _("Parabolic");
         _mainWindowController.AppInfo.Description = $"{_("Download web video and audio")}.";
-        _mainWindowController.AppInfo.Version = "2023.7.0";
-        _mainWindowController.AppInfo.Changelog = "<ul><li>Fixed an issue where the Help page couldn't be accessed after the name change</li><li>Updated translations (Thanks everyone on Weblate!)</li></ul>";
+        _mainWindowController.AppInfo.Version = "2023.7.1-rc1";
+        _mainWindowController.AppInfo.Changelog = "<ul><li>Fixed an issue where CPU usage was high during download due to excessive logging</li><li>When downloading a playlist, a media's position will be written to the tag's track property</li><li>Updated translations (Thanks everyone on Weblate!)</li></ul>";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/NickvisionApps/Parabolic");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/NickvisionApps/Parabolic/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/NickvisionApps/Parabolic/discussions");

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -179,18 +179,18 @@ public class AddDownloadDialogController
         if(_mediaUrlInfo != null)
         {
             var numberedRegex = new Regex(@"[0-9]+ - ", RegexOptions.None);
-            for (var i = 0; i < _mediaUrlInfo.MediaList.Count; i++)
+            foreach (var m in _mediaUrlInfo.MediaList)
             {
                 if (toggled)
                 {
-                    _mediaUrlInfo.MediaList[i].Title = $"{i + 1} - {_mediaUrlInfo.MediaList[i].Title}";
+                    m.Title = $"{m.PlaylistPosition} - {m.Title}";
                 }
                 else
                 {
-                    var match = numberedRegex.Match(_mediaUrlInfo.MediaList[i].Title);
+                    var match = numberedRegex.Match(m.Title);
                     if (match.Success)
                     {
-                        _mediaUrlInfo.MediaList[i].Title = _mediaUrlInfo.MediaList[i].Title.Remove(_mediaUrlInfo.MediaList[i].Title.IndexOf(match.Value), match.Value.Length);
+                        m.Title = m.Title.Remove(m.Title.IndexOf(match.Value), match.Value.Length);
                     }
                 }
             }
@@ -257,7 +257,7 @@ public class AddDownloadDialogController
         {
             if (media.ToDownload)
             {
-                Downloads.Add(new Download(media.Url, mediaFileType, saveFolder, media.Title, limitSpeed, Configuration.Current.SpeedLimit, quality, resolution == null ? null : _mediaUrlInfo.VideoResolutions[resolution.Value], subtitles, cropThumbnail, timeframe, username, password));
+                Downloads.Add(new Download(media.Url, mediaFileType, saveFolder, media.Title, limitSpeed, Configuration.Current.SpeedLimit, quality, resolution == null ? null : _mediaUrlInfo.VideoResolutions[resolution.Value], subtitles, cropThumbnail, timeframe, media.PlaylistPosition, username, password));
             }
         }
         Configuration.Current.PreviousSaveFolder = saveFolder;

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -37,12 +37,13 @@ public class Download
 {
     private readonly string _tempDownloadPath;
     private readonly string _logPath;
-    private bool _limitSpeed;
-    private uint _speedLimit;
-    private bool _cropThumbnail;
-    private Timeframe? _timeframe;
-    private string? _username;
-    private string? _password;
+    private readonly bool _limitSpeed;
+    private readonly uint _speedLimit;
+    private readonly bool _cropThumbnail;
+    private readonly Timeframe? _timeframe;
+    private readonly uint _playlistPosition;
+    private readonly string? _username;
+    private readonly string? _password;
     private ulong? _pid;
     private Dictionary<string, dynamic>? _ytOpt;
     private dynamic? _outFile;
@@ -119,10 +120,11 @@ public class Download
     /// <param name="subtitle">The subtitles for the download</param>
     /// <param name="cropThumbnail">Whether or not to crop the thumbnail</param>
     /// <param name="timeframe">A Timeframe to restrict the timespan of the media download</param>
+    /// <param name="playlistPosition">Position in playlist starting with 1, or 0 if not in playlist</param>
     /// <param name="username">A username for the website (if available)</param>
     /// <param name="password">A password for the website (if available)</param>
     /// <exception cref="ArgumentException">Thrown if timeframe is specified and limitSpeed is enabled</exception>
-    public Download(string mediaUrl, MediaFileType fileType, string saveFolder, string saveFilename, bool limitSpeed, uint speedLimit, Quality quality, VideoResolution? resolution, Subtitle subtitle, bool cropThumbnail, Timeframe? timeframe, string? username, string? password)
+    public Download(string mediaUrl, MediaFileType fileType, string saveFolder, string saveFilename, bool limitSpeed, uint speedLimit, Quality quality, VideoResolution? resolution, Subtitle subtitle, bool cropThumbnail, Timeframe? timeframe, uint playlistPosition, string? username, string? password)
     {
         Id = Guid.NewGuid();
         MediaUrl = mediaUrl;
@@ -142,6 +144,7 @@ public class Download
         _speedLimit = speedLimit;
         _cropThumbnail = cropThumbnail;
         _timeframe = timeframe;
+        _playlistPosition = playlistPosition;
         _username = username;
         _password = password;
         _pid = null;
@@ -269,7 +272,7 @@ public class Download
                 }
                 if (options.EmbedMetadata)
                 {
-                    postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "MetadataFromField" }, { "formats", new List<string>() { ":(?P<meta_comment>)", ":(?P<meta_description>)", ":(?P<meta_synopsis>)", ":(?P<meta_purl>)" } } });
+                    postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "MetadataFromField" }, { "formats", new List<string>() { ":(?P<meta_comment>)", ":(?P<meta_description>)", ":(?P<meta_synopsis>)", ":(?P<meta_purl>)", $"{_playlistPosition}:%(meta_track)s"} } });
                     postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "TCMetadata" }, { "add_metadata", true } });
                     if (FileType.GetSupportsThumbnails())
                     {

--- a/NickvisionTubeConverter.Shared/Models/MediaInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/MediaInfo.cs
@@ -24,9 +24,9 @@ public class MediaInfo : INotifyPropertyChanged
     /// </summary>
     public double Duration { get; init; }
     /// <summary>
-    /// Whether or not the media is part of a playlist 
+    /// Position of media in playlist, starting with 1 (0 means it's not part of playlist)
     /// </summary>
-    public bool IsPartOfPlaylist { get; init; }
+    public uint PlaylistPosition { get; init; }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -35,15 +35,16 @@ public class MediaInfo : INotifyPropertyChanged
     /// </summary>
     /// <param name="url">The url of the media</param>
     /// <param name="title">The title of the media</param>
-    /// <param name="partOfPlaylist">Whether or not the media is part of a playlist</param>
-    public MediaInfo(string url, string title, double duration, bool partOfPlaylist = false)
+    /// <param name="duration">The duration of the media in seconds</param>
+    /// <param name="playlistPosition">Position in playlist starting with 1, or 0 if not in playlist</param>
+    public MediaInfo(string url, string title, double duration, uint playlistPosition)
     {
         _title = title;
         _toDownload = true;
         Url = url;
         OriginalTitle = title;
         Duration = duration;
-        IsPartOfPlaylist = partOfPlaylist;
+        PlaylistPosition = playlistPosition;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
@@ -83,18 +83,20 @@ public class MediaUrlInfo
                     }
                     if (mediaInfo.HasKey("entries"))
                     {
+                        var i = 1u;
                         foreach (var e in mediaInfo["entries"].As<PyList>())
                         {
                             if (e.IsNone())
                             {
                                 continue;
                             }
-                            mediaUrlInfo.ParseFromPyDict(yt, e.As<PyDict>(), true, url);
+                            mediaUrlInfo.ParseFromPyDict(yt, e.As<PyDict>(), i, url);
+                            i++;
                         }
                     }
                     else
                     {
-                        mediaUrlInfo.ParseFromPyDict(yt, mediaInfo, false, url);
+                        mediaUrlInfo.ParseFromPyDict(yt, mediaInfo, 0, url);
                     }
                     outFile.close();
                 }
@@ -153,9 +155,9 @@ public class MediaUrlInfo
     /// </summary>
     /// <param name="yt">The YouttubeDL object</param>
     /// <param name="mediaInfo">Python dictionary with media info</param>
-    /// <param name="isPartOfPlaylist">Whether or not the media is part of a playlist</param>
+    /// <param name="playlistPosition">Position in playlist starting with 1, or 0 if not in playlist</param>
     /// <param name="defaultUrl">A default URL to use if none available</param>
-    private void ParseFromPyDict(dynamic yt, PyDict mediaInfo, bool isPartOfPlaylist, string defaultUrl)
+    private void ParseFromPyDict(dynamic yt, PyDict mediaInfo, uint playlistPosition, string defaultUrl)
     {
         var title = mediaInfo.HasKey("title") ? (mediaInfo["title"].As<string?>() ?? "Media") : "Media";
         foreach (var c in Path.GetInvalidFileNameChars())
@@ -195,6 +197,6 @@ public class MediaUrlInfo
         {
             url = mediaInfo["url"].As<string>();
         }
-        MediaList.Add(new MediaInfo(url, title, duration, isPartOfPlaylist));
+        MediaList.Add(new MediaInfo(url, title, duration, playlistPosition));
     }
 }

--- a/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
@@ -50,9 +50,10 @@
   </custom>
   
   <releases>
-    <release version="2023.7.0" date="2023-07-01">
+    <release version="2023.7.1" date="2023-07-07">
       <description translatable="no">
-        <p>- Fixed an issue where the Help page couldn't be accessed after the name change</p>
+        <p>- Fixed an issue where CPU usage was high during download due to excessive logging</p>
+        <p>- When downloading a playlist, a media's position will be written to the tag's track property</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>


### PR DESCRIPTION
Closes #417

I initially implemented it with a switch in add download dialog to disable it, but then I thought: what is the use-case for disabling it and is there any harm in writing track tag also for video? I think no use-case and no harm, so it just writes track number whenever the container allows it (MP4 doesn't).

When downloading single media, 0 will be written, but yt-dlp already did this by default (at least for audio files), so there's no changes here.