### PR TITLE
Numbered Suffix For Existing Filenames w/ Overwrite Files Off

### DIFF
--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -38,6 +38,7 @@ public partial class Program
             @"* Added the option to prevent suspend while using Parabolic
               * Improved bitrate used for audio-only downloads with the best quality
               * Parabolic will now prefer videos with the h264 codec when downloading in the mp4 format. If space is a concern, users are recommended to download in the webm format which uses the vp* codec
+              * If overwriting files is off and a download's file name exists, a numbered prefix will be attached to the end of the file name to prevent error
               * Fixed an issue where downloads with specific timeframes would download incorrectly
               * Fixed an issue where Parabolic would be unusable on systems without NetworkManager installed
               * Fixed an issue where Parabolic would say no active internet connection even though there was a connection established

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -38,7 +38,7 @@ public partial class Program
             @"* Added the option to prevent suspend while using Parabolic
               * Improved bitrate used for audio-only downloads with the best quality
               * Parabolic will now prefer videos with the h264 codec when downloading in the mp4 format. If space is a concern, users are recommended to download in the webm format which uses the vp* codec
-              * If overwriting files is off and a download's file name exists, a numbered prefix will be attached to the end of the file name to prevent error
+              * If overwriting files is off and a download's file name exists, a numbered suffix will be attached to the end of the file name to prevent error
               * Fixed an issue where downloads with specific timeframes would download incorrectly
               * Fixed an issue where Parabolic would be unusable on systems without NetworkManager installed
               * Fixed an issue where Parabolic would say no active internet connection even though there was a connection established

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -392,11 +392,12 @@ public class Download
                                             genericExtensionFound = true;
                                         }
                                     }
+                                    var baseFilename = Filename;
                                     var i = 0;
                                     while (!options.OverwriteExistingFiles && File.Exists(path.Replace(Id.ToString(), Path.GetFileNameWithoutExtension(Filename))))
                                     {
                                         i++;
-                                        Filename = $"{Path.GetFileNameWithoutExtension(Filename)} ({i}){Path.GetExtension(Filename)}";
+                                        Filename = $"{Path.GetFileNameWithoutExtension(baseFilename)} ({i}){Path.GetExtension(baseFilename)}";
                                     }
                                     try
                                     {
@@ -432,12 +433,14 @@ public class Download
                     Completed?.Invoke(this, IsSuccess);
                 }
             }).FireAndForget();
+
         }
     }
 
     /// <summary>
     /// Stops the download
     /// </summary>
+
     public void Stop()
     {
         if (IsRunning)

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -392,6 +392,12 @@ public class Download
                                             genericExtensionFound = true;
                                         }
                                     }
+                                    var i = 0;
+                                    while (!options.OverwriteExistingFiles && File.Exists(path.Replace(Id.ToString(), Path.GetFileNameWithoutExtension(Filename))))
+                                    {
+                                        i++;
+                                        Filename = $"{Path.GetFileNameWithoutExtension(Filename)} ({i}){Path.GetExtension(Filename)}";
+                                    }
                                     try
                                     {
                                         File.Move(path, path.Replace(Id.ToString(), Path.GetFileNameWithoutExtension(Filename)), options.OverwriteExistingFiles);

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -433,14 +433,12 @@ public class Download
                     Completed?.Invoke(this, IsSuccess);
                 }
             }).FireAndForget();
-
         }
     }
 
     /// <summary>
     /// Stops the download
     /// </summary>
-
     public void Stop()
     {
         if (IsRunning)

--- a/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
@@ -55,6 +55,7 @@
         <p>- Added the option to prevent suspend while using Parabolic</p>
         <p>- Improved bitrate used for audio-only downloads with the best quality</p>
         <p>- Parabolic will now prefer videos with the h264 codec when downloading in the mp4 format. If space is a concern, users are recommended to download in the webm format which uses the vp* codec</p>
+        <p>- If overwriting files is off and a download's file name exists, a numbered prefix will be attached to the end of the file name to prevent error</p>
         <p>- Fixed an issue where downloads with specific timeframes would download incorrectly</p>
         <p>- Fixed an issue where Parabolic would be unusable on systems without NetworkManager installed</p>
         <p>- Fixed an issue where Parabolic would say no active internet connection even though there was a connection established</p>

--- a/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
@@ -55,7 +55,7 @@
         <p>- Added the option to prevent suspend while using Parabolic</p>
         <p>- Improved bitrate used for audio-only downloads with the best quality</p>
         <p>- Parabolic will now prefer videos with the h264 codec when downloading in the mp4 format. If space is a concern, users are recommended to download in the webm format which uses the vp* codec</p>
-        <p>- If overwriting files is off and a download's file name exists, a numbered prefix will be attached to the end of the file name to prevent error</p>
+        <p>- If overwriting files is off and a download's file name exists, a numbered suffix will be attached to the end of the file name to prevent error</p>
         <p>- Fixed an issue where downloads with specific timeframes would download incorrectly</p>
         <p>- Fixed an issue where Parabolic would be unusable on systems without NetworkManager installed</p>
         <p>- Fixed an issue where Parabolic would say no active internet connection even though there was a connection established</p>


### PR DESCRIPTION
If overwriting files is off and a download's file name exists, a numbered suffix will be attached to the end of the file name to prevent error

Closes #529 