### PR TITLE
Support Opening History Downloads + Empty History State

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp
@@ -51,17 +51,34 @@ Adw.Window _root {
 
         Gtk.Separator {}
       
-        Gtk.ScrolledWindow _scrolledWindow {
-          propagate-natural-height: true;
-          max-content-height: 300;
+        Adw.ViewStack _viewStack {
+          Adw.ViewStackPage {
+            name: "no-history";
+            child: Adw.StatusPage {
+              icon-name: "document-open-recent-symbolic";
+              title: _("No Previous Downloads");
 
-          child: Adw.PreferencesGroup _urlsGroup {
-            margin-top: 12;
-            margin-start: 12;
-            margin-end: 12;
-            margin-bottom: 12;
-          };
-          
+              styles ["compact"]
+            };
+          }
+
+          Adw.ViewStackPage {
+            name: "history";
+            child: Gtk.ScrolledWindow _scrolledWindow {
+              hexpand: true;
+              vexpand: true;
+              propagate-natural-height: true;
+              max-content-height: 300;
+
+              child: Adw.PreferencesGroup _urlsGroup {
+                margin-top: 12;
+                margin-start: 12;
+                margin-end: 12;
+                margin-bottom: 12;
+              };
+            };
+          }
+
           styles ["view"]
         }
       }

--- a/NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs
@@ -84,7 +84,7 @@ public partial class HistoryDialog : Adw.Window
             {
                 var openButton = Gtk.Button.New();
                 openButton.SetIconName("document-open-symbolic");
-                openButton.SetTooltipText(_("Open in File Manager"));
+                openButton.SetTooltipText(_("Open"));
                 openButton.SetValign(Gtk.Align.Center);
                 openButton.AddCssClass("flat");
                 openButton.OnClicked += (sender, e) =>

--- a/NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs
@@ -66,6 +66,20 @@ public partial class HistoryDialog : Adw.Window
             }
             row.SetTitleLines(1);
             row.SetSubtitleLines(1);
+            if(File.Exists(pair.Value.Path))
+            {
+                var openButton = Gtk.Button.New();
+                openButton.SetIconName("media-playback-start-symbolic");
+                openButton.SetTooltipText(_("Play"));
+                openButton.SetValign(Gtk.Align.Center);
+                openButton.AddCssClass("flat");
+                openButton.OnClicked += (sender, e) =>
+                {
+                    var fileLauncher = Gtk.FileLauncher.New(Gio.FileHelper.NewForPath(pair.Value.Path));
+                    gtk_file_launcher_launch(fileLauncher.Handle, 0, 0, (source, res, data) => { }, 0);
+                };
+                row.AddSuffix(openButton);
+            }
             var downloadButton = Gtk.Button.New();
             downloadButton.SetIconName("view-refresh-symbolic");
             downloadButton.SetTooltipText(_("Download Again"));
@@ -76,20 +90,6 @@ public partial class HistoryDialog : Adw.Window
                 DownloadAgainRequested?.Invoke(this, pair.Key);
             };
             row.AddSuffix(downloadButton);
-            if(File.Exists(pair.Value.Path))
-            {
-                var openButton = Gtk.Button.New();
-                openButton.SetIconName("document-open-symbolic");
-                openButton.SetTooltipText(_("Open"));
-                openButton.SetValign(Gtk.Align.Center);
-                openButton.AddCssClass("flat");
-                openButton.OnClicked += (sender, e) =>
-                {
-                    var fileLauncher = Gtk.FileLauncher.New(Gio.FileHelper.NewForPath(pair.Value.Path));
-                    gtk_file_launcher_launch(fileLauncher.Handle, 0, 0, (source, res, data) => { }, 0);
-                };
-                row.AddSuffix(openButton);
-            }
             row.SetActivatableWidget(downloadButton);
             _urlsGroup.Add(row);
             _historyRows.Add(row);

--- a/NickvisionTubeConverter.Shared/Models/DownloadHistory.cs
+++ b/NickvisionTubeConverter.Shared/Models/DownloadHistory.cs
@@ -16,14 +16,14 @@ public class DownloadHistory
     /// <summary>
     /// The download history
     /// </summary>
-    public Dictionary<string, (string Title, DateTime Date)> History { get; set; }
+    public Dictionary<string, (string Title, DateTime Date, string Path)> History { get; set; }
     
     /// <summary>
     /// Constructs a DownloadHistory
     /// </summary>
     public DownloadHistory()
     {
-        History = new Dictionary<string, (string Title, DateTime Date)>();
+        History = new Dictionary<string, (string Title, DateTime Date, string Path)>();
     }
     
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Models/DownloadManager.cs
+++ b/NickvisionTubeConverter.Shared/Models/DownloadManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using static NickvisionTubeConverter.Shared.Helpers.Gettext;
 
 namespace NickvisionTubeConverter.Shared.Models;
@@ -200,7 +201,7 @@ public class DownloadManager
             DownloadAdded?.Invoke(this, (download.Id, download.Filename, download.SaveFolder, false));
         }
         var history = DownloadHistory.Current;
-        history.History[download.MediaUrl] = (download.Filename, DateTime.Now);
+        history.History[download.MediaUrl] = (Path.GetFileNameWithoutExtension(download.Filename), DateTime.Now, $"{download.SaveFolder}{Path.DirectorySeparatorChar}{download.Filename}");
         history.Save();
     }
 

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-13 21:27+0000\n"
 "Last-Translator: fawaz006 <fawaz27000@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -126,7 +126,7 @@ msgstr "الافتراضي"
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "ينزَّل"
@@ -274,7 +274,7 @@ msgstr "لا"
 msgid "No downloads running"
 msgstr "لا يوجد ما ينزَّل الآن"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "افتح"
 
@@ -568,6 +568,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "أوقف كل التنزيلات"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-13 21:27+0000\n"
 "Last-Translator: fawaz006 <fawaz27000@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -55,7 +55,7 @@ msgstr "{0:f1} ك‌بايت\\ث"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} م‌بايت\\ث"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -122,11 +122,11 @@ msgstr ""
 msgid "Default"
 msgstr "الافتراضي"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "ينزَّل"
@@ -200,13 +200,13 @@ msgstr "اسم الملف"
 msgid "GitHub Repo"
 msgstr "مستودع جت‌هب"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "حلقة مفاتيح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "لم يتم فتح حلقة المفاتيح."
 
@@ -214,8 +214,8 @@ msgstr "لم يتم فتح حلقة المفاتيح."
 msgid "List of supported sites"
 msgstr "قائمة المواقع المدعومة"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -236,12 +236,12 @@ msgstr "رابط الوسائط"
 msgid "Media URL (Invalid)"
 msgstr "رابط الوسائط (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "اسم"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "الاسم (فارغ)"
 
@@ -265,14 +265,18 @@ msgstr ""
 "فيودور سوبليف {1}\n"
 "دا‌بق‌جاي {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "لا"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "لا يوجد ما ينزَّل الآن"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "افتح"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -280,14 +284,14 @@ msgstr "لا يوجد ما ينزَّل الآن"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "كلمة السر"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "كلمة السر (فارغة)"
 
@@ -322,7 +326,7 @@ msgstr "حدِّد ملف تعريف الارتباط"
 msgid "Select Save Folder"
 msgstr "اختر مجلد الحفظ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "كلمة السر الجديدة"
@@ -335,7 +339,7 @@ msgstr ""
 "لا تزل بعض التنزيلات جاريةً.\n"
 "أمتأكد أنك تريد إغلاق محوِّل المقاطع وإيقاف التنزيلات الجارية؟"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "انتهت بعض التنزيلات بخطأ!"
 
@@ -375,7 +379,7 @@ msgstr ""
 "البرنامَج تنتهك قوانين حقوق النشر المحلية أو قانون الألفية للملكية الرقمية "
 "(DMCA). يستخدم المستخدمون هذا التطبيق على مسؤوليتهم الخاصة."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "هذه الخطوة لا رجوع فيها. هل أنت متأكد أنك تريد حذفه؟"
 
@@ -396,12 +400,12 @@ msgstr "غير قادر على فتح حلقة المفاتيح. أعد تشغي
 msgid "Unlock Keyring"
 msgstr "فتح حلقة مفاتيح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "الرابط (غير صالح)"
 
@@ -409,13 +413,13 @@ msgstr "الرابط (غير صالح)"
 msgid "Use manual credential"
 msgstr "استخدم بيانات الاعتماد اليدوية"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "اسم المستخدم (فارغ)"
 
@@ -437,8 +441,8 @@ msgstr "ينتظر..."
 msgid "Worst"
 msgstr "الأسوأ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "نعم"
 
@@ -1062,9 +1066,6 @@ msgstr "— يدعم تنزيل بيانات الوصف وترجمات المق�
 
 #~ msgid "New"
 #~ msgstr "جديد"
-
-#~ msgid "Open"
-#~ msgstr "افتح"
 
 #~ msgid "Close"
 #~ msgstr "أغلق"

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-13 21:27+0000\n"
 "Last-Translator: fawaz006 <fawaz27000@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -126,7 +126,7 @@ msgstr "الافتراضي"
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "ينزَّل"
@@ -274,10 +274,6 @@ msgstr "لا"
 msgid "No downloads running"
 msgstr "لا يوجد ما ينزَّل الآن"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "افتح"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -294,6 +290,11 @@ msgstr "كلمة السر"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "كلمة السر (فارغة)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "قائمة التشغيل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -947,6 +948,9 @@ msgstr "— ينزِّل أكثر من تنزيل آنًا"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— يدعم تنزيل بيانات الوصف وترجمات المقاطع"
+
+#~ msgid "Open"
+#~ msgstr "افتح"
 
 #~ msgid "Credential"
 #~ msgstr "الاعتماد"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
@@ -261,10 +261,6 @@ msgstr "না"
 msgid "No downloads running"
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "উদঘাটন"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -280,6 +276,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
@@ -934,6 +934,9 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Open"
+#~ msgstr "উদঘাটন"
 
 #, fuzzy
 #~ msgid "Credentials"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "{0:f1} MiB/s"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, fuzzy, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
@@ -191,13 +191,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "গিটহাবের ভান্ডার"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -205,8 +205,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr ""
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -251,15 +251,19 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "না"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 #, fuzzy
 msgid "No downloads running"
 msgstr "অধঃগৃহীত হচ্ছে"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "উদঘাটন"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -267,14 +271,14 @@ msgstr "অধঃগৃহীত হচ্ছে"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -311,7 +315,7 @@ msgstr "সংগ্রাহক তথ্যপথ বেছে নিন"
 msgid "Select Save Folder"
 msgstr "সংগ্রাহক তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -324,7 +328,7 @@ msgstr ""
 "কিছু অধঃগ্রহণাদি এখনও চলছে।\n"
 "আপনি নিশ্চিতভাবে টিউব কনভার্টার বন্ধ করতে ও অধঃগ্রহণাদি থামাতে চান?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr ""
 
@@ -365,7 +369,7 @@ msgstr ""
 "প্রতিলিপিধর্ম(কপিরাইট) বা ডি এম সি এ আইনের ভঙ্গ করতে পারে তার জন্য দায়ী নয়। "
 "ব্যবহারকারীরা নিজ ঝুঁকিতে ব্যবহার করুন।"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -387,12 +391,12 @@ msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ�
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -400,14 +404,14 @@ msgstr ""
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "ব্যবহারকারীর দৃষ্টিতে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "ব্যবহারকারীর দৃষ্টিতে"
@@ -430,8 +434,8 @@ msgstr "অপেক্ষা করুন...."
 msgid "Worst"
 msgstr "চলনশই"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "হ্যাঁ"
 
@@ -999,9 +1003,6 @@ msgstr ""
 
 #~ msgid "New"
 #~ msgstr "নূতন"
-
-#~ msgid "Open"
-#~ msgstr "উদঘাটন"
 
 #~ msgid "Close"
 #~ msgstr "বন্ধ"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
@@ -261,7 +261,7 @@ msgstr "না"
 msgid "No downloads running"
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "উদঘাটন"
 
@@ -563,6 +563,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "অধঃগ্রহণ থামান"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-21 20:34+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -119,7 +119,7 @@ msgstr "Výchozí"
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Stahování"
@@ -267,7 +267,7 @@ msgstr "Ne"
 msgid "No downloads running"
 msgstr "Nejsou spuštěna žádná stahování"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Otevřít"
 
@@ -563,6 +563,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Zastavit všechna stahování"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-21 20:34+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -119,7 +119,7 @@ msgstr "Výchozí"
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Stahování"
@@ -267,10 +267,6 @@ msgstr "Ne"
 msgid "No downloads running"
 msgstr "Nejsou spuštěna žádná stahování"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Otevřít"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -287,6 +283,11 @@ msgstr "Heslo"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Heslo (prázdné)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Playlist"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -950,6 +951,9 @@ msgstr "— Možnost stahovat několik videí najednou"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Podporuje stahování metadat a titulků videí"
+
+#~ msgid "Open"
+#~ msgstr "Otevřít"
 
 #~ msgid "Credential"
 #~ msgstr "Údaj"

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-21 20:34+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -115,11 +115,11 @@ msgstr ""
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Stahování"
@@ -193,13 +193,13 @@ msgstr "Název souboru"
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Klíčenka"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Klíčenka nebyla odemčena."
 
@@ -207,8 +207,8 @@ msgstr "Klíčenka nebyla odemčena."
 msgid "List of supported sites"
 msgstr "Seznam podporovaných webů"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr "Přihlásit se"
 
@@ -229,12 +229,12 @@ msgstr "URL média"
 msgid "Media URL (Invalid)"
 msgstr "Adresa URL média (neplatná)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Název"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Název (prázdný)"
 
@@ -258,14 +258,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Nejsou spuštěna žádná stahování"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Otevřít"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -273,14 +277,14 @@ msgstr "Nejsou spuštěna žádná stahování"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Heslo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Heslo (prázdné)"
 
@@ -315,7 +319,7 @@ msgstr "Vybrat soubor s cookies"
 msgid "Select Save Folder"
 msgstr "Vybrat složku k uložení"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr "Nastavit heslo"
 
@@ -327,7 +331,7 @@ msgstr ""
 "Některá stahování stále probíhají.\n"
 "Určitě chcete zavřít Parabolic a zastavit probíhající stahování?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Některá stahování skončila s chybami!"
 
@@ -367,7 +371,7 @@ msgstr ""
 "zneužití tohoto programu, které může porušovat místní zákony o autorských "
 "právech/DMCA. Uživatelé používají tuto aplikaci na vlastní nebezpečí."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Tato akce je nevratná. Určitě chcete klíčenku odstranit?"
 
@@ -391,12 +395,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Odemknout klíčenku"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "Adresa URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "Adresa URL (neplatná)"
 
@@ -404,13 +408,13 @@ msgstr "Adresa URL (neplatná)"
 msgid "Use manual credential"
 msgstr "Použít manuální údaje"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Uživatelské jméno (prázdné)"
 
@@ -432,8 +436,8 @@ msgstr "Čekání..."
 msgid "Worst"
 msgstr "Nejhorší"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Ano"
 
@@ -1079,9 +1083,6 @@ msgstr "— Podporuje stahování metadat a titulků videí"
 
 #~ msgid "New"
 #~ msgstr "Nový"
-
-#~ msgid "Open"
-#~ msgstr "Otevřít"
 
 #~ msgid "Close"
 #~ msgstr "Zavřít"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-01 12:51+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Standard"
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Wird heruntergeladen"
@@ -265,10 +265,6 @@ msgstr "Nein"
 msgid "No downloads running"
 msgstr "Keine laufenden Downloads"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Öffnen"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Passwort"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Passwort (Leer)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Wiedergabeliste"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -960,6 +961,9 @@ msgstr "— Lade mehrere Medien gleichzeitig herunter"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Unterstützt herunterladen von Metadaten und Videountertiteln"
+
+#~ msgid "Open"
+#~ msgstr "Öffnen"
 
 #, fuzzy
 #~ msgid "Credential"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-01 12:51+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Standard"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Wird heruntergeladen"
@@ -191,13 +191,13 @@ msgstr "Dateiname"
 msgid "GitHub Repo"
 msgstr "GitHub-Repository"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Keyring konnte nicht ensperrt werden."
 
@@ -205,8 +205,8 @@ msgstr "Keyring konnte nicht ensperrt werden."
 msgid "List of supported sites"
 msgstr "Liste der unterstützten Seiten"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "Video Url"
 msgid "Media URL (Invalid)"
 msgstr "Video Url (ungültig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Name"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Name (Leer)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Keine laufenden Downloads"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Öffnen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Keine laufenden Downloads"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Passwort"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Passwort (Leer)"
 
@@ -313,7 +317,7 @@ msgstr "Cookie-Datei auswählen"
 msgid "Select Save Folder"
 msgstr "Speicherordner wählen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Neues Passwort"
@@ -327,7 +331,7 @@ msgstr ""
 "Bist du sicher dass du Parabolic schließen und die laufenden Downloads "
 "beenden möchtest?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Einige Downloads wurden mit Fehlern beendet!"
 
@@ -368,7 +372,7 @@ msgstr ""
 "Gesetze verstoßen könnte. Die Verwendung dieser Anwendung erfolgt auf eigene "
 "Gefahr."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Diese Aktion kann nicht rückgängig gemacht werden. Bist du sicher dass du es "
@@ -395,12 +399,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Keyring ensperren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (Ungültig)"
 
@@ -408,13 +412,13 @@ msgstr "URL (Ungültig)"
 msgid "Use manual credential"
 msgstr "Manuelle Anmeldedaten verwenden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nutzername"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nutzername (Leer)"
 
@@ -436,8 +440,8 @@ msgstr "Warten..."
 msgid "Worst"
 msgstr "Schlimmste"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Ja"
 
@@ -1075,9 +1079,6 @@ msgstr "— Unterstützt herunterladen von Metadaten und Videountertiteln"
 
 #~ msgid "Cancel"
 #~ msgstr "Abbrechen"
-
-#~ msgid "Open"
-#~ msgstr "Öffnen"
 
 #~ msgid "Close"
 #~ msgstr "Schließen"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-01 12:51+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Standard"
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Wird heruntergeladen"
@@ -265,7 +265,7 @@ msgstr "Nein"
 msgid "No downloads running"
 msgstr "Keine laufenden Downloads"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Öffnen"
 
@@ -567,6 +567,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Alle Downloads stoppen"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Por defecto"
 msgid "Delete Credential?"
 msgstr "¿Borrar las credenciales?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Descargando"
@@ -265,10 +265,6 @@ msgstr "No"
 msgid "No downloads running"
 msgstr "No hay descargas en curso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Abrir"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Contraseña"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Contraseña (vacía)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Lista de reproducción"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -957,6 +958,9 @@ msgstr "— Ejecutar múltiples descargas a la vez"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Admite la descarga de los metadatos y subtítulos del video"
+
+#~ msgid "Open"
+#~ msgstr "Abrir"
 
 #~ msgid "Credential"
 #~ msgstr "Credencial"

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Por defecto"
 msgid "Delete Credential?"
 msgstr "¿Borrar las credenciales?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Descargando"
@@ -265,7 +265,7 @@ msgstr "No"
 msgid "No downloads running"
 msgstr "No hay descargas en curso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Abrir"
 
@@ -565,6 +565,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Detener toda las descargas"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiBps"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} Mbps"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Por defecto"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "¿Borrar las credenciales?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Descargando"
@@ -191,13 +191,13 @@ msgstr "Nombre del archivo"
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Llavero"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "El llavero no ha sido desbloqueado."
 
@@ -205,8 +205,8 @@ msgstr "El llavero no ha sido desbloqueado."
 msgid "List of supported sites"
 msgstr "Lista de sitios compatibles"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr "Inicio de sesión"
 
@@ -227,12 +227,12 @@ msgstr "URL de los medios"
 msgid "Media URL (Invalid)"
 msgstr "URL a los medios (No Válido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nombre"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nombre (vacío)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "No"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "No hay descargas en curso"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Abrir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "No hay descargas en curso"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Contraseña"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Contraseña (vacía)"
 
@@ -313,7 +317,7 @@ msgstr "Selecciona archivo de las cookies"
 msgid "Select Save Folder"
 msgstr "Selecciona Guardar carpeta"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr "Establecer contraseña"
 
@@ -326,7 +330,7 @@ msgstr ""
 "¿Estás seguro de que deseas cerrar Parabolic y detener las descargas en "
 "curso?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "¡Algunas descargas terminaron con errores!"
 
@@ -366,7 +370,7 @@ msgstr ""
 "mal uso de este programa que pueda violar las leyes locales del copyright/"
 "DMCA. Los usuarios utilizan esta aplicación bajo su propio riesgo."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Esta acción es irreversible. ¿Estás seguro de que quieres borrarlo?"
 
@@ -391,12 +395,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Desbloquear el llavero"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (No Válida)"
 
@@ -404,13 +408,13 @@ msgstr "URL (No Válida)"
 msgid "Use manual credential"
 msgstr "Utilizar credenciales manuales"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nombre de usuario (vacío)"
 
@@ -432,8 +436,8 @@ msgstr "Esperando..."
 msgid "Worst"
 msgstr "Peor"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Sí"
 
@@ -1059,9 +1063,6 @@ msgstr "— Admite la descarga de los metadatos y subtítulos del video"
 
 #~ msgid "Home"
 #~ msgstr "Inicio"
-
-#~ msgid "Open"
-#~ msgstr "Abrir"
 
 #~ msgid "About {0}"
 #~ msgstr "Acerca de {0}"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-26 20:30+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} Kb/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} Mb/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Par défaut"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Supprimer le certificat ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Téléchargement"
@@ -191,13 +191,13 @@ msgstr "Nom du fichier"
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Trousseau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Le trousseau n’a pas été déverrouillé."
 
@@ -205,8 +205,8 @@ msgstr "Le trousseau n’a pas été déverrouillé."
 msgid "List of supported sites"
 msgstr "Liste des sites pris en charge"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "URL du média"
 msgid "Media URL (Invalid)"
 msgstr "URL du média (invalide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nom"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Non"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Aucun téléchargement en cours"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Ouvrir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Aucun téléchargement en cours"
 msgid "Parabolic"
 msgstr "Parabole"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Mot de passe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Mot de passe (vide)"
 
@@ -313,7 +317,7 @@ msgstr "Sélectionner un fichier de cookies"
 msgid "Select Save Folder"
 msgstr "Sélectionner un dossier de sauvegarde"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Nouveau mot de passe"
@@ -327,7 +331,7 @@ msgstr ""
 "Êtes-vous sûr⋅e de vouloir fermer Parabole et arrêter les téléchargement en "
 "cours ?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Certains téléchargements se sont terminés avec des erreurs !"
 
@@ -368,7 +372,7 @@ msgstr ""
 "le copyright/DMCA. Les utilisateurs se servent de cette application à leurs "
 "propres risques."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Cette action est irréversible. Êtes-vous sûr⋅e de vouloir le supprimer ?"
@@ -394,12 +398,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Déverrouiller le trousseau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (invalide)"
 
@@ -407,13 +411,13 @@ msgstr "URL (invalide)"
 msgid "Use manual credential"
 msgstr "Utiliser un certificat manuel"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nom d’utilisateur (vide)"
 
@@ -435,8 +439,8 @@ msgstr "Attente..."
 msgid "Worst"
 msgstr "Basse"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Oui"
 
@@ -1121,9 +1125,6 @@ msgstr ""
 
 #~ msgid "New"
 #~ msgstr "Nouveau"
-
-#~ msgid "Open"
-#~ msgstr "Ouvrir"
 
 #~ msgid "Close"
 #~ msgstr "Fermer"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-26 20:30+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Par défaut"
 msgid "Delete Credential?"
 msgstr "Supprimer le certificat ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Téléchargement"
@@ -265,10 +265,6 @@ msgstr "Non"
 msgid "No downloads running"
 msgstr "Aucun téléchargement en cours"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Ouvrir"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Mot de passe"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Mot de passe (vide)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Liste de lecture"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -966,6 +967,9 @@ msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Prend en charge le téléchargement des métadonnées et des sous-titres des "
 "vidéos"
+
+#~ msgid "Open"
+#~ msgstr "Ouvrir"
 
 #~ msgid "Credential"
 #~ msgstr "Certificat"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-26 20:30+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Par défaut"
 msgid "Delete Credential?"
 msgstr "Supprimer le certificat ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Téléchargement"
@@ -265,7 +265,7 @@ msgstr "Non"
 msgid "No downloads running"
 msgstr "Aucun téléchargement en cours"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -567,6 +567,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Arrêter tous les téléchargements"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-18 16:07+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -122,7 +122,7 @@ msgstr "ברירת מחדל"
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "בהורדה"
@@ -270,11 +270,6 @@ msgstr "לא"
 msgid "No downloads running"
 msgstr "אין הורדות פעילות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "פתיחת קובץ"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -291,6 +286,11 @@ msgstr "ססמה"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "ססמה (ריק)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "רשימת השמעה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -950,6 +950,10 @@ msgstr "- הפעלת מספר הורדות במקביל"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- תמיכה בהורדת נתוני מידע וכתוביות לסרטים"
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "פתיחת קובץ"
 
 #~ msgid "Credential"
 #~ msgstr "פרטי זיהוי"

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-18 16:07+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -122,7 +122,7 @@ msgstr "ברירת מחדל"
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "בהורדה"
@@ -270,7 +270,7 @@ msgstr "לא"
 msgid "No downloads running"
 msgstr "אין הורדות פעילות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "פתיחת קובץ"
@@ -565,6 +565,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "עצירת כל ההורדות"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-18 16:07+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -55,7 +55,7 @@ msgstr "‏{0:f1} קי״ב/שנ׳"
 msgid "{0:f1} MiB/s"
 msgstr "‏{0:f1} מבי״ב/שנ׳"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -118,11 +118,11 @@ msgstr ""
 msgid "Default"
 msgstr "ברירת מחדל"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "בהורדה"
@@ -196,13 +196,13 @@ msgstr "שם קובץ"
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "קבוצת מפתחות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "קבוצת המפתחות לא שוחררה."
 
@@ -210,8 +210,8 @@ msgstr "קבוצת המפתחות לא שוחררה."
 msgid "List of supported sites"
 msgstr "רשימה של קבצים נתמכים"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -232,12 +232,12 @@ msgstr "כתובת מדיה"
 msgid "Media URL (Invalid)"
 msgstr "כתובת מדיה (לא תקינה)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "שם"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "שם (ריק)"
 
@@ -261,14 +261,19 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "לא"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "אין הורדות פעילות"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "פתיחת קובץ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -276,14 +281,14 @@ msgstr "אין הורדות פעילות"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "ססמה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "ססמה (ריק)"
 
@@ -318,7 +323,7 @@ msgstr "בחירת קובץ עוגיות"
 msgid "Select Save Folder"
 msgstr "בחירת תיקיית שמירה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "ססמה חדשה"
@@ -331,7 +336,7 @@ msgstr ""
 "כמה הורדות עדיין פעילות.\n"
 "האם אכן ברצונך לסגור את Parabolic ולעצור את ההורדות הפעילות?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "כמה הורדות הסתיימו עם שגיאות!"
 
@@ -371,7 +376,7 @@ msgstr ""
 "זו שעשוי להפר את חוקי זכויות היוצרים המקומיים/חוקי DMCA. השימוש שמשתמשים "
 "עושים ביישום זה הוא על אחריותם הבלעדית בלבד."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "פעולה זו בלתי הפיכה. האם אכן ברצונך לבצע את המחיקה?"
 
@@ -394,12 +399,12 @@ msgstr "לא ניתן לשחרר את קבוצת המפתחות. יש להפעי
 msgid "Unlock Keyring"
 msgstr "שחרור קבוצת מפתחות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "כתובת"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "כתובת (לא תקינה)"
 
@@ -407,13 +412,13 @@ msgstr "כתובת (לא תקינה)"
 msgid "Use manual credential"
 msgstr "שימוש מזהה גישה ידנית"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "שם משתמש"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "שם משתמש (ריק)"
 
@@ -435,8 +440,8 @@ msgstr "בהמתנה…"
 msgid "Worst"
 msgstr "גרוע ביותר"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "כן"
 

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 msgid "Download Again"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr ""
 
@@ -538,6 +538,10 @@ msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+msgid "No Previous Downloads"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 msgid "Download Again"
 msgstr ""
 
@@ -253,10 +253,6 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -272,6 +268,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "{0:f1} MiB/s"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 msgid "Download Again"
 msgstr ""
 
@@ -184,13 +184,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -198,8 +198,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -220,12 +220,12 @@ msgstr ""
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -244,13 +244,17 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
@@ -259,14 +263,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -301,7 +305,7 @@ msgstr ""
 msgid "Select Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -311,7 +315,7 @@ msgid ""
 "Are you sure you want to close Parabolic and stop the running downloads?"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr ""
 
@@ -348,7 +352,7 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -369,12 +373,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -382,13 +386,13 @@ msgstr ""
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr ""
 
@@ -410,8 +414,8 @@ msgstr ""
 msgid "Worst"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/mp"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/mp"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Alapértelmezett"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Letöltés folyamatban"
@@ -191,13 +191,13 @@ msgstr "Fájlnév"
 msgid "GitHub Repo"
 msgstr "GitHub tároló"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Jelszókezelő"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Jelszókezelő feloldása nem sikerült."
 
@@ -205,8 +205,8 @@ msgstr "Jelszókezelő feloldása nem sikerült."
 msgid "List of supported sites"
 msgstr "Támogatott honlapok listája"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "Hivatkozás"
 msgid "Media URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Megnevezés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Megnevezés (üres)"
 
@@ -256,14 +256,19 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nem"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Nincs folyamatban letöltés"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "Fájl megnyitása"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +276,14 @@ msgstr "Nincs folyamatban letöltés"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Jelszó"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Jelszó (üres)"
 
@@ -313,7 +318,7 @@ msgstr ""
 msgid "Select Save Folder"
 msgstr "Letöltés helyének kiválasztása"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Új jelszó"
@@ -326,7 +331,7 @@ msgstr ""
 "Egyes letöltések még folyamatban vannak.\n"
 "Valóban megszakítja a letöltéseket és kilép az alkalmazásból?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr ""
 
@@ -366,7 +371,7 @@ msgstr ""
 "használata során esetlegesen fellépő jogsértésekért. A felhasználó saját "
 "felelősségére használja a programot."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "A művelet nem visszafordítható. Valóban törli a bejelentkezési adatokat?"
@@ -390,12 +395,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Jelszókezelő feloldása"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "Hivatkozás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
@@ -403,13 +408,13 @@ msgstr "Hivatkozás (hibás)"
 msgid "Use manual credential"
 msgstr "Bejelentkezés másként"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Felhasználónév (üres)"
 
@@ -431,8 +436,8 @@ msgstr "Várakozik..."
 msgid "Worst"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Igen"
 

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -117,7 +117,7 @@ msgstr "Alapértelmezett"
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Letöltés folyamatban"
@@ -265,11 +265,6 @@ msgstr "Nem"
 msgid "No downloads running"
 msgstr "Nincs folyamatban letöltés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "Fájl megnyitása"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -286,6 +281,11 @@ msgstr "Jelszó"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Jelszó (üres)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Lejátszási lista"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -942,6 +942,10 @@ msgstr "— Párhuzamos letöltési lehetőség"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Támogatott a feliratok és egyebek beágyazása"
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "Fájl megnyitása"
 
 #~ msgid "Credential"
 #~ msgstr "Bejelentkezés"

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -117,7 +117,7 @@ msgstr "Alapértelmezett"
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Letöltés folyamatban"
@@ -265,7 +265,7 @@ msgstr "Nem"
 msgid "No downloads running"
 msgstr "Nincs folyamatban letöltés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "Fájl megnyitása"
@@ -561,6 +561,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Minden letöltés megszakítása"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -115,7 +115,7 @@ msgstr "Bawaan"
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Mengunduh"
@@ -266,7 +266,7 @@ msgstr "Tidak"
 msgid "No downloads running"
 msgstr "Tidak ada unduhan yang berjalan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Buka"
 
@@ -567,6 +567,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Hentikan Unduhan"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/dtk"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/dtk"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Default"
 msgstr "Bawaan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Mengunduh"
@@ -192,13 +192,13 @@ msgstr "Nama File"
 msgid "GitHub Repo"
 msgstr "Repo GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Keyring belum dibuka."
 
@@ -206,8 +206,8 @@ msgstr "Keyring belum dibuka."
 msgid "List of supported sites"
 msgstr "Daftar situs yang didukung"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -228,12 +228,12 @@ msgstr "URL Media"
 msgid "Media URL (Invalid)"
 msgstr "URL Media (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nama"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nama (Kosong)"
 
@@ -257,14 +257,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Tidak"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Tidak ada unduhan yang berjalan"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Buka"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -272,14 +276,14 @@ msgstr "Tidak ada unduhan yang berjalan"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Kata sandi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Kata sandi (Kosong)"
 
@@ -314,7 +318,7 @@ msgstr "Pilih File Cookie"
 msgid "Select Save Folder"
 msgstr "Pilih Folder Simpan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Kata Sandi Baru"
@@ -329,7 +333,7 @@ msgstr ""
 "Apakah anda yakin ingin menutup Tube Converter dan menghentikan unduhan yang "
 "sedang berjalan?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Beberapa unduhan selesai dengan error!"
 
@@ -372,7 +376,7 @@ msgstr ""
 "penyalahgunaan program ini yang mungkin melanggar hak cipta lokal/hukum "
 "DMCA. Pengguna menggunakan aplikasi ini dengan risiko mereka sendiri."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Aksi ini tidak dapat diurungkan. Apakah anda yakin untuk menghapusnya?"
 
@@ -397,12 +401,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Buka Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (tidak sah)"
 
@@ -410,13 +414,13 @@ msgstr "URL (tidak sah)"
 msgid "Use manual credential"
 msgstr "Gunakan kredensial manual"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nama pengguna"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nama pengguna (Kosong)"
 
@@ -438,8 +442,8 @@ msgstr "Menunggu..."
 msgid "Worst"
 msgstr "Terburuk"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Iya"
 
@@ -1040,9 +1044,6 @@ msgstr ""
 
 #~ msgid "New"
 #~ msgstr "Baru"
-
-#~ msgid "Open"
-#~ msgstr "Buka"
 
 #~ msgid "Close"
 #~ msgstr "Tutup"

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -115,7 +115,7 @@ msgstr "Bawaan"
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Mengunduh"
@@ -266,10 +266,6 @@ msgstr "Tidak"
 msgid "No downloads running"
 msgstr "Tidak ada unduhan yang berjalan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Buka"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -286,6 +282,11 @@ msgstr "Kata sandi"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Kata sandi (Kosong)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Daftar Putar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -946,6 +947,9 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Open"
+#~ msgstr "Buka"
 
 #~ msgid "Setup Keyring"
 #~ msgstr "Atur Keyring"

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-15 21:33+0000\n"
 "Last-Translator: Yuri Brandi <destroyercrazy0@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Predefinita"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "In corso"
@@ -191,13 +191,13 @@ msgstr "Nome file"
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Portachiavi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Il portachiavi non è stato sbloccato."
 
@@ -205,8 +205,8 @@ msgstr "Il portachiavi non è stato sbloccato."
 msgid "List of supported sites"
 msgstr "Elenco dei siti supportati"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "URL del media"
 msgid "Media URL (Invalid)"
 msgstr "URL del media (non valido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nome"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nome (vuoto)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "No"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Nessuno scaricamento in corso"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Apri"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Nessuno scaricamento in corso"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Password"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Password (vuota)"
 
@@ -313,7 +317,7 @@ msgstr "Seleziona file cookie"
 msgid "Select Save Folder"
 msgstr "Seleziona cartella di salvataggio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Nuova password"
@@ -326,7 +330,7 @@ msgstr ""
 "Sono ancora in corso alcuni scaricamenti.\n"
 "Chiudere Parabolic e interromperli?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Alcuni scaricamenti sono terminati con degli errori."
 
@@ -366,7 +370,7 @@ msgstr ""
 "improprio di questo programma che possa violare le leggi locali sul "
 "copyright/DMCA. Gli utenti utilizzano questa applicazione a proprio rischio."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Questa azione è irreversibile. Confermare l'eliminazione?"
 
@@ -392,12 +396,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Sblocca portachiavi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (non valido)"
 
@@ -405,13 +409,13 @@ msgstr "URL (non valido)"
 msgid "Use manual credential"
 msgstr "Usa un certificato manuale"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nome utente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nome utente (vuoto)"
 
@@ -433,8 +437,8 @@ msgstr "In attesa…"
 msgid "Worst"
 msgstr "Peggiore"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Sì"
 
@@ -1098,9 +1102,6 @@ msgstr "— Supporta lo scaricamento di metadati e sottotitoli dei video"
 
 #~ msgid "New"
 #~ msgstr "Nuovo"
-
-#~ msgid "Open"
-#~ msgstr "Apri"
 
 #~ msgid "Close"
 #~ msgstr "Chiudi"

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-15 21:33+0000\n"
 "Last-Translator: Yuri Brandi <destroyercrazy0@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Predefinita"
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "In corso"
@@ -265,7 +265,7 @@ msgstr "No"
 msgid "No downloads running"
 msgstr "Nessuno scaricamento in corso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Apri"
 
@@ -564,6 +564,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Ferma tutti i download"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-15 21:33+0000\n"
 "Last-Translator: Yuri Brandi <destroyercrazy0@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Predefinita"
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "In corso"
@@ -265,10 +265,6 @@ msgstr "No"
 msgid "No downloads running"
 msgstr "Nessuno scaricamento in corso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Apri"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Password"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Password (vuota)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Playlist"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -958,6 +959,9 @@ msgstr "— Scarica più di un file alla volta"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Supporta lo scaricamento di metadati e sottotitoli dei video"
+
+#~ msgid "Open"
+#~ msgstr "Apri"
 
 #~ msgid "Credential"
 #~ msgstr "Certificato"

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-13 17:24+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -115,7 +115,7 @@ msgstr "デフォルト"
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "ダウンロード中"
@@ -263,7 +263,7 @@ msgstr "いいえ"
 msgid "No downloads running"
 msgstr "進行中のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "開く"
 
@@ -559,6 +559,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "すべてのダウンロードを停止"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-13 17:24+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/毎秒"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/毎秒"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Default"
 msgstr "デフォルト"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "ダウンロード中"
@@ -189,13 +189,13 @@ msgstr "ファイル名"
 msgid "GitHub Repo"
 msgstr "GitHub リポジトリ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "キーリング"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "キーリングはロック解除されていません。"
 
@@ -203,8 +203,8 @@ msgstr "キーリングはロック解除されていません。"
 msgid "List of supported sites"
 msgstr "サポートされているサイト"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -225,12 +225,12 @@ msgstr "メディアの URL"
 msgid "Media URL (Invalid)"
 msgstr "メディアの URL (無効)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "名前"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "名前（空）"
 
@@ -254,14 +254,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "いいえ"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "進行中のダウンロードはありません"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "開く"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -269,14 +273,14 @@ msgstr "進行中のダウンロードはありません"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "パスワード"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "パスワード（空）"
 
@@ -311,7 +315,7 @@ msgstr "クッキーのファイルを選択"
 msgid "Select Save Folder"
 msgstr "保存するフォルダーを選択"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "新しいパスワード"
@@ -324,7 +328,7 @@ msgstr ""
 "ダウンロードが続行中です。\n"
 "本当に Parabolic を閉じてダウンロードを中断しますか？"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "一部のダウンロードはエラーで失敗しました！"
 
@@ -364,7 +368,7 @@ msgstr ""
 "ニアム著作権法）に反する可能性のある、このプログラムの誤用について責任を負い"
 "ません。ユーザーによる、このアプリケーションの使用は自己責任です。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "このアクションは取り消せません。本当に削除しますか？"
 
@@ -387,12 +391,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "キーリングをロック解除"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (無効)"
 
@@ -400,13 +404,13 @@ msgstr "URL (無効)"
 msgid "Use manual credential"
 msgstr "マニュアル資格情報を使う"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "ユーザー名"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "ユーザー名（空）"
 
@@ -428,8 +432,8 @@ msgstr "待機中..."
 msgid "Worst"
 msgstr "最低"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "はい"
 
@@ -1060,9 +1064,6 @@ msgstr "— メタデータと字幕のダウンロードに対応"
 
 #~ msgid "New"
 #~ msgstr "新規"
-
-#~ msgid "Open"
-#~ msgstr "開く"
 
 #~ msgid "Close"
 #~ msgstr "閉じる"

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-13 17:24+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -115,7 +115,7 @@ msgstr "デフォルト"
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "ダウンロード中"
@@ -263,10 +263,6 @@ msgstr "いいえ"
 msgid "No downloads running"
 msgstr "進行中のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "開く"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -283,6 +279,11 @@ msgstr "パスワード"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "パスワード（空）"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "再生リスト"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -945,6 +946,9 @@ msgstr "— 同時に複数のダウンロードが可能"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— メタデータと字幕のダウンロードに対応"
+
+#~ msgid "Open"
+#~ msgstr "開く"
 
 #~ msgid "Credential"
 #~ msgstr "資格情報"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -55,7 +55,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, fuzzy, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Laster ned"
@@ -193,13 +193,13 @@ msgstr "Filtype"
 msgid "GitHub Repo"
 msgstr "GitHub-kodelager"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -207,8 +207,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "Liste over støttede sider"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -230,13 +230,13 @@ msgstr "Videonettadresse"
 msgid "Media URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 #, fuzzy
 msgid "Name"
 msgstr "Filtype"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -255,14 +255,18 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nei"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Ingen nedlastinger kjører"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Åpne"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -270,14 +274,14 @@ msgstr "Ingen nedlastinger kjører"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -313,7 +317,7 @@ msgstr "Velg lagringsmappe"
 msgid "Select Save Folder"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -326,7 +330,7 @@ msgstr ""
 "Noen nedlastinger er underveis.\n"
 "Lukk Tube Converter og stopp kjørende nedlastinger?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Noen nedlastinger ble fullført med feil."
 
@@ -368,7 +372,7 @@ msgstr ""
 "programmet for å bryte lokalt lovverk/DCMA-lover. Brukere anvender dette "
 "programmet på egen risiko."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -392,12 +396,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
@@ -406,14 +410,14 @@ msgstr "Videonettadresse (ugyldig)"
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "Brukergrensesnitt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "Brukergrensesnitt"
@@ -436,8 +440,8 @@ msgstr "Venter …"
 msgid "Worst"
 msgstr "Dårlig"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Ja"
 
@@ -1008,9 +1012,6 @@ msgstr ""
 
 #~ msgid "Changelog"
 #~ msgstr "Endringslogg"
-
-#~ msgid "Open"
-#~ msgstr "Åpne"
 
 #~ msgid "Discussions"
 #~ msgstr "Diskusjoner"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -116,7 +116,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Laster ned"
@@ -264,10 +264,6 @@ msgstr "Nei"
 msgid "No downloads running"
 msgstr "Ingen nedlastinger kjører"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Åpne"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -283,6 +279,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
@@ -941,6 +941,9 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Open"
+#~ msgstr "Åpne"
 
 #, fuzzy
 #~ msgid "Credentials"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -116,7 +116,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Laster ned"
@@ -264,7 +264,7 @@ msgstr "Nei"
 msgid "No downloads running"
 msgstr "Ingen nedlastinger kjører"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Åpne"
 
@@ -569,6 +569,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Stopp alle nedlastinger"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Standaard"
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Downloaden"
@@ -265,10 +265,6 @@ msgstr "Nee"
 msgid "No downloads running"
 msgstr "Geen actieve downloads"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Openen"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Wachtwoord"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Wachtwoord (leeg)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Afspeellijst"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -930,6 +931,9 @@ msgstr "— Voer meerdere downloads tegelijk uit"
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Ondersteuning voor het downloaden van video-metagegevens en -ondertitels"
+
+#~ msgid "Open"
+#~ msgstr "Openen"
 
 #~ msgid "Credential"
 #~ msgstr "Inloggegevens"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Standaard"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Downloaden"
@@ -191,13 +191,13 @@ msgstr "Bestandsnaam"
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Sleutelbos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Sleutelbos is niet ontgrendeld."
 
@@ -205,8 +205,8 @@ msgstr "Sleutelbos is niet ontgrendeld."
 msgid "List of supported sites"
 msgstr "Lijst met ondersteunde websites"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "Media-URL"
 msgid "Media URL (Invalid)"
 msgstr "Media-URL (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Naam"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Naam (leeg)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nee"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Geen actieve downloads"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Openen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Geen actieve downloads"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Wachtwoord (leeg)"
 
@@ -313,7 +317,7 @@ msgstr "Cookies-bestand selecteren"
 msgid "Select Save Folder"
 msgstr "Opslagmap selecteren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Nieuw wachtwoord"
@@ -328,7 +332,7 @@ msgstr ""
 "Weet u zeker dat u Tube Converter wilt sluiten en de lopende downloads wilt "
 "stoppen?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Sommige downloads zijn voltooid met fouten!"
 
@@ -369,7 +373,7 @@ msgstr ""
 "aansprakelijk voor enig misbruik van deze app dat lokale auteursrecht-/DMCA-"
 "wetgeving kan schenden. Gebruikers gebruiken deze app op eigen risico."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -391,12 +395,12 @@ msgstr "Kon sleutelbos niet ontgrendelen. Herstart de app en probeer opnieuw."
 msgid "Unlock Keyring"
 msgstr "Sleutelbos ontgrendelen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (ongeldig)"
 
@@ -404,13 +408,13 @@ msgstr "URL (ongeldig)"
 msgid "Use manual credential"
 msgstr "Handmatige inloggegevens gebruiken"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Gebruikersnaam (leeg)"
 
@@ -432,8 +436,8 @@ msgstr "Wachten…"
 msgid "Worst"
 msgstr "Slechtst"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Ja"
 
@@ -1042,9 +1046,6 @@ msgstr ""
 
 #~ msgid "New"
 #~ msgstr "Nieuw"
-
-#~ msgid "Open"
-#~ msgstr "Openen"
 
 #~ msgid "Close"
 #~ msgstr "Sluiten"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-07 17:22+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Standaard"
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Downloaden"
@@ -265,7 +265,7 @@ msgstr "Nee"
 msgid "No downloads running"
 msgstr "Geen actieve downloads"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Openen"
 
@@ -561,6 +561,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Alle downloads stoppen"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgstr ""
 msgid "{0:f1} MiB/s"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 msgid "Download Again"
 msgstr ""
 
@@ -186,13 +186,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -200,8 +200,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -222,12 +222,12 @@ msgstr ""
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -246,13 +246,17 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
@@ -261,14 +265,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -303,7 +307,7 @@ msgstr ""
 msgid "Select Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -313,7 +317,7 @@ msgid ""
 "Are you sure you want to close Parabolic and stop the running downloads?"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr ""
 
@@ -350,7 +354,7 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -371,12 +375,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -384,13 +388,13 @@ msgstr ""
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr ""
 
@@ -412,8 +416,8 @@ msgstr ""
 msgid "Worst"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 msgid "Download Again"
 msgstr ""
 
@@ -255,7 +255,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr ""
 
@@ -540,6 +540,10 @@ msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+msgid "No Previous Downloads"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 msgid "Download Again"
 msgstr ""
 
@@ -255,10 +255,6 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -274,6 +270,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -120,7 +120,7 @@ msgstr "Domyślne"
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Pobierane"
@@ -268,11 +268,6 @@ msgstr "Nie"
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "Otwórz plik"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -289,6 +284,11 @@ msgstr "Hasło"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Hasło (puste)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Playlista"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -959,6 +959,10 @@ msgstr "- Obsługuje pobieranie wielu plików jednocześnie"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Obsługuje pobieranie metadanych i napisów do wideo"
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "Otwórz plik"
 
 #~ msgid "Credential"
 #~ msgstr "Dane logowania"

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -55,7 +55,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -116,11 +116,11 @@ msgstr ""
 msgid "Default"
 msgstr "Domyślne"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Pobierane"
@@ -194,13 +194,13 @@ msgstr "Nazwa pliku"
 msgid "GitHub Repo"
 msgstr "Repozytorium na Githubie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Lista kluczy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Lista kluczy nie została odblokowana."
 
@@ -208,8 +208,8 @@ msgstr "Lista kluczy nie została odblokowana."
 msgid "List of supported sites"
 msgstr "Lista obsługiwanych stron internetowych"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -230,12 +230,12 @@ msgstr "Adres URL"
 msgid "Media URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nazwa (pusta)"
 
@@ -259,14 +259,19 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "Otwórz plik"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -274,14 +279,14 @@ msgstr "Żadne pobieranie nie jest uruchomione"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Hasło"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Hasło (puste)"
 
@@ -316,7 +321,7 @@ msgstr "Wybierz ciasteczko"
 msgid "Select Save Folder"
 msgstr "Wybierz folder docelowy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Nowe hasło"
@@ -329,7 +334,7 @@ msgstr ""
 "Niektóre pliki są nadal pobierane.\n"
 "Czy na pewno chcesz zamknąć Parabolic i zatrzymać trwające pobieranie?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Niektóre procesy pobierania zostały zakończone z błędami!"
 
@@ -370,7 +375,7 @@ msgstr ""
 "naruszyć lokalne prawa autorskie lub DMCA. Użytkownicy używają tej aplikacji "
 "na własne ryzyko."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "To działanie jest nieodwracalne. Czy na pewno chcesz usunąć te dane?"
 
@@ -395,12 +400,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Odblokuj listę kluczy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "Adres URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
@@ -408,13 +413,13 @@ msgstr "Adres URL (błędne dane)"
 msgid "Use manual credential"
 msgstr "Wprowadź ręcznie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nazwa użytkownika (pusta)"
 
@@ -436,8 +441,8 @@ msgstr "Oczekiwanie..."
 msgid "Worst"
 msgstr "Najgorsza"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Tak"
 

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -120,7 +120,7 @@ msgstr "Domyślne"
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Pobierane"
@@ -268,7 +268,7 @@ msgstr "Nie"
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "Otwórz plik"
@@ -568,6 +568,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Zatrzymaj wszystkie procesy pobierania"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-18 12:24+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Padrão"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Baixando"
@@ -191,13 +191,13 @@ msgstr "Nome do arquivo"
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Chaveiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "O chaveiro não foi desbloqueado."
 
@@ -205,8 +205,8 @@ msgstr "O chaveiro não foi desbloqueado."
 msgid "List of supported sites"
 msgstr "Lista de sites suportados"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "URL da mídia"
 msgid "Media URL (Invalid)"
 msgstr "URL de vídeo (inválida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Nome"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Nome (vazio)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Não"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Nenhum download em andamento"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Abr"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Nenhum download em andamento"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Senha"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Senha (vazia)"
 
@@ -313,7 +317,7 @@ msgstr "Selecione o arquivo de cookies"
 msgid "Select Save Folder"
 msgstr "Selecione a pasta de destino"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Nova senha"
@@ -327,7 +331,7 @@ msgstr ""
 "Tem certeza de que deseja fechar o Parabolic e interromper os downloads em "
 "execução?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Alguns downloads terminaram com erros!"
 
@@ -367,7 +371,7 @@ msgstr ""
 "indevido deste programa que possa violar as leis locais de direitos autorais/"
 "DMCA. Os usuários usam este aplicativo por sua própria conta e risco."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Essa ação é irreversível. Tem certeza de que deseja excluí-lo?"
 
@@ -392,12 +396,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (inválida)"
 
@@ -405,13 +409,13 @@ msgstr "URL (inválida)"
 msgid "Use manual credential"
 msgstr "Utilizar outra credencial manualmente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Nome de usuário (vazio)"
 
@@ -433,8 +437,8 @@ msgstr "Esperando..."
 msgid "Worst"
 msgstr "Pior"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Sim"
 
@@ -1070,9 +1074,6 @@ msgstr "— Suporta o download de metadados e legendas"
 
 #~ msgid "Discussions"
 #~ msgstr "Discussões"
-
-#~ msgid "Open"
-#~ msgstr "Abr"
 
 #~ msgid "Close"
 #~ msgstr "Fechar"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-18 12:24+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -117,7 +117,7 @@ msgstr "Padrão"
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Baixando"
@@ -265,7 +265,7 @@ msgstr "Não"
 msgid "No downloads running"
 msgstr "Nenhum download em andamento"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Abr"
 
@@ -565,6 +565,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Parar todos os download"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-18 12:24+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -117,7 +117,7 @@ msgstr "Padrão"
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Baixando"
@@ -265,10 +265,6 @@ msgstr "Não"
 msgid "No downloads running"
 msgstr "Nenhum download em andamento"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Abr"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Senha"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Senha (vazia)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Playlist"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -956,6 +957,9 @@ msgstr "— Execute vários downloads ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta o download de metadados e legendas"
+
+#~ msgid "Open"
+#~ msgstr "Abr"
 
 #~ msgid "Credential"
 #~ msgstr "Credencial"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "A transferir"
@@ -193,13 +193,13 @@ msgstr "Nome do Ficheiro"
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -207,8 +207,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "Lista de sítios suportados"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -229,13 +229,13 @@ msgstr "URL da Media"
 msgid "Media URL (Invalid)"
 msgstr "URL da Media (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 #, fuzzy
 msgid "Name"
 msgstr "Nome do Ficheiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -259,14 +259,19 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Não"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Não há transferências a decorrer"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "Abrir Ficheiro"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -274,14 +279,14 @@ msgstr "Não há transferências a decorrer"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -316,7 +321,7 @@ msgstr "Selecione Ficheiro de Cookies"
 msgid "Select Save Folder"
 msgstr "Selecione Pasta de Destino"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -330,7 +335,7 @@ msgstr ""
 "Tem a certeza que quer fechar o Tube Converter e parar as transferências em "
 "curso?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Algumas transferências terminaram com erros!"
 
@@ -374,7 +379,7 @@ msgstr ""
 "autor/DMCA. Os utilizadores usam esta aplicação por sua própria conta e "
 "risco."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -400,12 +405,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "URL da Media (Inválido)"
@@ -414,14 +419,14 @@ msgstr "URL da Media (Inválido)"
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "Interface do Utilizador"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "Interface do Utilizador"
@@ -444,8 +449,8 @@ msgstr "À espera..."
 msgid "Worst"
 msgstr "Pior"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Sim"
 

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "A transferir"
@@ -268,7 +268,7 @@ msgstr "Não"
 msgid "No downloads running"
 msgstr "Não há transferências a decorrer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "Abrir Ficheiro"
@@ -577,6 +577,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Parar Todas as Transferências"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "A transferir"
@@ -268,11 +268,6 @@ msgstr "Não"
 msgid "No downloads running"
 msgstr "Não há transferências a decorrer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "Abrir Ficheiro"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -289,6 +284,11 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Playlist"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -956,6 +956,10 @@ msgstr "— Corre múltiplas transferências ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta transferência de metadados e legendas de vídeo"
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "Abrir Ficheiro"
 
 #~ msgid "youtube"
 #~ msgstr "youtube"

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-29 18:14+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -120,7 +120,7 @@ msgstr "По умолчанию"
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Загружается"
@@ -268,7 +268,7 @@ msgstr "Нет"
 msgid "No downloads running"
 msgstr "Ничего не загружается"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Открыть"
 
@@ -564,6 +564,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Остановить все загрузки"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-29 18:14+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -120,7 +120,7 @@ msgstr "По умолчанию"
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Загружается"
@@ -268,10 +268,6 @@ msgstr "Нет"
 msgid "No downloads running"
 msgstr "Ничего не загружается"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Открыть"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -288,6 +284,11 @@ msgstr "Пароль"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Пароль (пустой)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Плейлист"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -950,6 +951,9 @@ msgstr "— Запускайте несколько загрузок однов�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Возможно скачать метаданные и субтитры к видео"
+
+#~ msgid "Open"
+#~ msgstr "Открыть"
 
 #~ msgid "Credential"
 #~ msgstr "Учётные данные"

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-29 18:14+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.1\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:719
@@ -55,7 +55,7 @@ msgstr "{0:f1} КиБ/с"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} МиБ/с"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -116,11 +116,11 @@ msgstr ""
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Загружается"
@@ -194,13 +194,13 @@ msgstr "Имя файла"
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Связка ключей"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Связка ключей не была разблокирована."
 
@@ -208,8 +208,8 @@ msgstr "Связка ключей не была разблокирована."
 msgid "List of supported sites"
 msgstr "Список поддерживаемых сайтов"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -230,12 +230,12 @@ msgstr "Ссылка"
 msgid "Media URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Имя"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Имя (пустое)"
 
@@ -259,14 +259,18 @@ msgstr ""
 "Фёдор Соболев {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Ничего не загружается"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Открыть"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -274,14 +278,14 @@ msgstr "Ничего не загружается"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Пароль"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Пароль (пустой)"
 
@@ -316,7 +320,7 @@ msgstr "Выберите файл куки"
 msgid "Select Save Folder"
 msgstr "Выберите папку загрузки"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Новый пароль"
@@ -329,7 +333,7 @@ msgstr ""
 "Некоторые загрузки ещё не завершены.\n"
 "Вы уверены, что хотите закрыть Parabolic и остановить все загрузки?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Некоторые загрузки завершились с ошибкой!"
 
@@ -369,7 +373,7 @@ msgstr ""
 "использование программы, которое может нарушать местные законы об авторском "
 "праве или DMCA. Пользователи используют это приложение на свой страх и риск."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Это действие необратимо. Вы уверены, что хотите удалить?"
 
@@ -394,12 +398,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Разблокировать связку ключей"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "Ссылка"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
@@ -407,13 +411,13 @@ msgstr "Ссылка (Некорректная)"
 msgid "Use manual credential"
 msgstr "Ввести данные вручную"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Имя пользователя (пустое)"
 
@@ -435,8 +439,8 @@ msgstr "Ожидание..."
 msgid "Worst"
 msgstr "Худшее"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Да"
 
@@ -1104,9 +1108,6 @@ msgstr "— Возможно скачать метаданные и субтит
 
 #~ msgid "Discussions"
 #~ msgstr "Обсуждения"
-
-#~ msgid "Open"
-#~ msgstr "Открыть"
 
 #~ msgid "Enter media URL here"
 #~ msgstr "Введите ссылку на видео, аудио или плейлист"

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-13 01:53+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Laddar ned"
@@ -267,10 +267,6 @@ msgstr "Nej"
 msgid "No downloads running"
 msgstr "Inga nedladdningar körs"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Öppna"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -287,6 +283,11 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Spellista"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -942,6 +943,9 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Open"
+#~ msgstr "Öppna"
 
 #, fuzzy
 #~ msgid "Credentials"

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-13 01:53+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Laddar ned"
@@ -267,7 +267,7 @@ msgstr "Nej"
 msgid "No downloads running"
 msgstr "Inga nedladdningar körs"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Öppna"
 
@@ -573,6 +573,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Stoppa alla nedladdningar"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-13 01:53+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Laddar ned"
@@ -192,13 +192,13 @@ msgstr "Filnamn"
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -206,8 +206,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "Lista över webbplatser som stöds"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -228,13 +228,13 @@ msgstr "Media-URL"
 msgid "Media URL (Invalid)"
 msgstr "Media-URL (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 #, fuzzy
 msgid "Name"
 msgstr "Filnamn"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -258,14 +258,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Nej"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Inga nedladdningar körs"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Öppna"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -273,14 +277,14 @@ msgstr "Inga nedladdningar körs"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -315,7 +319,7 @@ msgstr "Välj cookies-fil"
 msgid "Select Save Folder"
 msgstr "Välj lagringsmapp"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -329,7 +333,7 @@ msgstr ""
 "Är du säker på att du vill stänga Tube Converter och stoppa de pågående "
 "nedladdningarna?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Vissa nedladdningar avslutades med fel!"
 
@@ -371,7 +375,7 @@ msgstr ""
 "detta program som kan bryta mot lokala upphovsrättslagar/DMCA-lagar. "
 "Användare använder detta program på egen risk."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -395,12 +399,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Media-URL (ogiltig)"
@@ -409,14 +413,14 @@ msgstr "Media-URL (ogiltig)"
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "Användargränssnitt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "Användargränssnitt"
@@ -439,8 +443,8 @@ msgstr "Väntar..."
 msgid "Worst"
 msgstr "Sämst"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Ja"
 
@@ -1119,9 +1123,6 @@ msgstr ""
 
 #~ msgid "Exit"
 #~ msgstr "Avsluta"
-
-#~ msgid "Open"
-#~ msgstr "Öppna"
 
 #~ msgid "Stop All Downloads (Ctrl+Shift+C)"
 #~ msgstr "Stoppa alla nedladdningar (Ctrl+Shift+C)"

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-28 18:27+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "இயல்புநிலை"
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "பதிவிறக்குகிறது"
@@ -265,7 +265,7 @@ msgstr "இல்லை"
 msgid "No downloads running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "கோப்பைத் திறக்கவும்"
@@ -561,6 +561,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "அனைத்து பதிவிறக்கங்களையும் நிறுத்து"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-28 18:27+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "இயல்புநிலை"
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "பதிவிறக்குகிறது"
@@ -265,11 +265,6 @@ msgstr "இல்லை"
 msgid "No downloads running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "கோப்பைத் திறக்கவும்"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -286,6 +281,11 @@ msgstr "கடவுச்சொல்"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "கடவுச்சொல் (காலி)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "பாடல் பட்டியல்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -949,6 +949,10 @@ msgstr "- ஒரே நேரத்தில் பல பதிவிறக்�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— மெட்டாடேட்டா மற்றும் காணொளி வசனங்களைப் பதிவிறக்குவதை ஆதரிக்கிறது"
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "கோப்பைத் திறக்கவும்"
 
 #~ msgid "Credential"
 #~ msgstr "நற்சான்றிதழ்"

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-28 18:27+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} கிலோபிட்/வினாடி (KiB/s)"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} மெபிபைட்/வினாடி (MiB/s)"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "இயல்புநிலை"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "பதிவிறக்குகிறது"
@@ -191,13 +191,13 @@ msgstr "கோப்பு பெயர்"
 msgid "GitHub Repo"
 msgstr "GitHub களஞ்சியம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "சாவி வளையம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "சாவி வளையம் திறக்கப்படவில்லை."
 
@@ -205,8 +205,8 @@ msgstr "சாவி வளையம் திறக்கப்படவில�
 msgid "List of supported sites"
 msgstr "ஆதரிக்கப்படும் தளங்களின் பட்டியல்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "ஊடகத்தின் URL"
 msgid "Media URL (Invalid)"
 msgstr "ஊடகத்தின் URL (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "பெயர்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "பெயர் (காலி)"
 
@@ -256,14 +256,19 @@ msgstr ""
 "ஃபியோடர் சோபோலெவ் {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "இல்லை"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "கோப்பைத் திறக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +276,14 @@ msgstr "பதிவிறக்கங்கள் எதுவும் இய�
 msgid "Parabolic"
 msgstr "பரபோலிக்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "கடவுச்சொல்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "கடவுச்சொல் (காலி)"
 
@@ -313,7 +318,7 @@ msgstr "குக்கீகள் கோப்பைத் தேர்ந்�
 msgid "Select Save Folder"
 msgstr "சேமி கோப்புறையை தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "புதிய கடவுச்சொல்"
@@ -326,7 +331,7 @@ msgstr ""
 "சில பதிவிறக்கங்கள் இன்னும் செயலில் உள்ளன.\n"
 "பரபோலிக் ஐ மூடிவிட்டு இயங்கும் பதிவிறக்கங்களை நிறுத்த விரும்புகிறீர்களா?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "சில பதிவிறக்கங்கள் பிழைகளுடன் முடிந்தது!"
 
@@ -366,7 +371,7 @@ msgstr ""
 "நிக்விஷன் பரபோலிக் இன் ஆசிரியர்கள் பொறுப்பல்ல/பொறுப்பேற்க மாட்டார்கள். பயனர்கள் இந்த "
 "பயன்பாட்டை தங்கள் சொந்த ஆபத்தில் பயன்படுத்துகின்றனர்."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "இந்த நடவடிக்கை மீள முடியாதது. நிச்சயமாக அதை நீக்க வேண்டுமா?"
 
@@ -388,12 +393,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "சாவி வளையத்தைத் திறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (செல்லாதது)"
 
@@ -401,13 +406,13 @@ msgstr "URL (செல்லாதது)"
 msgid "Use manual credential"
 msgstr "கைமுறை நற்சான்றிதழைப் பயன்படுத்தவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "பயனர் பெயர்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "பயனர் பெயர் (காலி)"
 
@@ -429,8 +434,8 @@ msgstr "காத்திருக்கிறது..."
 msgid "Worst"
 msgstr "மோசமான"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "ஆம்"
 

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Default"
 msgstr "Öntanımlı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "İndiriliyor"
@@ -191,13 +191,13 @@ msgstr "Dosya Adı"
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Anahtarlık"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Anahtarlık kilidi açılmamış."
 
@@ -205,8 +205,8 @@ msgstr "Anahtarlık kilidi açılmamış."
 msgid "List of supported sites"
 msgstr "Desteklenen sitelerin listesi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,12 +227,12 @@ msgstr "Ortam URLʼsi"
 msgid "Media URL (Invalid)"
 msgstr "Ortam URLʼsi (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Ad"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Ad (Boş)"
 
@@ -256,14 +256,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Çalışan indirme yok"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Aç"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -271,14 +275,14 @@ msgstr "Çalışan indirme yok"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Parola"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Parola (Boş)"
 
@@ -313,7 +317,7 @@ msgstr "Çerez Dosyasını Seç"
 msgid "Select Save Folder"
 msgstr "Kayıt Klasörünü Seçin"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Yeni Parola"
@@ -327,7 +331,7 @@ msgstr ""
 "Parabolicʼi kapatmak ve devam eden indirmeleri durdurmak istediğinizden emin "
 "misiniz?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Bazı indirmeler hatalarla tamamlandı!"
 
@@ -368,7 +372,7 @@ msgstr ""
 "değildir. Kullanıcılar bu uygulamayı riski kendilerine ait olmak üzere "
 "kullanırlar."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Bu işlem geri alınamaz. Silmek istediğinizden emin misiniz?"
 
@@ -395,12 +399,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Anahtarlık Kilidini Aç"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (Geçersiz)"
 
@@ -408,13 +412,13 @@ msgstr "URL (Geçersiz)"
 msgid "Use manual credential"
 msgstr "El ile kimlik bilgisi kullan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Kullanıcı adı (Boş)"
 
@@ -436,8 +440,8 @@ msgstr "Bekliyor..."
 msgid "Worst"
 msgstr "En Kötü"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Evet"
 
@@ -1087,9 +1091,6 @@ msgstr "— Üst veri ve video altyazı indirmeyi destekler"
 #~ "Nicholas Logozzo https://github.com/nlogozzo\n"
 #~ "Fyodor Sobolev https://github.com/fsobolev\n"
 #~ "DaPigGuy https://github.com/DaPigGuy"
-
-#~ msgid "Open"
-#~ msgstr "Aç"
 
 #~ msgid ""
 #~ "Downloading required dependencies...\n"

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Öntanımlı"
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "İndiriliyor"
@@ -265,7 +265,7 @@ msgstr "Hayır"
 msgid "No downloads running"
 msgstr "Çalışan indirme yok"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Aç"
 
@@ -567,6 +567,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Tüm İndirmeleri Durdur"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -117,7 +117,7 @@ msgstr "Öntanımlı"
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "İndiriliyor"
@@ -265,10 +265,6 @@ msgstr "Hayır"
 msgid "No downloads running"
 msgstr "Çalışan indirme yok"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Aç"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -285,6 +281,11 @@ msgstr "Parola"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Parola (Boş)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Çalma Listesi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -957,6 +958,9 @@ msgstr "— Aynı anda birden fazla indirme çalıştırın"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Üst veri ve video altyazı indirmeyi destekler"
+
+#~ msgid "Open"
+#~ msgstr "Aç"
 
 #~ msgid "Credential"
 #~ msgstr "Kimlik Bilgileri"

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -120,7 +120,7 @@ msgstr "За замовчуванням"
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Завантаження"
@@ -268,7 +268,7 @@ msgstr "Ні"
 msgid "No downloads running"
 msgstr "Немає завантажень"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Відкрити"
 
@@ -569,6 +569,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Зупинити всі завантаження"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:719
@@ -55,7 +55,7 @@ msgstr "{0:f1} КіБ/с"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} МіБ/с"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -116,11 +116,11 @@ msgstr ""
 msgid "Default"
 msgstr "За замовчуванням"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Завантаження"
@@ -194,13 +194,13 @@ msgstr "Ім'я файлу"
 msgid "GitHub Repo"
 msgstr "Репозиторій GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Keyring не розблоковано."
 
@@ -208,8 +208,8 @@ msgstr "Keyring не розблоковано."
 msgid "List of supported sites"
 msgstr "Список підтримуваних сайтів"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -230,12 +230,12 @@ msgstr "URL-адреса медіа"
 msgid "Media URL (Invalid)"
 msgstr "URL-адреса медіа (неправильна)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Ім'я"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Ім'я (Порожньо)"
 
@@ -259,14 +259,18 @@ msgstr ""
 "Fyodor Sobolev {1}\n"
 "DaPigGuy {2}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Ні"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Немає завантажень"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Відкрити"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -274,14 +278,14 @@ msgstr "Немає завантажень"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Пароль"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Пароль (Порожньо)"
 
@@ -316,7 +320,7 @@ msgstr "Виберіть файл cookies"
 msgid "Select Save Folder"
 msgstr "Натисніть \"Зберегти папку\""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Новий пароль"
@@ -329,7 +333,7 @@ msgstr ""
 "Деякі завантаження все ще тривають.\n"
 "Ви впевнені, що хочете закрити Parabolic і зупинити завантаження?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Деякі завантаження завершено з помилками!"
 
@@ -370,7 +374,7 @@ msgstr ""
 "закони про авторське право/DMCA. Користувачі використовують цей застосунок "
 "на власний ризик."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Ця дія є незворотною. Ви впевнені, що хочете його видалити?"
 
@@ -397,12 +401,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Розблокувати Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr "URL (Неправильна)"
 
@@ -410,13 +414,13 @@ msgstr "URL (Неправильна)"
 msgid "Use manual credential"
 msgstr "Використання облікових даних вручну"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Ім'я користувача (Порожнє)"
 
@@ -438,8 +442,8 @@ msgstr "Очікування..."
 msgid "Worst"
 msgstr "Найгірше"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Так"
 
@@ -1138,9 +1142,6 @@ msgstr "- Підтримує завантаження метаданих і су
 
 #~ msgid "Home"
 #~ msgstr "Головна"
-
-#~ msgid "Open"
-#~ msgstr "Відкрити"
 
 #~ msgid "Downloads"
 #~ msgstr "Завантаження"

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-07-12 18:52+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -120,7 +120,7 @@ msgstr "За замовчуванням"
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Завантаження"
@@ -268,10 +268,6 @@ msgstr "Ні"
 msgid "No downloads running"
 msgstr "Немає завантажень"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Відкрити"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -288,6 +284,11 @@ msgstr "Пароль"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Пароль (Порожньо)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Список відтворення"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -958,6 +959,9 @@ msgstr "- Запуск декількох завантажень одночас�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Підтримує завантаження метаданих і субтитрів до відео"
+
+#~ msgid "Open"
+#~ msgstr "Відкрити"
 
 #~ msgid "Credential"
 #~ msgstr "Облікові дані"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,7 +52,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, fuzzy, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "ڈاؤن لوڈ ہو رہا ہے"
@@ -192,13 +192,13 @@ msgstr "فائل کی قسم"
 msgid "GitHub Repo"
 msgstr "گٹ ہب رجسٹر(ریپوسٹری)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -206,8 +206,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "معاون سائٹس کی فہرست"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -229,13 +229,13 @@ msgstr "میڈیا URL"
 msgid "Media URL (Invalid)"
 msgstr "میڈیا URL (غلط)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 #, fuzzy
 msgid "Name"
 msgstr "فائل کی قسم"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -254,14 +254,18 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "نہیں"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہا ہے"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "کھولیں۔"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -269,14 +273,14 @@ msgstr "کوئی ڈاؤن لوڈ نہیں چل رہا ہے"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -312,7 +316,7 @@ msgstr "مطلوبہ جگہ فراہم کریں"
 msgid "Select Save Folder"
 msgstr "مطلوبہ جگہ فراہم کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -326,7 +330,7 @@ msgstr ""
 "کیا آپ واقعی ٹیوب کنورٹر کو بند کرنا اور چلنے والے ڈاؤن لوڈز کو روکنا چاہتے "
 "ہیں؟"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "کچھ ڈاؤن لوڈز غلطیوں کے ساتھ ختم ہو گئے!"
 
@@ -369,7 +373,7 @@ msgstr ""
 "ذمہ دار نہیں ہیں جو مقامی کاپی رائٹ/DMCA قوانین کی خلاف ورزی کر سکتا ہے۔ "
 "صارفین اس ایپلی کیشن کو اپنی ذمہ داری پر استعمال کرتے ہیں۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -395,12 +399,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "میڈیا URL (غلط)"
@@ -409,14 +413,14 @@ msgstr "میڈیا URL (غلط)"
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "صارف انٹرفیس"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "صارف انٹرفیس"
@@ -439,8 +443,8 @@ msgstr "منتظر..."
 msgid "Worst"
 msgstr "بدتر"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "ہاں"
 
@@ -1026,9 +1030,6 @@ msgstr ""
 #~ msgstr ""
 #~ "اگر ڈاؤن لوڈز چل رہے ہیں تو چھوڑنے کے بجائے ونڈو کو چھپائیں۔ پس منظر کی "
 #~ "سرگرمی کی حیثیت دکھانے کے لیے GNOME 44+ کی ضرورت ہے"
-
-#~ msgid "Open"
-#~ msgstr "کھولیں۔"
 
 #~ msgid ""
 #~ "Downloading required dependencies...\n"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "ڈاؤن لوڈ ہو رہا ہے"
@@ -263,10 +263,6 @@ msgstr "نہیں"
 msgid "No downloads running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہا ہے"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "کھولیں۔"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -282,6 +278,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
@@ -943,6 +943,9 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Open"
+#~ msgstr "کھولیں۔"
 
 #, fuzzy
 #~ msgid "Credentials"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "ڈاؤن لوڈ ہو رہا ہے"
@@ -263,7 +263,7 @@ msgstr "نہیں"
 msgid "No downloads running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہا ہے"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "کھولیں۔"
 
@@ -572,6 +572,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "تمام ڈاؤن لوڈ کو روکیں"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -112,7 +112,7 @@ msgstr "Mặc định"
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "Đang tải xuống"
@@ -256,7 +256,7 @@ msgstr "Không"
 msgid "No downloads running"
 msgstr "Không có tải xuống nào đang chạy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 msgid "Open"
 msgstr "Mở"
 
@@ -555,6 +555,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "Dừng Tất cả Tải xuống"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 #, fuzzy

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Default"
 msgstr "Mặc định"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "Đang tải xuống"
@@ -187,13 +187,13 @@ msgstr "Tên Tệp"
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr "Keyring chưa được mở khóa."
 
@@ -201,8 +201,8 @@ msgstr "Keyring chưa được mở khóa."
 msgid "List of supported sites"
 msgstr "Danh sách các trang được hỗ trợ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -223,12 +223,12 @@ msgstr "Địa chỉ"
 msgid "Media URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 msgid "Name"
 msgstr "Tên"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr "Tên (Trống)"
 
@@ -247,14 +247,18 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr "Không"
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr "Không có tải xuống nào đang chạy"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+msgid "Open"
+msgstr "Mở"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -262,14 +266,14 @@ msgstr "Không có tải xuống nào đang chạy"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Mật khẩu (Trống)"
 
@@ -304,7 +308,7 @@ msgstr "Chọn Tệp Cookie"
 msgid "Select Save Folder"
 msgstr "Chọn Thư mục Lưu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 #, fuzzy
 msgid "Set Password"
 msgstr "Mật khẩu Mới"
@@ -318,7 +322,7 @@ msgstr ""
 "Một số quá trình tải xuống chưa hoàn tất.\n"
 "Bạn có chắc bạn muốn đóng Tube Converter và hủy các quá trình đó không?"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr "Một số tải xuống kết thúc với lỗi!"
 
@@ -360,7 +364,7 @@ msgstr ""
 "với mọi hành vi lạm dụng chương trình này mà có thể vi phạm luật bản quyền "
 "hoặc luật DMCA sở tại. Người dùng tự chịu rủi ro khi sử dụng ứng dụng này."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Hành động này không thể đảo ngược. Bạn chắc chắn muốn xóa nó chứ?"
 
@@ -383,12 +387,12 @@ msgstr "Không thể mở khóa keyring. Vui lòng khởi động lại ứng d�
 msgid "Unlock Keyring"
 msgstr "Mở khóa Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr "Địa chỉ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
@@ -397,13 +401,13 @@ msgstr "Địa chỉ (Không hợp lệ)"
 msgid "Use manual credential"
 msgstr "Dùng chứng chỉ thủ công"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 msgid "Username"
 msgstr "Tên tài khoản"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 msgid "Username (Empty)"
 msgstr "Tên tài khoản (Trống)"
 
@@ -425,8 +429,8 @@ msgstr "Đang chờ..."
 msgid "Worst"
 msgstr "Tệ nhất"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr "Có"
 
@@ -1076,9 +1080,6 @@ msgstr "— Hỗ trợ tải về siêu dữ liệu và phụ đề"
 
 #~ msgid "New"
 #~ msgstr "Mới"
-
-#~ msgid "Open"
-#~ msgstr "Mở"
 
 #~ msgid "Close"
 #~ msgstr "Đóng"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -112,7 +112,7 @@ msgstr "Mặc định"
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "Đang tải xuống"
@@ -256,10 +256,6 @@ msgstr "Không"
 msgid "No downloads running"
 msgstr "Không có tải xuống nào đang chạy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-msgid "Open"
-msgstr "Mở"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -276,6 +272,11 @@ msgstr "Mật khẩu"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr "Mật khẩu (Trống)"
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "Danh sách phát"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -940,6 +941,9 @@ msgstr "— Chạy nhiều tải xuống cùng một lúc"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Hỗ trợ tải về siêu dữ liệu và phụ đề"
+
+#~ msgid "Open"
+#~ msgstr "Mở"
 
 #~ msgid "Credential"
 #~ msgstr "Chứng chỉ"

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 10:34+0200\n"
+"POT-Creation-Date: 2023-07-22 10:36+0200\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:85
 #, fuzzy
 msgid "Download Again"
 msgstr "下载中"
@@ -261,11 +261,6 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
-#, fuzzy
-msgid "Open"
-msgstr "打开文件"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
@@ -282,6 +277,11 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:73
+#, fuzzy
+msgid "Play"
+msgstr "播放列表"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:113
 msgid "Playlist"
@@ -933,6 +933,10 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Open"
+#~ msgstr "打开文件"
 
 #, fuzzy
 #~ msgid "youtube"

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 01:28+0200\n"
+"POT-Creation-Date: 2023-07-22 09:59+0200\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -54,7 +54,7 @@ msgstr "{0:f1} KiB/s"
 msgid "{0:f1} MiB/s"
 msgstr "{0:f1} MiB/s"
 
-#: ../../../Models/DownloadManager.cs:165
+#: ../../../Models/DownloadManager.cs:166
 #, csharp-format
 msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:64
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
 #, fuzzy
 msgid "Download Again"
 msgstr "下载中"
@@ -191,13 +191,13 @@ msgstr "文件名"
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:174
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:157
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:113
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:107
 msgid "Keyring has not been unlocked."
 msgstr ""
 
@@ -205,8 +205,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "支持的网站列表"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 msgid "Login"
 msgstr ""
 
@@ -227,13 +227,13 @@ msgstr ""
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:237
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:195
 #, fuzzy
 msgid "Name"
 msgstr "文件名"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:264
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:247
 msgid "Name (Empty)"
 msgstr ""
 
@@ -252,14 +252,19 @@ msgid ""
 "DaPigGuy {2}"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "No"
 msgstr ""
 
-#: ../../../Models/DownloadManager.cs:173
+#: ../../../Models/DownloadManager.cs:174
 msgid "No downloads running"
 msgstr ""
+
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#, fuzzy
+msgid "Open"
+msgstr "打开文件"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Program.cs:49
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
@@ -267,14 +272,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:260
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:243
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:210
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:39
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:271
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 msgid "Password (Empty)"
 msgstr ""
 
@@ -309,7 +314,7 @@ msgstr "选择 Cookie 文件"
 msgid "Select Save Folder"
 msgstr "选择保存文件夹"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:67
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:66
 msgid "Set Password"
 msgstr ""
 
@@ -322,7 +327,7 @@ msgstr ""
 "有些下载仍在进行中。\n"
 "确定要关闭 Tube Converter 并停止正在进行的下载吗？"
 
-#: ../../../Models/DownloadManager.cs:169
+#: ../../../Models/DownloadManager.cs:170
 msgid "Some downloads finished with errors!"
 msgstr ""
 
@@ -364,7 +369,7 @@ msgstr ""
 "Nickvision Tube Converter 的作者对任何可能违反当地版权/DMCA 法律的滥用本程序"
 "的行为概不负责。用户使用本程序的风险由他们自己承担。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -385,12 +390,12 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:256
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:200
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:259
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -398,14 +403,14 @@ msgstr ""
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:258
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:205
 #, fuzzy
 msgid "Username"
 msgstr "用户界面"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "用户界面"
@@ -428,8 +433,8 @@ msgstr ""
 msgid "Worst"
 msgstr "最差"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:303
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:308
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:286
 msgid "Yes"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 09:59+0200\n"
+"POT-Creation-Date: 2023-07-22 10:34+0200\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:75
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:71
 #, fuzzy
 msgid "Download Again"
 msgstr "下载中"
@@ -261,7 +261,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:87
+#: ../../../../NickvisionTubeConverter.GNOME/Controls/HistoryDialog.cs:83
 #, fuzzy
 msgid "Open"
 msgstr "打开文件"
@@ -560,6 +560,11 @@ msgstr ""
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:49
 msgid "Search..."
 msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:59
+#, fuzzy
+msgid "No Previous Downloads"
+msgstr "停止所有下载"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:52
 msgid "Keyring Disabled"


### PR DESCRIPTION
As per #453:
> so we can quickly search and open previously downloaded videos.

This PR makes it where the history will also save the path of a downloaded media. If that path still exists when the HistoryDialog is opened, an open button will be added to the row to allow the user to open the folder of that downloaded media:

![image](https://github.com/NickvisionApps/Parabolic/assets/17648453/1588e1ac-3191-4d76-bc20-d02af51f90fc)
