### PR TITLE
Clear issues list (again) for 2023.9.0

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: DaPigGuy/flatpak-github-actions/flatpak-builder@master
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.2
         with:
           bundle: org.nickvision.tubeconverter.flatpak
           manifest-path: flatpak/org.nickvision.tubeconverter.json

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           check_filenames: true
           skip: cargo-sources.json,.git,*.svg,*.html,*.js,*.po,*.pot,*.page
-          ignore_words_list: gir
+          ignore_words_list: gir,te

--- a/NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp
@@ -127,11 +127,14 @@ Adw.Window _root {
                       visible: false;
                     }
 
-                    Adw.ComboRow _subtitleRow {
-                      title: _("Subtitle");
-                      model: Gtk.StringList {
-                        strings [C_("Subtitle", "None"), "VTT", "SRT"]
-                      };
+                    Adw.ActionRow _subtitleRow {
+                      title: _("Download Subtitle");
+                      activatable-widget: _subtitleSwitch;
+
+                      [suffix]
+                        Gtk.Switch _subtitleSwitch {
+                        valign: center;
+                      }
                     }
                   }
 

--- a/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
@@ -243,7 +243,6 @@ Adw.PreferencesWindow _root {
 
       Adw.EntryRow _subtitleLangsRow {
         title: _("Subtitle Languages (Comma-Separated)");
-        show-apply-button: true;
 
         [prefix]
         Gtk.Image {
@@ -270,7 +269,7 @@ Adw.PreferencesWindow _root {
                   maximum-size: 300;
                   child: Gtk.Label {
                     wrap: true;
-                    label: _("Some sites use two-letter language codes, whereas others use three-letter. For example, \"en\" and \"eng\" are both used for English.\n\nPlease specify both two-letter and three-letter codes for your languages for the best results.");
+                    label: _("Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, \"en\", \"en-US\" and \"eng\" are all used for English.\n\nPlease specify all valid codes for your languages for the best results.");
                   };
                 }
             };

--- a/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
@@ -416,6 +416,22 @@ Adw.PreferencesWindow _root {
             valign: center;
           }
         }
+
+        Adw.ActionRow {
+          title: _("Remove data about media source");
+          subtitle: _("Clear metadata fields containing URL and another data that can lead to the media source");
+          activatable-widget: _removeSourceDataSwitch;
+
+          [prefix]
+          Gtk.Image {
+            icon-name: "larger-brush-symbolic";
+          }
+
+          [suffix]
+          Gtk.Switch _removeSourceDataSwitch {
+            valign: center;
+          }
+        }
       }
 
       Adw.ActionRow {

--- a/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
@@ -417,8 +417,8 @@ Adw.PreferencesWindow _root {
         }
 
         Adw.ActionRow {
-          title: _("Remove data about media source");
-          subtitle: _("Clear metadata fields containing URL and another data that can lead to the media source");
+          title: _("Remove Source Data");
+          subtitle: _("Clear metadata fields containing the URL and other identifying information of the media source");
           activatable-widget: _removeSourceDataSwitch;
 
           [prefix]

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -233,6 +233,7 @@ public partial class AddDownloadDialog : Adw.Window
             _saveFolderString = GLib.Functions.GetUserSpecialDir(GLib.UserDirectory.DirectoryDownload) ?? "";
         }
         _saveFolderRow.SetText(Path.GetFileName(_saveFolderString) ?? "");
+        _subtitleSwitch.SetActive(_controller.PreviousSubtitleState);
         _speedLimitRow.SetSubtitle($"{_("{0:f1} KiB/s", _controller.CurrentSpeedLimit)} {_("(Configurable in preferences)")}");
     }
 

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -40,7 +40,8 @@ public partial class AddDownloadDialog : Adw.Window
     [Gtk.Connect] private readonly Adw.ComboRow _fileTypeRow;
     [Gtk.Connect] private readonly Adw.ComboRow _qualityRow;
     [Gtk.Connect] private readonly Adw.ComboRow _audioLanguageRow;
-    [Gtk.Connect] private readonly Adw.ComboRow _subtitleRow;
+    [Gtk.Connect] private readonly Adw.ActionRow _subtitleRow;
+    [Gtk.Connect] private readonly Gtk.Switch _subtitleSwitch;
     [Gtk.Connect] private readonly Adw.EntryRow _saveFolderRow;
     [Gtk.Connect] private readonly Gtk.Button _selectSaveFolderButton;
     [Gtk.Connect] private readonly Adw.ActionRow _openAdvancedRow;
@@ -588,11 +589,11 @@ public partial class AddDownloadDialog : Adw.Window
         }
         if(_keyringRow.GetSelected() == 0 || _keyringRow.GetSelected() == GTK_INVALID_LIST_POSITION || !_authRow.GetEnableExpansion())
         {
-            _controller.PopulateDownloads(SelectedMediaFileType, quality, resolutionIndex, audioLanguage, (Subtitle)_subtitleRow.GetSelected(), _saveFolderString, _speedLimitSwitch.GetActive(), _splitChaptersSwitch.GetActive(), _cropThumbnailSwitch.GetActive(), timeframe, _usernameRow.GetText(), _passwordRow.GetText());
+            _controller.PopulateDownloads(SelectedMediaFileType, quality, resolutionIndex, audioLanguage, _subtitleSwitch.GetActive(), _saveFolderString, _speedLimitSwitch.GetActive(), _splitChaptersSwitch.GetActive(), _cropThumbnailSwitch.GetActive(), timeframe, _usernameRow.GetText(), _passwordRow.GetText());
         }
         else
         {
-            await _controller.PopulateDownloadsAsync(SelectedMediaFileType, quality, resolutionIndex, audioLanguage, (Subtitle)_subtitleRow.GetSelected(), _saveFolderString, _speedLimitSwitch.GetActive(), _splitChaptersSwitch.GetActive(), _cropThumbnailSwitch.GetActive(), timeframe, ((int)_keyringRow.GetSelected()) - 1);
+            await _controller.PopulateDownloadsAsync(SelectedMediaFileType, quality, resolutionIndex, audioLanguage, _subtitleSwitch.GetActive(), _saveFolderString, _speedLimitSwitch.GetActive(), _splitChaptersSwitch.GetActive(), _cropThumbnailSwitch.GetActive(), timeframe, ((int)_keyringRow.GetSelected()) - 1);
         }
         OnDownload?.Invoke(this, EventArgs.Empty);
     }

--- a/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
@@ -43,6 +43,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
     [Gtk.Connect] private readonly Gtk.Button _unsetCookiesFileButton;
     [Gtk.Connect] private readonly Gtk.Switch _disallowConversionsSwitch;
     [Gtk.Connect] private readonly Adw.ExpanderRow _embedMetadataRow;
+    [Gtk.Connect] private readonly Gtk.Switch _removeSourceDataSwitch;
     [Gtk.Connect] private readonly Gtk.Switch _cropAudioThumbnailSwitch;
     [Gtk.Connect] private readonly Gtk.Switch _embedChaptersSwitch;
 
@@ -93,6 +94,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         }
         _disallowConversionsSwitch.SetActive(_controller.DisallowConversions);
         _embedMetadataRow.SetEnableExpansion(_controller.EmbedMetadata);
+        _removeSourceDataSwitch.SetActive(_controller.RemoveSourceData);
         _cropAudioThumbnailSwitch.SetActive(_controller.CropAudioThumbnails);
         _embedChaptersSwitch.SetActive(_controller.EmbedChapters);
     }
@@ -128,6 +130,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _controller.ProxyUrl = _proxyRow.GetText();
         _controller.DisallowConversions = _disallowConversionsSwitch.GetActive();
         _controller.EmbedMetadata = _embedMetadataRow.GetEnableExpansion();
+        _controller.RemoveSourceData = _removeSourceDataSwitch.GetActive();
         _controller.CropAudioThumbnails = _cropAudioThumbnailSwitch.GetActive();
         _controller.EmbedChapters = _embedChaptersSwitch.GetActive();
         _controller.SaveConfiguration();

--- a/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
@@ -66,7 +66,13 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _ariaMaxConnectionsPerServerResetButton.OnClicked += (sender, e) => _ariaMaxConnectionsPerServerSpin.SetValue(16);
         _ariaMinSplitSizeResetButton.OnClicked += (sender, e) => _ariaMinSplitSizeSpin.SetValue(20);
         _sponsorBlockInfoButton.OnClicked += async (sender, e) => await LaunchSponsorBlockInfoAsync();
-        _subtitleLangsRow.OnApply += SubtitleLangsChanged;
+        _subtitleLangsRow.OnNotify += (sender, e) =>
+        {
+            if (e.Pspec.GetName() == "text")
+            {
+                SubtitleLangsChanged();
+            }
+        };
         _chromeCookiesButton.OnClicked += async (sender, e) => await LaunchChromeCookiesExtensionAsync();
         _firefoxCookiesButton.OnClicked += async (sender, e) => await LaunchFirefoxCookiesExtensionAsync();
         _selectCookiesFileButton.OnClicked += async (sender, e) => await SelectCookiesFileAsync();
@@ -168,9 +174,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
     /// <summary>
     /// Occurs when the subtitle langs row is applied
     /// </summary>
-    /// <param name="sender">Adw.EntryRow</param>
-    /// <param name="e">EventArgs</param>
-    private void SubtitleLangsChanged(Adw.EntryRow sender, EventArgs e)
+    private void SubtitleLangsChanged()
     {
         _subtitleLangsRow.SetTitle(_("Subtitle Languages (Comma-Separated)"));
         _subtitleLangsRow.RemoveCssClass("error");
@@ -178,7 +182,6 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         if(valid)
         {
             _controller.SubtitleLangs = _subtitleLangsRow.GetText();
-            _controller.SaveConfiguration();
         }
         else
         {

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -71,6 +71,10 @@ public class AddDownloadDialogController
     /// </summary>
     public MediaFileType PreviousMediaFileType => Configuration.Current.PreviousMediaFileType;
     /// <summary>
+    /// The previously used subtitle downloading state
+    /// </summary>
+    public bool PreviousSubtitleState => Configuration.Current.PreviousSubtitleState;
+    /// <summary>
     /// Whether or not to number titles
     /// </summary>
     public bool NumberTitles => Configuration.Current.NumberTitles;
@@ -274,6 +278,7 @@ public class AddDownloadDialogController
         {
             Configuration.Current.PreviousVideoResolution = _mediaUrlInfo.VideoResolutions[resolution.Value].ToString();
         }
+        Configuration.Current.PreviousSubtitleState = subtitles;
         Aura.Active.SaveConfig("config");
     }
 

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -247,7 +247,7 @@ public class AddDownloadDialogController
     /// <param name="quality">The quality of the downloads</param>
     /// <param name="resolution">The index of the video resolution if available</param>
     /// <param name="audioLanguage">The audio language code</param>
-    /// <param name="subtitles">The subtitle format of the downloads</param>
+    /// <param name="subtitles">Whether or not to download the subtitles</param>
     /// <param name="saveFolder">The save folder of the downloads</param>
     /// <param name="limitSpeed">Whether or not to use speed limit</param>
     /// <param name="splitChapters">Whether or not to split based on chapters</param>
@@ -255,7 +255,7 @@ public class AddDownloadDialogController
     /// <param name="timeframe">A Timeframe to restrict the timespan of the media download</param>
     /// <param name="username">A username for the website (if available)</param>
     /// <param name="password">A password for the website (if available)</param>
-    public void PopulateDownloads(MediaFileType mediaFileType, Quality quality, int? resolution, string? audioLanguage, Subtitle subtitles, string saveFolder, bool limitSpeed, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, string? username, string? password)
+    public void PopulateDownloads(MediaFileType mediaFileType, Quality quality, int? resolution, string? audioLanguage, bool subtitles, string saveFolder, bool limitSpeed, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, string? username, string? password)
     {
         Downloads.Clear();
         foreach (var media in _mediaUrlInfo.MediaList)
@@ -284,14 +284,14 @@ public class AddDownloadDialogController
     /// <param name="quality">The quality of the downloads</param>
     /// <param name="resolution">The index of the video resolution if available</param>
     /// <param name="audioLanguage">The audio language code</param>
-    /// <param name="subtitles">The subtitle format of the downloads</param>
+    /// <param name="subtitles">Whether or not to download the subtitles</param>
     /// <param name="saveFolder">The save folder of the downloads</param>
     /// <param name="limitSpeed">Whether or not to use speed limit</param>
     /// <param name="splitChapters">Whether or not to split based on chapters</param>
     /// <param name="cropThumbnail">Whether or not to crop the thumbnail</param>
     /// <param name="timeframe">A Timeframe to restrict the timespan of the media download</param>
     /// <param name="credentialIndex">The index of the credential to use</param>
-    public async Task PopulateDownloadsAsync(MediaFileType mediaFileType, Quality quality, int? resolution, string? audioLanguage, Subtitle subtitles, string saveFolder, bool limitSpeed, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, int credentialIndex)
+    public async Task PopulateDownloadsAsync(MediaFileType mediaFileType, Quality quality, int? resolution, string? audioLanguage, bool subtitles, string saveFolder, bool limitSpeed, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, int credentialIndex)
     {
         if(_keyring != null)
         {

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -53,7 +53,7 @@ public class MainWindowController : IDisposable
     /// <summary>
     /// The DownloadOptions for a download
     /// </summary>
-    public DownloadOptions DownloadOptions => new DownloadOptions(Configuration.Current.OverwriteExistingFiles, Configuration.Current.UseAria, Configuration.Current.AriaMaxConnectionsPerServer, Configuration.Current.AriaMinSplitSize, Configuration.Current.YouTubeSponsorBlock, Configuration.Current.SubtitleLangs, Configuration.Current.ProxyUrl, Configuration.Current.CookiesPath, Configuration.Current.EmbedMetadata, Configuration.Current.EmbedChapters);
+    public DownloadOptions DownloadOptions => new DownloadOptions(Configuration.Current.OverwriteExistingFiles, Configuration.Current.UseAria, Configuration.Current.AriaMaxConnectionsPerServer, Configuration.Current.AriaMinSplitSize, Configuration.Current.YouTubeSponsorBlock, Configuration.Current.SubtitleLangs, Configuration.Current.ProxyUrl, Configuration.Current.CookiesPath, Configuration.Current.EmbedMetadata, Configuration.Current.RemoveSourceData, Configuration.Current.EmbedChapters);
     /// <summary>
     /// Gets the DownloadHistory object
     /// </summary>

--- a/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
@@ -219,7 +219,7 @@ public class PreferencesViewController
     }
 
     /// <summary>
-    /// Whether ot not to remove data about media source from metadata
+    /// Whether or not to remove data about media source from metadata
     /// </summary>
     /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
     public bool RemoveSourceData

--- a/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
@@ -26,7 +26,7 @@ public class PreferencesViewController
     {
         var cultures = CultureInfo.GetCultures(CultureTypes.AllCultures).Where(x => !string.IsNullOrEmpty(x.Name)).ToArray();
         var codes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        codes.UnionWith(cultures.Select(x => x.TwoLetterISOLanguageName));
+        codes.UnionWith(cultures.Select(x => x.Name));
         codes.UnionWith(cultures.Select(x => x.ThreeLetterISOLanguageName));
         _supportedLangCodes = codes.ToList();
     }

--- a/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/PreferencesViewController.cs
@@ -219,6 +219,17 @@ public class PreferencesViewController
     }
 
     /// <summary>
+    /// Whether ot not to remove data about media source from metadata
+    /// </summary>
+    /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
+    public bool RemoveSourceData
+    {
+        get => Configuration.Current.RemoveSourceData;
+
+        set => Configuration.Current.RemoveSourceData = value;
+    }
+
+    /// <summary>
     /// Whether or not to embed chapters in a download
     /// </summary>
     public bool EmbedChapters

--- a/NickvisionTubeConverter.Shared/Docs/html/C/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/C/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Advanced">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/C/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/C/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Note">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Advanced">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/ar/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ar/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="متقدم">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/ar/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ar/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="ملاحظة">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="متقدم">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">رابط الوكيل</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/bn/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/bn/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Advanced">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/bn/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/bn/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="নোট">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Advanced">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/cs/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/cs/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Výchozí: vypnuto</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Dostupné pouze při povoleném vložení metadat.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Pokročilé">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Výchozí: vypnuto</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Vkládání kapitol</dt>
 <dd class="terms">
 <p class="p">Pokud je tato funkce povolena, aplikace Parabolic označí média informacemi o kapitolách, pokud jsou dostupné</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/cs/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/cs/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Jazyky titulků</dt>
 <dd class="terms">
-<p class="p">Seznam dvoupísmenných a třípísmenných jazykových kódů oddělených čárkou, které se použijí při výběru jazyků titulků ke stažení. Použije se pouze v případě, že je při stahování vybrán platný formát <span class="code">Subtitle</span>.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Upozornění">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Některé stránky používají dvoupísmenné jazykové kódy, jiné třípísmenné. Například pro angličtinu se používá <span class="code">en</span> i <span class="code">eng</span>. Pro dosažení nejlepších výsledků zadejte pro své jazyky dvoupísmenné i třípísmenné kódy.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Pokročilé">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Výchozí: dvoupísmenný a třípísmenný kód tvého jazyka. Například na americkém (en-US) systému budou výchozí kódy <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">URL proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/de/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/de/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Standardeinstellung: Aus</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Nur verfügbar wenn "Metadaten einbetten" aktiviert ist.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Erweitert">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Standardeinstellung: Aus</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Kapitel Einbetten</dt>
 <dd class="terms">
 <p class="p">Wenn diese Option aktiviert ist, markiert Parabolic Medien mit Kapitelinformationen, falls vorhanden.</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/de/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/de/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Untertitelsprachen</dt>
 <dd class="terms">
-<p class="p">Eine durch Kommata getrennte Liste von Sprachcodes mit zwei oder drei Buchstaben. Die Liste wird bei der Sprachauswahl der herunterzuladenden Untertitel verwendet. Gilt nur, wenn in einem Download ein gültiges Untertitelformat ausgewählt ist.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Anmerkung">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Manche Webseiten verwenden Sprachcodes mit zwei Buchstaben, andere mit drei Buchstaben. Beispielsweise werden <span class="code">en</span> und <span class="code">eng</span> beide für Englisch verwendet. Um die besten Ergebnisse zu erzielen, gib bitte sowohl zweistellige als auch dreistellige Codes an.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Erweitert">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Standardeinstellung: Der zweistellige und dreistellige Sprachcode deiner Kultur. Auf einem US-amerkanischen System wäre das beispielsweise <span class="code">en,eng</span>.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy-URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/el/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/el/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Για προχωρημένους">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/el/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/el/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Σημείωση">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Για προχωρημένους">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/es/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/es/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Predeterminado: Apagado</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Sólo disponible si está activada la opción Incrustar metadatos.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avanzada">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Predeterminado: Apagado</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Incrustar capítulos</dt>
 <dd class="terms">
 <p class="p">Si está activada, Parabolic etiquetará un medio con la información del capítulo si está disponible</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/es/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/es/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Idiomas de los subtítulos</dt>
 <dd class="terms">
-<p class="p">Una lista separada por comas de códigos de idioma de dos y tres letras para usar al seleccionar los idiomas de los subtítulos que se van a descargar. Sólo se aplica cuando se selecciona un formato <span class="code">Subtítulo</span> válido en una descarga.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Nota">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Algunos sitios usan códigos lingüísticos de dos letras, mientras que otros usan de tres. Por ejemplo, <span class="code">en</span> y <span class="code">eng</span> se usan ambos para el inglés. Especifique los códigos de dos y tres letras de sus idiomas para obtener los mejores resultados.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avanzada">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Predeterminado: el código lingüístico de dos y tres letras de su cultura. Por ejemplo, en un sistema en-US el valor predeterminado sería <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">URL del proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/fi/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/fi/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Edistyneet">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Upota kappaleet</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/fi/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/fi/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Huomautus">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Edistyneet">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Välityspalvelimen URL-osoite</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/fr/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/fr/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Par défaut : Désactivée</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Uniquement disponible si l’inclusion des métadonnées est activée.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avancé">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Par défaut : Désactivée</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Inclure les chapitres</dt>
 <dd class="terms">
 <p class="p">Si cette option est activée, Parabole inclura dans un média les informations relatives à ses chapitres, si disponibles</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/fr/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/fr/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Langues des sous-titres</dt>
 <dd class="terms">
-<p class="p">Une liste de codes de langages de deux ou trois lettres, séparés par une virgule, à utiliser pour sélectionner les langages des sous-titres à télécharger. S’applique uniquement lorsqu’un format de <span class="code">sous-titres</span> valide est sélectionné dans un téléchargement.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Note">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Certains sites utilisent des abréviations de langages à deux lettres, alors que d’autres utilisent trois lettres. Par exemple, <span class="code">en</span> et <span class="code">eng</span> sont tous les deux utilisés pour l’anglais. Spécifiez les abréviations pour vos langages avec 2 et 3 lettres pour avoir de meilleurs résultats.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avancé">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Par défaut : les codes à deux et trois lettres de votre langue locale. Par exemple, <span class="code">en,eng</span> sur un système en-US</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">URL de Proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/gl/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/gl/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avanzada">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/gl/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/gl/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Nota">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avanzada">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/he/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/he/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="מתקדם">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">הטמעת פרקים</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/he/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/he/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="הערה">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="מתקדם">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">כתובת מתווך</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/hi/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/hi/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="विस्तृत">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/hi/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/hi/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="टिप्पणी">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="विस्तृत">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/hu/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/hu/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Speciális">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Fejezetek beágyazása</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/hu/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/hu/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Megjegyzés">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Speciális">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy átjáró címe</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/id/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/id/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Tingkat Lanjut">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/id/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/id/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Catatan">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Tingkat Lanjut">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/it/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/it/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Predefinito: Disattivato</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Disponibile solo se Incorpora metadati è abilitato.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avanzato">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Predefinito: Disattivato</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Includi i capitoli</dt>
 <dd class="terms">
 <p class="p">Se abilitato, Parabolic taggherà un supporto con le informazioni sul capitolo, se disponibili</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/it/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/it/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Lingue dei Sottotitoli</dt>
 <dd class="terms">
-<p class="p">Una lista con campi separati da virgola di codici di lingua composti da due e tre caratteri da usare per selezionare le lingue dei sottotitoli da scaricare. È applicabile solo quando viene selezionato un formato valido <span class="code">Subtitle</span> in un download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Annotazione">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Alcuni siti utilizzano codici di lingua da due caratteri, mentre altri usano tre caratteri. Per esempio, <span class="code">en</span> e <span class="code">eng</span> sono usati entrambi per la lingua inglese. Per ottenere risultati migliori, si prega di inserire codici da due e tre caratteri per le lingue scelte.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avanzato">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">URL proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/ja/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ja/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">デフォルト: オフ</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">メタデータを埋め込む設定が有効な時のみ利用可能です。</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="高度">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">デフォルト: オフ</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">チャプター（章）を埋め込む</dt>
 <dd class="terms">
 <p class="p">有効であれば、Parabolic はメディアにチャプター（章）を利用可能であれば埋め込みます</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/ja/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ja/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="注記">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="高度">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">プロキシ URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/nb_NO/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/nb_NO/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avansert">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/nb_NO/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/nb_NO/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Merknad">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avansert">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/nl/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/nl/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Standaard: Uit</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Geavanceerd">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Standaard: Uit</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Hoofdstukken invoegen</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/nl/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/nl/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Ondertitel­talen</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Opmerking">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Geavanceerd">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy-URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/pl/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pl/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Domyślnie: wyłączone</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Dostępne wyłącznie, jeśli opcja "Zapisuj metadane w plikach" jest włączona.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Zaawansowane">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Domyślnie: wyłączone</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Zapisuj rozdziały w plikach</dt>
 <dd class="terms">
 <p class="p">Po włączeniu, Parabolic będzie oznaczać multimedia informacjami o rozdziałach, jeśli są dostępne</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/pl/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pl/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Języki napisów</dt>
 <dd class="terms">
-<p class="p">Lista oddzielonych przecinkami, dwuliterowych i trzyliterowych kodów języków, które mają zostać wybrane przy pobieraniu napisów. To ustawienie zadziała, jeśli poprawny format <span class="code">napisów</span> zostanie wybrany przy pobieraniu.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Uwaga">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Strony internetowe używają zarówno dwuliterowych, jak i trzyliterowych kodów języka. Na przykład, dla języka angielskiego są to <span class="code">en</span> i <span class="code">eng</span>. Aby uzyskać najlepsze wyniki, należy podać zarówno dwuliterowe, jak i trzyliterowe kody wybranych języków.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Zaawansowane">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Domyślnie: dwuliterowy i trzyliterowy kod języka ojczystego. Na przykład, dla systemu en-US wartością domyślną byłoby <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Adres URL serwera proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/pt_BR/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pt_BR/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avançado">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Incorporar capítulos</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/pt_BR/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pt_BR/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Nota">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avançado">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">URL da Proxy</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/pt_PT/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pt_PT/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avançado">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/pt_PT/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/pt_PT/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Nota">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avançado">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/ru/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ru/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">По умолчанию: Выключено</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Доступно только если Встраивание Метаданных включено.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Подробности">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">По умолчанию: Выключено</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Встраивать главы</dt>
 <dd class="terms">
 <p class="p">Если включено, Parabolic будет записывать данные о главах в медиа файл, если эта информация доступна</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/ru/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ru/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Языки субтитров</dt>
 <dd class="terms">
-<p class="p">Список разделённых запятой двух- и трёх-символьных кодов языков для использования при скачивании субтитров. Применяется только при выборе формата <span class="code">Субтитров</span> при добавлении загрузки.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Примечание">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Некоторые сайты используют двух-символьные языковые коды, тогда как другие используют трёх-символьные. Например, <span class="code">ru</span> и <span class="code">rus</span> используются для русского языка. Пожалуйста. указывайте оба варианта для необходимых языков, для достижения наилучших результатов.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Подробности">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">По умолчанию: Двух- и трёх-символьные коды для вашего языка. Например, на системе с локалью ru-RU будет указано <span class="code">ru,rus</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Адрес прокси-сервера</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/sv/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/sv/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Avancerat">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/sv/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/sv/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Anteckning">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Avancerat">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/ta/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ta/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">இயல்புநிலை: ஆஃப்</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">உட்பொதிவு மெட்டாடேட்டா இயக்கப்பட்டால் மட்டுமே கிடைக்கும்.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="மேம்பட்ட">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">இயல்புநிலை: ஆஃப்</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">அத்தியாயங்களை உட்பொதிக்கவும்</dt>
 <dd class="terms">
 <p class="p">இயக்கப்பட்டால், பாரபோலிக் மீடியாவை அத்தியாயத் தகவலுடன் குறியிடும்</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/ta/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ta/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">வசன மொழிகள்</dt>
 <dd class="terms">
-<p class="p">பதிவிறக்கம் செய்ய வசனம் மொழிகளைத் தேர்ந்தெடுக்கும்போது பயன்படுத்த வேண்டிய இரண்டு எழுத்து மற்றும் மூன்றெழுத்து மொழிக் குறியீடுகளின் கமாவால் பிரிக்கப்பட்ட பட்டியல். பதிவிறக்கத்தில் சரியான <span class="code">Subtitle</span> வடிவம் தேர்ந்தெடுக்கப்பட்டால் மட்டுமே பொருந்தும்.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="குறிப்பு">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">சில தளங்கள் இரண்டெழுத்து மொழிக் குறியீடுகளைப் பயன்படுத்துகின்றன, மற்றவை மூன்றெழுத்துகளைப் பயன்படுத்துகின்றன. எடுத்துக்காட்டாக, <span class="code">en</span> மற்றும் <span class="code">eng</span> இரண்டும் ஆங்கிலத்திற்குப் பயன்படுத்தப்படுகின்றன. சிறந்த முடிவுகளுக்கு உங்கள் மொழிகளுக்கான இரண்டு எழுத்து மற்றும் மூன்றெழுத்து குறியீடுகள் இரண்டையும் குறிப்பிடவும்.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="மேம்பட்ட">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">இயல்புநிலை: உங்கள் கலாச்சாரத்தின் இரண்டெழுத்து மற்றும் மூன்றெழுத்து மொழிக் குறியீடு. எடுத்துக்காட்டாக, en-US கணினியில் இயல்புநிலையாக <span class="code">en,eng</span> இருக்கும்</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">ப்ராக்ஸி URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/tr/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/tr/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Gelişmiş">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Bölümleri Göm</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/tr/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/tr/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Not">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Gelişmiş">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URLʼsi</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/uk/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/uk/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">За замовчуванням: Вимк</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Доступно, якщо ввімкнено Вбудовувати метадані.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Додатково">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">За замовчуванням: Вимк</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Вставити розділи</dt>
 <dd class="terms">
 <p class="p">Якщо ввімкнено, Parabolic позначатиме носій інформацією про розділ, якщо вона є</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/uk/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/uk/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Мови субтитрів</dt>
 <dd class="terms">
-<p class="p">Список розділених комами двобуквених та трибуквених мовних кодів для вибору мови субтитрів для завантаження. Застосовується лише тоді, коли під час завантаження вибрано правильний формат <span class="code">Субтитрів</span>.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Примітка">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Деякі сайти використовують дволітерні мовні коди, тоді як інші - трилітерні. Наприклад, <span class="code">en</span> та <span class="code">eng</span> використовуються для англійської мови. Будь ласка, вказуйте як двобуквені, так і трибуквені коди для ваших мов, щоб отримати найкращі результати.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Додатково">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">За замовчуванням: дво- та трилітерний мовний код вашої культури. Наприклад, в англо-американській системі за замовчуванням буде <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Проксі URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/ur/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ur/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Advanced">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">ابواب کو شامل کریں</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/ur/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/ur/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Note">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Advanced">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">پراکسی یو-آر-ایل</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/vi/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/vi/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Nâng cao">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/vi/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/vi/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Ghi chú">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Nâng cao">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/html/zh_Hans/converter.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/zh_Hans/converter.html
@@ -83,6 +83,28 @@ document.addEventListener('DOMContentLoaded', function() {
 </svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
 </div>
 </dd>
+<dt class="terms">Remove Source Data</dt>
+<dd class="terms">
+<p class="p">Only available if Embed Metadata is enabled.</p>
+<p class="p">If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+<p class="p">Fields that are cleared: <span class="code">comment</span>, <span class="code">description</span>, <span class="code">synopsis</span>, <span class="code">purl</span> and <span class="code">handler_name</span> in each stream.</p>
+<div class="note note-advanced" title="Advanced">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m5.4473 12.572c-2.039 0.957-3.4473 3.019-3.4473 5.428v4h20v-4c0-2.406-1.406-4.466-3.441-5.424a8 8 0 0 1 -6.559 3.424 8 8 0 0 1 -6.5527 -3.428z"></path>
+  <path class="yelp-svg-fill" d="m12 3a5 5 0 0 0 -5 5 5 5 0 0 0 5 5 5 5 0 0 0 5 -5 5 5 0 0 0 -5 -5zm0 3a2 2 0 0 1 2 2 2 2 0 0 1 -2 2 2 2 0 0 1 -2 -2 2 2 0 0 1 2 -2z"></path>
+  <path class="yelp-svg-fill" d="m15.312 6 3.688 1v2l-3.4688 1z"></path>
+  <path class="yelp-svg-fill" d="m14 11.312-1 3.688h-2l-1-3.469z"></path>
+  <path class="yelp-svg-fill" d="m10 4.6875 1-3.6875h2l1 3.4688z"></path>
+  <path class="yelp-svg-fill" d="m8.6875 10-3.6875-1v-2l3.4688-1z"></path>
+  <path class="yelp-svg-fill" d="m12.928 4.2435 3.3146-1.9003 1.4142 1.4142-1.7457 3.1599z"></path>
+  <path class="yelp-svg-fill" d="m15.757 8.9281 1.9003 3.3146-1.4142 1.4142-3.1599-1.7457z"></path>
+  <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
+  <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Off</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Embed Chapters</dt>
 <dd class="terms">
 <p class="p">If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/html/zh_Hans/downloader.html
+++ b/NickvisionTubeConverter.Shared/Docs/html/zh_Hans/downloader.html
@@ -174,14 +174,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Subtitles Languages</dt>
 <dd class="terms">
-<p class="p">A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <span class="code">Subtitle</span> format is selected in a download.</p>
+<p class="p">A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
 <div class="note" title="Note">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Some sites use two-letter language codes, whereas others use three-letter. For example, <span class="code">en</span> and <span class="code">eng</span> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p></div></div></div>
 </div>
 <div class="note note-advanced" title="Advanced">
 <svg height="24" width="24" version="1.1">
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <span class="code">en,eng</span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Default: Your culture's language codes. For example, on an en-US system the default would be <span class="code">en,en-US,eng</span></p></div></div></div>
 </div>
 </dd>
 <dt class="terms">Proxy URL</dt>

--- a/NickvisionTubeConverter.Shared/Docs/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-09-06 17:07+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -288,25 +288,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-09-06 17:07+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -66,8 +66,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "قص الصور المصغرة لصوتيات"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -113,11 +113,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/bn.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/bn.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -328,10 +328,11 @@ msgstr "Jazyky titulků"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Seznam dvoupísmenných a třípísmenných jazykových kódů oddělených čárkou, "
 "které se použijí při výběru jazyků titulků ke stažení. Použije se pouze v "
@@ -339,11 +340,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Některé stránky používají dvoupísmenné jazykové kódy, jiné třípísmenné. "
 "Například pro angličtinu se používá <code>en</code> i <code>eng</code>. Pro "
@@ -352,9 +355,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "Výchozí: dvoupísmenný a třípísmenný kód tvého jazyka. Například na americkém "
 "(en-US) systému budou výchozí kódy <code>en,eng</code>"

--- a/NickvisionTubeConverter.Shared/Docs/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -71,8 +71,8 @@ msgstr ""
 "Ušetříte však čas při stahování, protože nebude spuštěn konvertor."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Výchozí: vypnuto"
 
@@ -107,7 +107,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Oříznutí miniatur zvuku"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Dostupné pouze při povoleném vložení metadat."
 
@@ -122,11 +122,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Pokud je tato funkce povolena, aplikace Parabolic označí média informacemi o "
+"kapitolách, pokud jsou dostupné"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Vkládání kapitol"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/de.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-26 16:10+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -332,10 +332,11 @@ msgstr "Untertitelsprachen"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Eine durch Kommata getrennte Liste von Sprachcodes mit zwei oder drei "
 "Buchstaben. Die Liste wird bei der Sprachauswahl der herunterzuladenden "
@@ -344,11 +345,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Manche Webseiten verwenden Sprachcodes mit zwei Buchstaben, andere mit drei "
 "Buchstaben. Beispielsweise werden <code>en</code> und <code>eng</code> beide "
@@ -357,9 +360,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "Standardeinstellung: Der zweistellige und dreistellige Sprachcode deiner "
 "Kultur. Auf einem US-amerkanischen System wäre das beispielsweise <code>en,"

--- a/NickvisionTubeConverter.Shared/Docs/po/de.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-26 16:10+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -73,8 +73,8 @@ msgstr ""
 "nicht ausgeführt wird."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Standardeinstellung: Aus"
 
@@ -111,7 +111,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Audio-Vorschau Zuschneiden"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Nur verfügbar wenn \"Metadaten einbetten\" aktiviert ist."
 
@@ -126,11 +126,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Wenn diese Option aktiviert ist, markiert Parabolic Medien mit "
+"Kapitelinformationen, falls vorhanden."
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Kapitel Einbetten"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/el.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/el.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/el.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/el.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/es.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -73,8 +73,8 @@ msgstr ""
 "ejecutará el conversor."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Predeterminado: Apagado"
 
@@ -110,7 +110,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Recortar miniaturas de audio"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Sólo disponible si está activada la opción Incrustar metadatos."
 
@@ -125,11 +125,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Si está activada, Parabolic etiquetará un medio con la información del "
+"capítulo si está disponible"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Incrustar capítulos"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/es.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -330,10 +330,11 @@ msgstr "Idiomas de los subtítulos"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Una lista separada por comas de códigos de idioma de dos y tres letras para "
 "usar al seleccionar los idiomas de los subtítulos que se van a descargar. "
@@ -342,11 +343,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Algunos sitios usan códigos lingüísticos de dos letras, mientras que otros "
 "usan de tres. Por ejemplo, <code>en</code> y <code>eng</code> se usan ambos "
@@ -355,9 +358,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "Predeterminado: el código lingüístico de dos y tres letras de su cultura. "
 "Por ejemplo, en un sistema en-US el valor predeterminado sería <code>en,eng</"

--- a/NickvisionTubeConverter.Shared/Docs/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 20:09+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 20:09+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Upota kappaleet"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -73,8 +73,8 @@ msgstr ""
 "téléchargement puisque aucune opération de conversion n’aura lieu."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Par défaut : Désactivée"
 
@@ -111,7 +111,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Rogner les vignettes des fichiers audio"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Uniquement disponible si l’inclusion des métadonnées est activée."
 
@@ -127,11 +127,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Si cette option est activée, Parabole inclura dans un média les informations "
+"relatives à ses chapitres, si disponibles"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Inclure les chapitres"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -336,10 +336,11 @@ msgstr "Langues des sous-titres"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Une liste de codes de langages de deux ou trois lettres, séparés par une "
 "virgule, à utiliser pour sélectionner les langages des sous-titres à "
@@ -348,11 +349,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Certains sites utilisent des abréviations de langages à deux lettres, alors "
 "que d’autres utilisent trois lettres. Par exemple, <code>en</code> et "
@@ -362,9 +365,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "Par défaut : les codes à deux et trois lettres de votre langue locale. Par "
 "exemple, <code>en,eng</code> sur un système en-US"

--- a/NickvisionTubeConverter.Shared/Docs/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/gl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 20:09+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/gl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 20:09+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/he.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/he.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -288,25 +288,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/he.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/he.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -66,8 +66,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "חיתוך תמונה ממוזערה לשמע"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -113,11 +113,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "הטמעת פרקים"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/hi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/hi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/hu.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-07 00:46+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Borítókép javítása"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Fejezetek beágyazása"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/hu.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-07 00:46+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -289,25 +289,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/id.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/id.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/id.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/id.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/it.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-09-10 21:21+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -72,8 +72,8 @@ msgstr ""
 "convertitore non verrà eseguito."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Predefinito: Disattivato"
 
@@ -109,7 +109,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Ritaglia miniature audio"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Disponibile solo se Incorpora metadati è abilitato."
 
@@ -124,11 +124,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Se abilitato, Parabolic taggherà un supporto con le informazioni sul "
+"capitolo, se disponibili"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Includi i capitoli"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/it.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-09-10 21:21+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -322,10 +322,11 @@ msgstr "Lingue dei Sottotitoli"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Una lista con campi separati da virgola di codici di lingua composti da due "
 "e tre caratteri da usare per selezionare le lingue dei sottotitoli da "
@@ -334,11 +335,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Alcuni siti utilizzano codici di lingua da due caratteri, mentre altri usano "
 "tre caratteri. Per esempio, <code>en</code> e <code>eng</code> sono usati "
@@ -348,8 +351,8 @@ msgstr ""
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -71,8 +71,8 @@ msgstr ""
 "ます。しかしコンバーターは実行されないため、ダウンロード時間を短縮できます。"
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "デフォルト: オフ"
 
@@ -107,7 +107,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "オーディオサムネイルを整形"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "メタデータを埋め込む設定が有効な時のみ利用可能です。"
 
@@ -122,11 +122,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"有効であれば、Parabolic はメディアにチャプター（章）を利用可能であれば埋め込"
+"みます"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "チャプター（章）を埋め込む"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -316,25 +316,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/nb_NO.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/nb_NO.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr "Ondertitel­talen"
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Standaard: Uit"
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Audio-miniaturen bijsnijden"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Hoofdstukken invoegen"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Docs/po/parabolic.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,7 +62,8 @@ msgstr ""
 #. (itstool) path: note/p
 #: yelp/C/converter.page:29
 #: yelp/C/converter.page:45
-#: yelp/C/converter.page:52
+#: yelp/C/converter.page:54
+#: yelp/C/converter.page:61
 #: yelp/C/downloader.page:51
 #: yelp/C/downloader.page:77
 msgid "Default: Off"
@@ -96,6 +97,7 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/converter.page:42
+#: yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -106,11 +108,26 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid "If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid "Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Docs/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Docs/po/parabolic.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -253,17 +253,17 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
-msgid "A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download."
+msgid "A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
-msgid "Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results."
+msgid "Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, \"en\", \"en-US\" and \"eng\" are all used for English. Please specify all valid codes for your languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
-msgid "Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code>"
+msgid "Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-04 09:58+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -327,10 +327,11 @@ msgstr "Języki napisów"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Lista oddzielonych przecinkami, dwuliterowych i trzyliterowych kodów "
 "języków, które mają zostać wybrane przy pobieraniu napisów. To ustawienie "
@@ -339,11 +340,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Strony internetowe używają zarówno dwuliterowych, jak i trzyliterowych kodów "
 "języka. Na przykład, dla języka angielskiego są to <code>en</code> i "
@@ -352,9 +355,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "Domyślnie: dwuliterowy i trzyliterowy kod języka ojczystego. Na przykład, "
 "dla systemu en-US wartością domyślną byłoby <code>en,eng</code>"

--- a/NickvisionTubeConverter.Shared/Docs/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-04 09:58+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -73,8 +73,8 @@ msgstr ""
 "czas."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "Domyślnie: wyłączone"
 
@@ -110,7 +110,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Przycinaj miniatury plików audio"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 "Dostępne wyłącznie, jeśli opcja \"Zapisuj metadane w plikach\" jest włączona."
@@ -126,11 +126,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Po włączeniu, Parabolic będzie oznaczać multimedia informacjami o "
+"rozdziałach, jeśli są dostępne"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Zapisuj rozdziały w plikach"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Cortar miniaturas para áudio"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Incorporar capítulos"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pt_PT.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/pt_PT.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -327,10 +327,11 @@ msgstr "Языки субтитров"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Список разделённых запятой двух- и трёх-символьных кодов языков для "
 "использования при скачивании субтитров. Применяется только при выборе "
@@ -338,11 +339,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Некоторые сайты используют двух-символьные языковые коды, тогда как другие "
 "используют трёх-символьные. Например, <code>ru</code> и <code>rus</code> "
@@ -351,9 +354,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "По умолчанию: Двух- и трёх-символьные коды для вашего языка. Например, на "
 "системе с локалью ru-RU будет указано <code>ru,rus</code>"

--- a/NickvisionTubeConverter.Shared/Docs/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -73,8 +73,8 @@ msgstr ""
 "Конвертера."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "По умолчанию: Выключено"
 
@@ -111,7 +111,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Обрезать миниатюры для аудио"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Доступно только если Встраивание Метаданных включено."
 
@@ -126,11 +126,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Если включено, Parabolic будет записывать данные о главах в медиа файл, если "
+"эта информация доступна"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Встраивать главы"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/sv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-03 17:56+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/sv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-03 17:56+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ta.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -71,8 +71,8 @@ msgstr ""
 "மாற்றி இயக்கப்படாமல் இருப்பதால், பதிவிறக்குவதில் நேரத்தை மிச்சப்படுத்துவீர்கள்."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "இயல்புநிலை: ஆஃப்"
 
@@ -107,7 +107,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "ஒலி அமைப்பு சிறுபடங்களை செதுக்கு"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "உட்பொதிவு மெட்டாடேட்டா இயக்கப்பட்டால் மட்டுமே கிடைக்கும்."
 
@@ -122,11 +122,32 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr "இயக்கப்பட்டால், பாரபோலிக் மீடியாவை அத்தியாயத் தகவலுடன் குறியிடும்"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "அத்தியாயங்களை உட்பொதிக்கவும்"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr "இயக்கப்பட்டால், பாரபோலிக் மீடியாவை அத்தியாயத் தகவலுடன் குறியிடும்"

--- a/NickvisionTubeConverter.Shared/Docs/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ta.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -322,10 +322,11 @@ msgstr "வசன மொழிகள்"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "பதிவிறக்கம் செய்ய வசனம் மொழிகளைத் தேர்ந்தெடுக்கும்போது பயன்படுத்த வேண்டிய இரண்டு எழுத்து "
 "மற்றும் மூன்றெழுத்து மொழிக் குறியீடுகளின் கமாவால் பிரிக்கப்பட்ட பட்டியல். பதிவிறக்கத்தில் "
@@ -333,11 +334,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "சில தளங்கள் இரண்டெழுத்து மொழிக் குறியீடுகளைப் பயன்படுத்துகின்றன, மற்றவை மூன்றெழுத்துகளைப் "
 "பயன்படுத்துகின்றன. எடுத்துக்காட்டாக, <code>en</code> மற்றும் <code>eng</code> இரண்டும் "
@@ -346,9 +349,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "இயல்புநிலை: உங்கள் கலாச்சாரத்தின் இரண்டெழுத்து மற்றும் மூன்றெழுத்து மொழிக் குறியீடு. "
 "எடுத்துக்காட்டாக, en-US கணினியில் இயல்புநிலையாக <code>en,eng</code> இருக்கும்"

--- a/NickvisionTubeConverter.Shared/Docs/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Ses Küçük Resimlerini Kırp"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Bölümleri Göm"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/uk.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -75,8 +75,8 @@ msgstr ""
 "запускатиметься."
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr "За замовчуванням: Вимк"
 
@@ -111,7 +111,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "Обрізати мініатюри аудіо"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr "Доступно, якщо ввімкнено Вбудовувати метадані."
 
@@ -126,11 +126,34 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+#, fuzzy
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+"Якщо ввімкнено, Parabolic позначатиме носій інформацією про розділ, якщо "
+"вона є"
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "Вставити розділи"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/uk.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -331,10 +331,11 @@ msgstr "Мови субтитрів"
 
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
+#, fuzzy
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 "Список розділених комами двобуквених та трибуквених мовних кодів для вибору "
 "мови субтитрів для завантаження. Застосовується лише тоді, коли під час "
@@ -342,11 +343,13 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 "Деякі сайти використовують дволітерні мовні коди, тоді як інші - трилітерні. "
 "Наприклад, <code>en</code> та <code>eng</code> використовуються для "
@@ -355,9 +358,10 @@ msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
+#, fuzzy
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 "За замовчуванням: дво- та трилітерний мовний код вашої культури. Наприклад, "
 "в англо-американській системі за замовчуванням буде <code>en,eng</code>"

--- a/NickvisionTubeConverter.Shared/Docs/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ur.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: 2023-08-04 09:58+0000\n"
 "Last-Translator: Abdur Rehman Imran <arehmanimran4@gmail.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -287,25 +287,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/ur.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: 2023-08-04 09:58+0000\n"
 "Last-Translator: Abdur Rehman Imran <arehmanimran4@gmail.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -65,8 +65,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -99,7 +99,7 @@ msgid "Crop Audio Thumbnails"
 msgstr "آڈیو تھمب نیلز کو تراشیں"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -112,11 +112,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr "ابواب کو شامل کریں"
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/vi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/vi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/zh_Hans.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-11 01:19+0300\n"
+"POT-Creation-Date: 2023-09-11 02:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -62,8 +62,8 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:52
-#: yelp/C/downloader.page:51 yelp/C/downloader.page:77
+#: yelp/C/converter.page:29 yelp/C/converter.page:45 yelp/C/converter.page:54
+#: yelp/C/converter.page:61 yelp/C/downloader.page:51 yelp/C/downloader.page:77
 msgid "Default: Off"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid "Crop Audio Thumbnails"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:42
+#: yelp/C/converter.page:42 yelp/C/converter.page:50
 msgid "Only available if Embed Metadata is enabled."
 msgstr ""
 
@@ -109,11 +109,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/converter.page:49
+msgid "Remove Source Data"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:51
+msgid ""
+"If enabled, Parabolic will clear metadata fields containing the URL and "
+"other identifying information of the media source."
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/converter.page:52
+msgid ""
+"Fields that are cleared: <code>comment</code>, <code>description</code>, "
+"<code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in "
+"each stream."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/converter.page:58
 msgid "Embed Chapters"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/converter.page:50
+#: yelp/C/converter.page:59
 msgid ""
 "If enabled, Parabolic will tag a media with chapter information if available"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Docs/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Docs/po/zh_Hans.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-09-10 03:30+0300\n"
+"POT-Creation-Date: 2023-09-11 01:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -284,25 +284,26 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/downloader.page:82
 msgid ""
-"A comma-separated list of two-letter and three-letter language codes to use "
-"when selecting languages of subtitles to download. Only applies when a valid "
-"<code>Subtitle</code> format is selected in a download."
+"A comma-separated list of two-letter, two-letter with region, and three-"
+"letter language codes to use when selecting languages of subtitles to "
+"download. Only applies when downloading a video with subtitles."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:84
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, <code>en</code> and <code>eng</code> are both used for English. "
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English. Please specify all valid codes for your "
+"languages for the best results."
 msgstr ""
 
 #. (itstool) path: note/p
 #: yelp/C/downloader.page:87
 msgid ""
-"Default: Your culture's two-letter and three-letter language code. For "
-"example, on an en-US system the default would be <code>en,eng</code>"
+"Default: Your culture's language codes. For example, on an en-US system the "
+"default would be <code>en,en-US,eng</code>"
 msgstr ""
 
 #. (itstool) path: item/title

--- a/NickvisionTubeConverter.Shared/Docs/yelp/C/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/C/converter.page
@@ -45,6 +45,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/C/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/C/downloader.page
@@ -79,12 +79,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ar/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ar/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ar/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ar/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/bn/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/bn/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/bn/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/bn/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/cs/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/cs/converter.page
@@ -48,6 +48,15 @@
 			<p>Výchozí: vypnuto</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Dostupné pouze při povoleném vložení metadat.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Výchozí: vypnuto</p>
+		</note>
+    </item>
 	<item>
 		<title>Vkládání kapitol</title>
 		<p>Pokud je tato funkce povolena, aplikace Parabolic označí média informacemi o kapitolách, pokud jsou dostupné</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/cs/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/cs/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>Jazyky titulků</title>
-        <p>Seznam dvoupísmenných a třípísmenných jazykových kódů oddělených čárkou, které se použijí při výběru jazyků titulků ke stažení. Použije se pouze v případě, že je při stahování vybrán platný formát <code>Subtitle</code>.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Některé stránky používají dvoupísmenné jazykové kódy, jiné třípísmenné. Například pro angličtinu se používá <code>en</code> i <code>eng</code>. Pro dosažení nejlepších výsledků zadejte pro své jazyky dvoupísmenné i třípísmenné kódy.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Výchozí: dvoupísmenný a třípísmenný kód tvého jazyka. Například na americkém (en-US) systému budou výchozí kódy <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/de/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/de/converter.page
@@ -42,6 +42,15 @@
 			<p>Standardeinstellung: Aus</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Nur verfügbar wenn "Metadaten einbetten" aktiviert ist.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Standardeinstellung: Aus</p>
+		</note>
+    </item>
 	<item>
 		<title>Kapitel Einbetten</title>
 		<p>Wenn diese Option aktiviert ist, markiert Parabolic Medien mit Kapitelinformationen, falls vorhanden.</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/de/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/de/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Untertitelsprachen</title>
-        <p>Eine durch Kommata getrennte Liste von Sprachcodes mit zwei oder drei Buchstaben. Die Liste wird bei der Sprachauswahl der herunterzuladenden Untertitel verwendet. Gilt nur, wenn in einem Download ein gültiges Untertitelformat ausgewählt ist.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Manche Webseiten verwenden Sprachcodes mit zwei Buchstaben, andere mit drei Buchstaben. Beispielsweise werden <code>en</code> und <code>eng</code> beide für Englisch verwendet. Um die besten Ergebnisse zu erzielen, gib bitte sowohl zweistellige als auch dreistellige Codes an.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Standardeinstellung: Der zweistellige und dreistellige Sprachcode deiner Kultur. Auf einem US-amerkanischen System wäre das beispielsweise <code>en,eng</code>.</p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/el/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/el/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/el/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/el/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/es/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/es/converter.page
@@ -48,6 +48,15 @@
 			<p>Predeterminado: Apagado</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Sólo disponible si está activada la opción Incrustar metadatos.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Predeterminado: Apagado</p>
+		</note>
+    </item>
 	<item>
 		<title>Incrustar capítulos</title>
 		<p>Si está activada, Parabolic etiquetará un medio con la información del capítulo si está disponible</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/es/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/es/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>Idiomas de los subtítulos</title>
-        <p>Una lista separada por comas de códigos de idioma de dos y tres letras para usar al seleccionar los idiomas de los subtítulos que se van a descargar. Sólo se aplica cuando se selecciona un formato <code>Subtítulo</code> válido en una descarga.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Algunos sitios usan códigos lingüísticos de dos letras, mientras que otros usan de tres. Por ejemplo, <code>en</code> y <code>eng</code> se usan ambos para el inglés. Especifique los códigos de dos y tres letras de sus idiomas para obtener los mejores resultados.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Predeterminado: el código lingüístico de dos y tres letras de su cultura. Por ejemplo, en un sistema en-US el valor predeterminado sería <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/fi/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/fi/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Upota kappaleet</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/fi/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/fi/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/fr/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/fr/converter.page
@@ -42,6 +42,15 @@
 			<p>Par défaut : Désactivée</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Uniquement disponible si l’inclusion des métadonnées est activée.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Par défaut : Désactivée</p>
+		</note>
+    </item>
 	<item>
 		<title>Inclure les chapitres</title>
 		<p>Si cette option est activée, Parabole inclura dans un média les informations relatives à ses chapitres, si disponibles</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/fr/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/fr/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Langues des sous-titres</title>
-        <p>Une liste de codes de langages de deux ou trois lettres, séparés par une virgule, à utiliser pour sélectionner les langages des sous-titres à télécharger. S’applique uniquement lorsqu’un format de <code>sous-titres</code> valide est sélectionné dans un téléchargement.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Certains sites utilisent des abréviations de langages à deux lettres, alors que d’autres utilisent trois lettres. Par exemple, <code>en</code> et <code>eng</code> sont tous les deux utilisés pour l’anglais. Spécifiez les abréviations pour vos langages avec 2 et 3 lettres pour avoir de meilleurs résultats.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Par défaut : les codes à deux et trois lettres de votre langue locale. Par exemple, <code>en,eng</code> sur un système en-US</p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/gl/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/gl/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/gl/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/gl/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/he/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/he/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>הטמעת פרקים</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/he/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/he/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/hi/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/hi/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/hi/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/hi/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/hu/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/hu/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Fejezetek beágyazása</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/hu/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/hu/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/id/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/id/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/id/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/id/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/it/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/it/converter.page
@@ -42,6 +42,15 @@
 			<p>Predefinito: Disattivato</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Disponibile solo se Incorpora metadati è abilitato.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Predefinito: Disattivato</p>
+		</note>
+    </item>
 	<item>
 		<title>Includi i capitoli</title>
 		<p>Se abilitato, Parabolic taggherà un supporto con le informazioni sul capitolo, se disponibili</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/it/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/it/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Lingue dei Sottotitoli</title>
-        <p>Una lista con campi separati da virgola di codici di lingua composti da due e tre caratteri da usare per selezionare le lingue dei sottotitoli da scaricare. È applicabile solo quando viene selezionato un formato valido <code>Subtitle</code> in un download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Alcuni siti utilizzano codici di lingua da due caratteri, mentre altri usano tre caratteri. Per esempio, <code>en</code> e <code>eng</code> sono usati entrambi per la lingua inglese. Per ottenere risultati migliori, si prega di inserire codici da due e tre caratteri per le lingue scelte.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ja/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ja/converter.page
@@ -48,6 +48,15 @@
 			<p>デフォルト: オフ</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>メタデータを埋め込む設定が有効な時のみ利用可能です。</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>デフォルト: オフ</p>
+		</note>
+    </item>
 	<item>
 		<title>チャプター（章）を埋め込む</title>
 		<p>有効であれば、Parabolic はメディアにチャプター（章）を利用可能であれば埋め込みます</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ja/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ja/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/nb_NO/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/nb_NO/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/nb_NO/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/nb_NO/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/nl/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/nl/converter.page
@@ -42,6 +42,15 @@
 			<p>Standaard: Uit</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Standaard: Uit</p>
+		</note>
+    </item>
 	<item>
 		<title>Hoofdstukken invoegen</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/nl/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/nl/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Ondertitel­talen</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pl/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pl/converter.page
@@ -48,6 +48,15 @@
 			<p>Domyślnie: wyłączone</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Dostępne wyłącznie, jeśli opcja "Zapisuj metadane w plikach" jest włączona.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Domyślnie: wyłączone</p>
+		</note>
+    </item>
 	<item>
 		<title>Zapisuj rozdziały w plikach</title>
 		<p>Po włączeniu, Parabolic będzie oznaczać multimedia informacjami o rozdziałach, jeśli są dostępne</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pl/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pl/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>Języki napisów</title>
-        <p>Lista oddzielonych przecinkami, dwuliterowych i trzyliterowych kodów języków, które mają zostać wybrane przy pobieraniu napisów. To ustawienie zadziała, jeśli poprawny format <code>napisów</code> zostanie wybrany przy pobieraniu.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Strony internetowe używają zarówno dwuliterowych, jak i trzyliterowych kodów języka. Na przykład, dla języka angielskiego są to <code>en</code> i <code>eng</code>. Aby uzyskać najlepsze wyniki, należy podać zarówno dwuliterowe, jak i trzyliterowe kody wybranych języków.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Domyślnie: dwuliterowy i trzyliterowy kod języka ojczystego. Na przykład, dla systemu en-US wartością domyślną byłoby <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pt_BR/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pt_BR/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Incorporar capítulos</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pt_BR/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pt_BR/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pt_PT/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pt_PT/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/pt_PT/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/pt_PT/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ru/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ru/converter.page
@@ -48,6 +48,15 @@
 			<p>По умолчанию: Выключено</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Доступно только если Встраивание Метаданных включено.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>По умолчанию: Выключено</p>
+		</note>
+    </item>
 	<item>
 		<title>Встраивать главы</title>
 		<p>Если включено, Parabolic будет записывать данные о главах в медиа файл, если эта информация доступна</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ru/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ru/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>Языки субтитров</title>
-        <p>Список разделённых запятой двух- и трёх-символьных кодов языков для использования при скачивании субтитров. Применяется только при выборе формата <code>Субтитров</code> при добавлении загрузки.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Некоторые сайты используют двух-символьные языковые коды, тогда как другие используют трёх-символьные. Например, <code>ru</code> и <code>rus</code> используются для русского языка. Пожалуйста. указывайте оба варианта для необходимых языков, для достижения наилучших результатов.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>По умолчанию: Двух- и трёх-символьные коды для вашего языка. Например, на системе с локалью ru-RU будет указано <code>ru,rus</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/sv/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/sv/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/sv/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/sv/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ta/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ta/converter.page
@@ -48,6 +48,15 @@
 			<p>இயல்புநிலை: ஆஃப்</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>உட்பொதிவு மெட்டாடேட்டா இயக்கப்பட்டால் மட்டுமே கிடைக்கும்.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>இயல்புநிலை: ஆஃப்</p>
+		</note>
+    </item>
 	<item>
 		<title>அத்தியாயங்களை உட்பொதிக்கவும்</title>
 		<p>இயக்கப்பட்டால், பாரபோலிக் மீடியாவை அத்தியாயத் தகவலுடன் குறியிடும்</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ta/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ta/downloader.page
@@ -82,12 +82,12 @@
     </item>
     <item>
         <title>வசன மொழிகள்</title>
-        <p>பதிவிறக்கம் செய்ய வசனம் மொழிகளைத் தேர்ந்தெடுக்கும்போது பயன்படுத்த வேண்டிய இரண்டு எழுத்து மற்றும் மூன்றெழுத்து மொழிக் குறியீடுகளின் கமாவால் பிரிக்கப்பட்ட பட்டியல். பதிவிறக்கத்தில் சரியான <code>Subtitle</code> வடிவம் தேர்ந்தெடுக்கப்பட்டால் மட்டுமே பொருந்தும்.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>சில தளங்கள் இரண்டெழுத்து மொழிக் குறியீடுகளைப் பயன்படுத்துகின்றன, மற்றவை மூன்றெழுத்துகளைப் பயன்படுத்துகின்றன. எடுத்துக்காட்டாக, <code>en</code> மற்றும் <code>eng</code> இரண்டும் ஆங்கிலத்திற்குப் பயன்படுத்தப்படுகின்றன. சிறந்த முடிவுகளுக்கு உங்கள் மொழிகளுக்கான இரண்டு எழுத்து மற்றும் மூன்றெழுத்து குறியீடுகள் இரண்டையும் குறிப்பிடவும்.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>இயல்புநிலை: உங்கள் கலாச்சாரத்தின் இரண்டெழுத்து மற்றும் மூன்றெழுத்து மொழிக் குறியீடு. எடுத்துக்காட்டாக, en-US கணினியில் இயல்புநிலையாக <code>en,eng</code> இருக்கும்</p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/tr/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/tr/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Bölümleri Göm</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/tr/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/tr/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/uk/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/uk/converter.page
@@ -42,6 +42,15 @@
 			<p>За замовчуванням: Вимк</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Доступно, якщо ввімкнено Вбудовувати метадані.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>За замовчуванням: Вимк</p>
+		</note>
+    </item>
 	<item>
 		<title>Вставити розділи</title>
 		<p>Якщо ввімкнено, Parabolic позначатиме носій інформацією про розділ, якщо вона є</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/uk/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/uk/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Мови субтитрів</title>
-        <p>Список розділених комами двобуквених та трибуквених мовних кодів для вибору мови субтитрів для завантаження. Застосовується лише тоді, коли під час завантаження вибрано правильний формат <code>Субтитрів</code>.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Деякі сайти використовують дволітерні мовні коди, тоді як інші - трилітерні. Наприклад, <code>en</code> та <code>eng</code> використовуються для англійської мови. Будь ласка, вказуйте як двобуквені, так і трибуквені коди для ваших мов, щоб отримати найкращі результати.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>За замовчуванням: дво- та трилітерний мовний код вашої культури. Наприклад, в англо-американській системі за замовчуванням буде <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ur/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ur/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>ابواب کو شامل کریں</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/ur/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/ur/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/vi/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/vi/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/vi/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/vi/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/zh_Hans/converter.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/zh_Hans/converter.page
@@ -42,6 +42,15 @@
 			<p>Default: Off</p>
 		</note>
     </item>
+    <item>
+		<title>Remove Source Data</title>
+		<p>Only available if Embed Metadata is enabled.</p>
+		<p>If enabled, Parabolic will clear metadata fields containing the URL and other identifying information of the media source.</p>
+        <p>Fields that are cleared: <code>comment</code>, <code>description</code>, <code>synopsis</code>, <code>purl</code> and <code>handler_name</code> in each stream.</p>
+		<note style="advanced">
+			<p>Default: Off</p>
+		</note>
+    </item>
 	<item>
 		<title>Embed Chapters</title>
 		<p>If enabled, Parabolic will tag a media with chapter information if available</p>

--- a/NickvisionTubeConverter.Shared/Docs/yelp/zh_Hans/downloader.page
+++ b/NickvisionTubeConverter.Shared/Docs/yelp/zh_Hans/downloader.page
@@ -76,12 +76,12 @@
     </item>
     <item>
         <title>Subtitles Languages</title>
-        <p>A comma-separated list of two-letter and three-letter language codes to use when selecting languages of subtitles to download. Only applies when a valid <code>Subtitle</code> format is selected in a download.</p>
+        <p>A comma-separated list of two-letter, two-letter with region, and three-letter language codes to use when selecting languages of subtitles to download. Only applies when downloading a video with subtitles.</p>
         <note>
-            <p>Some sites use two-letter language codes, whereas others use three-letter. For example, <code>en</code> and <code>eng</code> are both used for English. Please specify both two-letter and three-letter codes for your languages for the best results.</p>
+            <p>Different sites can use different language code formats for the same language. You may encounter one of the following three types: two-letter, two-letter with region, or three-letter. For example, "en", "en-US" and "eng" are all used for English. Please specify all valid codes for your languages for the best results.</p>
         </note>
 		<note style="advanced">
-			<p>Default: Your culture's two-letter and three-letter language code. For example, on an en-US system the default would be <code>en,eng</code></p>
+			<p>Default: Your culture's language codes. For example, on an en-US system the default would be <code>en,en-US,eng</code></p>
 		</note>
     </item>
     <item>

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -90,7 +90,7 @@ public class Configuration : ConfigurationBase
     /// </summary>
     public bool CropAudioThumbnails { get; set; }
     /// <summary>
-    /// Whether ot not to remove data about media source from metadata
+    /// Whether or not to remove data about media source from metadata
     /// </summary>
     /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
     public bool RemoveSourceData { get; set; }

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -111,6 +111,10 @@ public class Configuration : ConfigurationBase
     /// </summary>
     public string PreviousVideoResolution { get; set; }
     /// <summary>
+    /// The previously used subtitle downloading state
+    /// </summary>
+    public bool PreviousSubtitleState { get; set; }
+    /// <summary>
     /// Whether or not to number titles
     /// </summary>
     public bool NumberTitles { get; set; }
@@ -143,6 +147,7 @@ public class Configuration : ConfigurationBase
         PreviousSaveFolder = "";
         PreviousMediaFileType = MediaFileType.MP4;
         PreviousVideoResolution = "";
+        PreviousSubtitleState = false;
         NumberTitles = false;
     }
 

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -136,7 +136,7 @@ public class Configuration : ConfigurationBase
         AriaMaxConnectionsPerServer = 16;
         AriaMinSplitSize = 20;
         YouTubeSponsorBlock = false;
-        SubtitleLangs = $"{CultureInfo.CurrentCulture.TwoLetterISOLanguageName},{CultureInfo.CurrentCulture.ThreeLetterISOLanguageName}";
+        SubtitleLangs = $"{CultureInfo.CurrentCulture.TwoLetterISOLanguageName},{CultureInfo.CurrentCulture.Name},{CultureInfo.CurrentCulture.ThreeLetterISOLanguageName}";
         ProxyUrl = "";
         CookiesPath = "";
         DisallowConversions = false;

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -90,6 +90,11 @@ public class Configuration : ConfigurationBase
     /// </summary>
     public bool CropAudioThumbnails { get; set; }
     /// <summary>
+    /// Whether ot not to remove data about media source from metadata
+    /// </summary>
+    /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
+    public bool RemoveSourceData { get; set; }
+    /// <summary>
     /// Whether or not to embed chapters in a download
     /// </summary>
     public bool EmbedChapters { get; set; }
@@ -133,6 +138,7 @@ public class Configuration : ConfigurationBase
         DisallowConversions = false;
         EmbedMetadata = true;
         CropAudioThumbnails = false;
+        RemoveSourceData = false;
         EmbedChapters = false;
         PreviousSaveFolder = "";
         PreviousMediaFileType = MediaFileType.MP4;

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -26,7 +26,7 @@ public enum Quality
 /// </summary>
 public class Download
 {
-    private static string[] _youtubeLangCodes = { "af", "az", "id", "ms", "bs", "ca", "cs", "da", "de", "et", "en-IN", "en-GB", "en", "es", "es-419", "es-US", "eu", "fil", "fr", "fr-CA", "gl", "hr", "zu", "is", "it", "sw", "lv", "lt", "hu", "nl", "no", "uz", "pl", "pt-PT", "pt", "ro", "sq", "sk", "sl", "sr-Latn", "fi", "sv", "vi", "tr", "be", "bg", "ky", "kk", "mk", "mn", "ru", "sr", "uk", "el", "hy", "iw", "ur", "ar", "fa", "ne", "mr", "hi", "as", "bn", "pa", "gu", "or", "ta", "te", "kn", "ml", "si", "th", "lo", "my", "ka", "am", "km", "zh-CN", "zh-TW", "zh-HK", "ja", "ko" };
+    internal static string[] YoutubeLangCodes = { "af", "az", "id", "ms", "bs", "ca", "cs", "da", "de", "et", "en-IN", "en-GB", "en", "es", "es-419", "es-US", "eu", "fil", "fr", "fr-CA", "gl", "hr", "zu", "is", "it", "sw", "lv", "lt", "hu", "nl", "no", "uz", "pl", "pt-PT", "pt", "ro", "sq", "sk", "sl", "sr-Latn", "fi", "sv", "vi", "tr", "be", "bg", "ky", "kk", "mk", "mn", "ru", "sr", "uk", "el", "hy", "iw", "ur", "ar", "fa", "ne", "mr", "hi", "as", "bn", "pa", "gu", "or", "ta", "te", "kn", "ml", "si", "th", "lo", "my", "ka", "am", "km", "zh-CN", "zh-TW", "zh-HK", "ja", "ko" };
 
     private readonly string _tempDownloadPath;
     private readonly string _logPath;
@@ -205,11 +205,11 @@ public class Download
                     { "noprogress", true }
                 };
                 string? lang = null;
-                if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.Name))
+                if (YoutubeLangCodes.Contains(CultureInfo.CurrentCulture.Name))
                 {
                     lang = CultureInfo.CurrentCulture.Name;
                 }
-                else if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
+                else if (YoutubeLangCodes.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
                 {
                     lang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
                 }

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -22,16 +22,6 @@ public enum Quality
 }
 
 /// <summary>
-/// Subtitle types for a download
-/// </summary>
-public enum Subtitle
-{
-    None = 0,
-    VTT,
-    SRT
-}
-
-/// <summary>
 /// A model of a media download
 /// </summary>
 public class Download
@@ -75,9 +65,9 @@ public class Download
     /// </summary>
     public VideoResolution? Resolution { get; init; }
     /// <summary>
-    /// The subtitles for the download
+    /// Whether ot not to download the subtitles
     /// </summary>
-    public Subtitle Subtitle { get; init; }
+    public bool Subtitle { get; init; }
     /// <summary>
     /// The audio language code
     /// </summary>
@@ -120,7 +110,7 @@ public class Download
     /// <param name="quality">The quality of the download</param>
     /// <param name="resolution">The video resolution if available</param>
     /// <param name="audioLanguage">The audio language code</param>
-    /// <param name="subtitle">The subtitles for the download</param>
+    /// <param name="subtitle">Whether or not to download the subtitles</param>
     /// <param name="saveFolder">The folder to save the download to</param>
     /// <param name="saveFilename">The filename to save the download as</param>
     /// <param name="limitSpeed">Whether or not to limit the download speed</param>
@@ -132,7 +122,7 @@ public class Download
     /// <param name="username">A username for the website (if available)</param>
     /// <param name="password">A password for the website (if available)</param>
     /// <exception cref="ArgumentException">Thrown if timeframe is specified and limitSpeed is enabled</exception>
-    public Download(string mediaUrl, MediaFileType fileType, Quality quality, VideoResolution? resolution, string? audioLanguage, Subtitle subtitle, string saveFolder, string saveFilename, bool limitSpeed, uint speedLimit, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, uint playlistPosition, string? username, string? password)
+    public Download(string mediaUrl, MediaFileType fileType, Quality quality, VideoResolution? resolution, string? audioLanguage, bool subtitle, string saveFolder, string saveFilename, bool limitSpeed, uint speedLimit, bool splitChapters, bool cropThumbnail, Timeframe? timeframe, uint playlistPosition, string? username, string? password)
     {
         Id = Guid.NewGuid();
         MediaUrl = mediaUrl;
@@ -282,17 +272,17 @@ public class Download
                     {
                         postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "FFmpegVideoConvertor" }, { "preferedformat", FileType.ToString().ToLower() } });
                     }
-                    if (Subtitle != Subtitle.None)
+                    if (Subtitle)
                     {
                         var subtitleLangs = options.SubtitleLangs;
-                        if(subtitleLangs[subtitleLangs.Length - 1] == ',')
+                        if(subtitleLangs[^1] == ',')
                         {
                             subtitleLangs = subtitleLangs.Remove(subtitleLangs.Length - 1);
                         }
                         _ytOpt.Add("writesubtitles", true);
                         _ytOpt.Add("writeautomaticsub", true);
                         _ytOpt.Add("subtitleslangs", subtitleLangs.Split(",").Select(x => x.Trim()).ToList());
-                        postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "FFmpegSubtitlesConvertor" }, { "format", Subtitle.ToString().ToLower() } });
+                        postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "FFmpegSubtitlesConvertor" }, { "format", FileType == MediaFileType.MP4 ? "srt" : "vtt" } });
                         postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "FFmpegEmbedSubtitle" } });
                     }
                 }

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -67,7 +67,7 @@ public class Download
     /// </summary>
     public VideoResolution? Resolution { get; init; }
     /// <summary>
-    /// Whether ot not to download the subtitles
+    /// Whether or not to download the subtitles
     /// </summary>
     public bool Subtitle { get; init; }
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Models/DownloadOptions.cs
+++ b/NickvisionTubeConverter.Shared/Models/DownloadOptions.cs
@@ -42,6 +42,11 @@ public class DownloadOptions
     /// </summary>
     public bool EmbedMetadata { get; init; }
     /// <summary>
+    /// Whether ot not to remove data about media source from metadata
+    /// </summary>
+    /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
+    public bool RemoveSourceData { get; init; }
+    /// <summary>
     /// Whether or not to embed chapters in the downloaded file
     /// </summary>
     public bool EmbedChapters { get; init; }
@@ -58,8 +63,9 @@ public class DownloadOptions
     /// <param name="proxyUrl">The url of the proxy server to use</param>
     /// <param name="cookiesPath">The path to the cookies file to use for yt-dlp</param>
     /// <param name="embedMetadata">Whether or not to embed media metadata in the downloaded file</param>
+    /// <param name="removeSourceData">Whether ot not to remove data about media source from metadata</param>
     /// <param name="embedChapters">Whether or not to embed chapters in the downloaded file</param>
-    public DownloadOptions(bool overwriteExistingFiles, bool useAria, int ariaMaxConnectionsPerServer, int ariaMinSplitSize, bool youTubeSponsorBlock, string subtitleLangs, string proxyUrl, string cookiesPath, bool embedMetadata, bool embedChapters)
+    public DownloadOptions(bool overwriteExistingFiles, bool useAria, int ariaMaxConnectionsPerServer, int ariaMinSplitSize, bool youTubeSponsorBlock, string subtitleLangs, string proxyUrl, string cookiesPath, bool embedMetadata, bool removeSourceData, bool embedChapters)
     {
         OverwriteExistingFiles = overwriteExistingFiles;
         UseAria = useAria;
@@ -70,6 +76,7 @@ public class DownloadOptions
         ProxyUrl = proxyUrl;
         CookiesPath = cookiesPath;
         EmbedMetadata = embedMetadata;
+        RemoveSourceData = removeSourceData;
         EmbedChapters = embedChapters;
     }
 }

--- a/NickvisionTubeConverter.Shared/Models/DownloadOptions.cs
+++ b/NickvisionTubeConverter.Shared/Models/DownloadOptions.cs
@@ -42,7 +42,7 @@ public class DownloadOptions
     /// </summary>
     public bool EmbedMetadata { get; init; }
     /// <summary>
-    /// Whether ot not to remove data about media source from metadata
+    /// Whether or not to remove data about media source from metadata
     /// </summary>
     /// <remarks>This includes comment, description, synopsis and purl fields</remarks>
     public bool RemoveSourceData { get; init; }
@@ -63,7 +63,7 @@ public class DownloadOptions
     /// <param name="proxyUrl">The url of the proxy server to use</param>
     /// <param name="cookiesPath">The path to the cookies file to use for yt-dlp</param>
     /// <param name="embedMetadata">Whether or not to embed media metadata in the downloaded file</param>
-    /// <param name="removeSourceData">Whether ot not to remove data about media source from metadata</param>
+    /// <param name="removeSourceData">Whether or not to remove data about media source from metadata</param>
     /// <param name="embedChapters">Whether or not to embed chapters in the downloaded file</param>
     public DownloadOptions(bool overwriteExistingFiles, bool useAria, int ariaMaxConnectionsPerServer, int ariaMinSplitSize, bool youTubeSponsorBlock, string subtitleLangs, string proxyUrl, string cookiesPath, bool embedMetadata, bool removeSourceData, bool embedChapters)
     {

--- a/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
@@ -15,7 +15,6 @@ namespace NickvisionTubeConverter.Shared.Models;
 /// </summary>
 public class MediaUrlInfo
 {
-    private static string[] _youtubeLangCodes = { "af", "az", "id", "ms", "bs", "ca", "cs", "da", "de", "et", "en-IN", "en-GB", "en", "es", "es-419", "es-US", "eu", "fil", "fr", "fr-CA", "gl", "hr", "zu", "is", "it", "sw", "lv", "lt", "hu", "nl", "no", "uz", "pl", "pt-PT", "pt", "ro", "sq", "sk", "sl", "sr-Latn", "fi", "sv", "vi", "tr", "be", "bg", "ky", "kk", "mk", "mn", "ru", "sr", "uk", "el", "hy", "iw", "ur", "ar", "fa", "ne", "mr", "hi", "as", "bn", "pa", "gu", "or", "ta", "te", "kn", "ml", "si", "th", "lo", "my", "ka", "am", "km", "zh-CN", "zh-TW", "zh-HK", "ja", "ko" };
     private bool _tryVideo;
 
     /// <summary>
@@ -76,11 +75,11 @@ public class MediaUrlInfo
                         { "extract_flat", "in_playlist" }
                     };
                     string? lang = null;
-                    if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.Name))
+                    if (Download.YoutubeLangCodes.Contains(CultureInfo.CurrentCulture.Name))
                     {
                         lang = CultureInfo.CurrentCulture.Name;
                     }
-                    else if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
+                    else if (Download.YoutubeLangCodes.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
                     {
                         lang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
                     }

--- a/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/MediaUrlInfo.cs
@@ -2,7 +2,9 @@
 using Python.Runtime;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -13,6 +15,7 @@ namespace NickvisionTubeConverter.Shared.Models;
 /// </summary>
 public class MediaUrlInfo
 {
+    private static string[] _youtubeLangCodes = { "af", "az", "id", "ms", "bs", "ca", "cs", "da", "de", "et", "en-IN", "en-GB", "en", "es", "es-419", "es-US", "eu", "fil", "fr", "fr-CA", "gl", "hr", "zu", "is", "it", "sw", "lv", "lt", "hu", "nl", "no", "uz", "pl", "pt-PT", "pt", "ro", "sq", "sk", "sl", "sr-Latn", "fi", "sv", "vi", "tr", "be", "bg", "ky", "kk", "mk", "mn", "ru", "sr", "uk", "el", "hy", "iw", "ur", "ar", "fa", "ne", "mr", "hi", "as", "bn", "pa", "gu", "or", "ta", "te", "kn", "ml", "si", "th", "lo", "my", "ka", "am", "km", "zh-CN", "zh-TW", "zh-HK", "ja", "ko" };
     private bool _tryVideo;
 
     /// <summary>
@@ -72,6 +75,25 @@ public class MediaUrlInfo
                         { "ignoreerrors", true },
                         { "extract_flat", "in_playlist" }
                     };
+                    string? lang = null;
+                    if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.Name))
+                    {
+                        lang = CultureInfo.CurrentCulture.Name;
+                    }
+                    else if (_youtubeLangCodes.Contains(CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
+                    {
+                        lang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+                    }
+                    if (!string.IsNullOrEmpty(lang))
+                    {
+                        var youtubeLang = new PyList();
+                        youtubeLang.Append(new PyString(lang));
+                        var youtubeExtractorOpt = new PyDict();
+                        youtubeExtractorOpt["lang"] = youtubeLang;
+                        var extractorArgs = new PyDict();
+                        extractorArgs["youtube"] = youtubeExtractorOpt;
+                        ytOpt.Add("extractor_args", extractorArgs);
+                    }
                     if (!string.IsNullOrEmpty(proxyUrl))
                     {
                         ytOpt.Add("proxy", new PyString(proxyUrl));

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-09-06 17:07+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -30,7 +30,7 @@ msgstr "انتهى تنزيل «{0}»."
 msgid "\"{0}\" has finished with an error!"
 msgstr "انتهى «{0}» بخطأ!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(يُضبط في التفضيلات)"
 
@@ -44,7 +44,7 @@ msgstr "{0:f1} بايت\\ث"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} جيجابايت\\ث"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -66,8 +66,8 @@ msgstr[3] "{0} تنزيلات — {1:f1}% ({2})"
 msgstr[4] "{0} تنزيلًا — {1:f1}% ({2})"
 msgstr[5] "{0} تنزيل — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -78,15 +78,15 @@ msgstr[3] "{0} عناصر من أصل {1}"
 msgstr[4] "{0} عنصرًا من أصل {1}"
 msgstr[5] "{0} عنصر من أصل {1}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "أضف تنزيلًا"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "خيارات متقدمة"
 
@@ -94,12 +94,12 @@ msgstr "خيارات متقدمة"
 msgid "All downloads have finished."
 msgstr "انتهت كل التنزيلات."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "صوت"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "الأفضل"
 
@@ -123,7 +123,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "الافتراضي"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
@@ -143,11 +143,11 @@ msgstr "انتهى التنزيل بخطأ"
 msgid "Download log was copied to clipboard."
 msgstr "نُسخ سجل التنزيل إلى الحافظة."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "بدأ التنزيل باستخدام آريا٢"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "بدأ التنزيل باستخدام ffmpeg"
 
@@ -171,16 +171,16 @@ msgstr "ينزَّل {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "انتهت التنزيلات"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "وقت النهاية"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "وقت الانتهاء (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "تأكد من بيانات اعتمادك."
 
@@ -188,12 +188,12 @@ msgstr "تأكد من بيانات اعتمادك."
 msgid "Error"
 msgstr "خطأ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "تعذَّر تعطيل حلقة المفاتيح."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "يوجد الملفُّ بالفعل ولا يسمح بالكتابة فوقه"
 
@@ -209,13 +209,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "مستودع جت‌هب"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "حلقة مفاتيح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "حلقة مفاتيح مقفلة"
 
@@ -223,8 +223,8 @@ msgstr "حلقة مفاتيح مقفلة"
 msgid "List of supported sites"
 msgstr "قائمة المواقع المدعومة"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "لُج"
 
@@ -232,25 +232,25 @@ msgstr "لُج"
 msgid "Matrix Chat"
 msgstr "دردشة ماتركس"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "أقصى جودة"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "رابط الوسائط"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "رابط الوسائط (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "اسم"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "الاسم (فارغ)"
 
@@ -260,8 +260,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "لا"
 
@@ -279,14 +279,14 @@ msgstr "لا يوجد ما ينزَّل الآن"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "كلمة السر"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "كلمة السر (فارغة)"
 
@@ -294,7 +294,7 @@ msgstr "كلمة السر (فارغة)"
 msgid "Play"
 msgstr "شغِّل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "قائمة التشغيل"
 
@@ -306,34 +306,34 @@ msgstr "يجهِّز..."
 msgid "Processing..."
 msgstr "يعالج..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "صفِّر"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "أأصفِّر حلقة المفاتيح؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "أعد تشغيل التطبيق لفتح حلقة المفاتيح."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "موقع الحفظ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "مجلد الحفظ (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "حدِّد ملف تعريف الارتباط"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "اختر مجلد الحفظ"
 
@@ -349,12 +349,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "انتهت بعض التنزيلات بخطأ!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "وقت البَدْء"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "وقت البدء (غير صالح)"
 
@@ -362,12 +362,12 @@ msgstr "وقت البدء (غير صالح)"
 msgid "Stopped"
 msgstr "أوقف"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "لغات الترجمة (مفصولة بفاصلة)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "لغات الترجمة (غير صالح)"
 
@@ -385,11 +385,11 @@ msgstr ""
 "البرنامَج تنتهك قوانين حقوق النشر المحلية أو قانون الألفية للملكية الرقمية "
 "(DMCA). يستخدم المستخدمون هذا التطبيق على مسؤوليتهم الخاصة."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "هذه الخطوة لا رجوع فيها. هل أنت متأكد أنك تريد حذفه؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -401,11 +401,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "علي الجشي <ahj696@hotmail.com>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "تعذَّر تعطيل حلقة المفاتيح."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "تعذَّر تصفير حلقة المفاتيح."
 
@@ -418,35 +418,35 @@ msgstr "تعذر تثبيت التبعيات. أعد تشغيل التطبيق �
 msgid "Unlock Keyring"
 msgstr "فتح حلقة مفاتيح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "الرابط (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "استخدم بيانات الاعتماد اليدوية"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "اسم المستخدم (فارغ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "تحقَّق"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "مقطع"
 
@@ -455,13 +455,13 @@ msgstr "مقطع"
 msgid "Waiting..."
 msgstr "ينتظر..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "الأسوأ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "نعم"
 
@@ -491,62 +491,58 @@ msgid "Audio Language"
 msgstr "لغة الصوت"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "الترجمة"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "المنزِّل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "لا شيء"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "حدد العناصر لتنزِّلها أو لتغيِّر أسماءها."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "ترقِّيم العناوين"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "نزِّل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "حدِّد الكلَّ"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "ألغِ تحديد الكلِّ"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "حدُّ السرعة"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "تقسيم الفصول"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "قسِّم المقطع إلى عدة مقاطع أصغر حسب فصوله."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "قص الصور المصغرة"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "اجعل الصورة المصغرة مربعة، مفيدة عند تنزيل الموسيقى."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "تحميل جزء معين"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -555,11 +551,11 @@ msgstr ""
 "من الممكن أن تُقطَع الوسائط بغير دقة.\n"
 "تمكين هذا الخيار يعطِّل استخدام آريا٢ منزِّلًا."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "اتركه فارغًا للتنزيل من البداية."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "اتركه فارغًا للتنزيل حتى النهاية."
 
@@ -812,32 +808,34 @@ msgstr "استخدم SponsorBlock في اليوتيوب"
 msgid "SponsorBlock Information"
 msgstr "معلومات SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "معلومات رمز اللغة"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "بعض المواقع ترمِّز اللغات بحرفين، وبعضها بثلاثة، فيكتبون «ar» و «ara» يقصدون "
 "العربية.\n"
 "\n"
 "عيِّن كلا الترميزين تجد أحسن النتائج."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "رابط الوكيل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "مِلَفّ تعريف الارتباط"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -845,15 +843,15 @@ msgstr ""
 "لك أن تدخل ملف تعريف ارتباط في yt-dlp، وعندها تستطيع أن تنزِّل الوسائط التي "
 "تتطلب الولوج."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "امحُ ملف تعريف الارتباط"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "معلومات ملف تعريف الارتباط"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -861,15 +859,15 @@ msgstr ""
 "تدخل ملفات تعريف الارتباط في yt-dlp في تنسيق ملف نص. يمكنك أن تصدِّرها من "
 "متصفحك باستخدام الامتدادات التالية (استخدمها على مسؤوليتك):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "المحوِّل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "امنع التحويلات"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -878,15 +876,15 @@ msgstr ""
 "إن مُكِّن هذا فلن يحوَّل المقطع\\الصوت المنزَّل من تنسيق لآخر، بل سوف يكون تنسيقه "
 "حسب الجودة المختارة. (لن تستطيع اختيار تنسيق للملف)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "ضمِّن البيانات الوصفية"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "قص الصور المصغرة لصوتيات"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -894,7 +892,17 @@ msgstr ""
 "في حالة التمكين، سيقوم Parabolic تلقائيًا بتشغيل الخِيار المتقدم للصور المصغرة "
 "لتنزيلات الصوت"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "الفصول المدمجة"
 
@@ -994,6 +1002,13 @@ msgstr "— ينزِّل أكثر من تنزيل آنًا"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— يدعم تنزيل بيانات الوصف وترجمات المقاطع"
+
+#~ msgid "Subtitle"
+#~ msgstr "الترجمة"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "لا شيء"
 
 #~ msgid "Set Password"
 #~ msgstr "عيِّن كلمة السر"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "{০} অধঃগৃহীত হয়েছে।"
 msgid "\"{0}\" has finished with an error!"
 msgstr "{০} অধঃগৃহীত হয়েছে।"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -40,7 +40,7 @@ msgstr ""
 msgid "{0:f1} GiB/s"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -58,23 +58,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "অধিঃগৃহীত {০:f২}% ({১:N০} কিবাইট/সেকেন্ড)"
 msgstr[1] "অধিঃগৃহীত {০:f২}% ({১:N০} কিবাইট/সেকেন্ড)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "অধঃগ্রহণে নিন"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
@@ -83,12 +83,12 @@ msgstr ""
 msgid "All downloads have finished."
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "সর্বোত্তম"
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -135,12 +135,12 @@ msgstr "অধঃগ্রহণ সমাপ্ত"
 msgid "Download log was copied to clipboard."
 msgstr "অধঃগ্রহণের ক্রিয়াকর্ম লেখনপট্টিকাতে প্রতিলিপিত হয়েছে"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 #, fuzzy
 msgid "Download using aria2 has started"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 #, fuzzy
 msgid "Download using ffmpeg has started"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -166,16 +166,16 @@ msgstr "অধিঃগৃহীত {০:f২}% ({১:N০} কিবাইট/�
 msgid "Downloads Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -183,11 +183,11 @@ msgstr ""
 msgid "Error"
 msgstr "বিফল"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr ""
 
@@ -203,13 +203,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "গিটহাবের ভান্ডার"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -217,8 +217,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -226,25 +226,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -254,8 +254,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "না"
 
@@ -274,14 +274,14 @@ msgstr "অধঃগৃহীত হচ্ছে"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr ""
 
@@ -301,36 +301,36 @@ msgstr "প্রস্তুতি..."
 msgid "Processing..."
 msgstr "ক্রিয়ান্বয়ন..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 #, fuzzy
 msgid "Save Folder"
 msgstr "অধঃগ্রহণের তথ্যপথটি খুলুন"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 #, fuzzy
 msgid "Select Cookies File"
 msgstr "সংগ্রাহক তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "সংগ্রাহক তথ্যপথ বেছে নিন"
 
@@ -347,12 +347,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr ""
 
@@ -360,12 +360,12 @@ msgstr ""
 msgid "Stopped"
 msgstr "স্তব্ধ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr ""
 
@@ -384,11 +384,11 @@ msgstr ""
 "প্রতিলিপিধর্ম(কপিরাইট) বা ডি এম সি এ আইনের ভঙ্গ করতে পারে তার জন্য দায়ী নয়। "
 "ব্যবহারকারীরা নিজ ঝুঁকিতে ব্যবহার করুন।"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -398,11 +398,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -415,37 +415,37 @@ msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ�
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
 msgid "Username"
 msgstr "ব্যবহারকারীর দৃষ্টিতে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "ব্যবহারকারীর দৃষ্টিতে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr ""
 
@@ -454,13 +454,13 @@ msgstr ""
 msgid "Waiting..."
 msgstr "অপেক্ষা করুন...."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "চলনশই"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "হ্যাঁ"
 
@@ -490,76 +490,71 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr ""
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
 #, fuzzy
-msgctxt "Subtitle"
-msgid "None"
-msgstr "কোনোটিই নয়"
+msgid "Download Subtitle"
+msgstr "অধঃগ্রহণ"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "ভিডিও সংখ্যা"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "অধঃগ্রহণ"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "অধঃগ্রহণ থামান"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -814,77 +809,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "পরিবর্তক"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "পরাতথ্যের যুক্তি"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -989,6 +995,11 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "কোনোটিই নয়"
 
 #, fuzzy
 #~ msgid "Unable to unlock keyring. Restart the app to try again."

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "Soubor „{0}“ byl stažen."
 msgid "\"{0}\" has finished with an error!"
 msgstr "Stahování souboru „{0}“ skončilo s chybou!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Lze upravit v předvolbách)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -62,8 +62,8 @@ msgstr[0] "{0} stahování — {1:f1}% ({2})"
 msgstr[1] "{0} stahování — {1:f1}% ({2})"
 msgstr[2] "{0} stahování — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -71,15 +71,15 @@ msgstr[0] "{0} z {1} položky"
 msgstr[1] "{0} ze {1} položek"
 msgstr[2] "{0} z {1} položek"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Přidat stahování"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Rozšířené možnosti"
 
@@ -87,12 +87,12 @@ msgstr "Rozšířené možnosti"
 msgid "All downloads have finished."
 msgstr "Všechna stahování byla dokončena."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Zvuk"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Nejlepší"
 
@@ -116,7 +116,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
@@ -136,11 +136,11 @@ msgstr "Stahování dokončeno s chybou"
 msgid "Download log was copied to clipboard."
 msgstr "Protokol stahování byl zkopírován do schránky."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Bylo spuštěno stahování pomocí aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Bylo spuštěno stahování pomocí ffmpeg"
 
@@ -164,16 +164,16 @@ msgstr "Stahování {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Stahování dokončena"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Čas konce"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Čas konce (neplatný)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Ujistěte se, že jsou údaje správné."
 
@@ -181,12 +181,12 @@ msgstr "Ujistěte se, že jsou údaje správné."
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Nepodařilo se zakázat klíčenku."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Soubor již existuje a přepisování je zakázáno"
 
@@ -202,13 +202,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Klíčenka"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Klíčenka uzamčena"
 
@@ -216,8 +216,8 @@ msgstr "Klíčenka uzamčena"
 msgid "List of supported sites"
 msgstr "Seznam podporovaných webů"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Přihlásit se"
 
@@ -225,25 +225,25 @@ msgstr "Přihlásit se"
 msgid "Matrix Chat"
 msgstr "Matrix chat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Maximální kvalita"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL média"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Adresa URL média (neplatná)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Název"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Název (prázdný)"
 
@@ -253,8 +253,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Ne"
 
@@ -272,14 +272,14 @@ msgstr "Nejsou spuštěna žádná stahování"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Heslo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Heslo (prázdné)"
 
@@ -287,7 +287,7 @@ msgstr "Heslo (prázdné)"
 msgid "Play"
 msgstr "Přehrát"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Playlist"
 
@@ -299,34 +299,34 @@ msgstr "Příprava..."
 msgid "Processing..."
 msgstr "Zpracovává se..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Resetovat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Resetovat klíčenku?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Pro odemknutí klíčenky restartujte aplikaci."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Složka k uložení"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Složka k uložení (neplatná)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Vybrat soubor s cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Vybrat složku k uložení"
 
@@ -342,12 +342,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Některá stahování skončila s chybami!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Čas začátku"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Čas začátku (neplatný)"
 
@@ -355,12 +355,12 @@ msgstr "Čas začátku (neplatný)"
 msgid "Stopped"
 msgstr "Zastaveno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Jazyky titulků (oddělené čárkou)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Jazyky titulků (neplatné)"
 
@@ -378,11 +378,11 @@ msgstr ""
 "zneužití tohoto programu, které může porušovat místní zákony o autorských "
 "právech/DMCA. Uživatelé používají tuto aplikaci na vlastní nebezpečí."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Tato akce je nevratná. Určitě chcete klíčenku odstranit?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -394,11 +394,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Nepodařilo se zakázat klíčenku."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Nepodařilo se resetovat klíčenku."
 
@@ -413,35 +413,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Odemknout klíčenku"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Adresa URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "Adresa URL (neplatná)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Použít manuální údaje"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Uživatelské jméno (prázdné)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Ověřit"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -450,13 +450,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Nejhorší"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Ano"
 
@@ -486,62 +486,58 @@ msgid "Audio Language"
 msgstr "Jazyk zvuku"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Titulky"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Stahování"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Žádné"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Vyberte položky ke stažení nebo změňte názvy souborů."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Očíslovat názvy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Stáhnout"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Vybrat vše"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Zrušit výběr"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Omezení rychlosti"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Rozdělit kapitoly"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Rozdělí video do několika menších podle jeho kapitol."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Oříznout miniaturu"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Oříznout miniaturu na čtverec, užitečné při stahování hudby."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Stáhnout konkrétní časový úsek"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "Povolením této možnosti zakážete použití aria2 jako downloaderu, pokud je "
 "povolen."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Ponechte prázdné pro stažení od začátku."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Ponechte prázdné pro stáhnutí do konce."
 
@@ -813,17 +809,19 @@ msgstr "Použít SponsorBlock pro YouTube"
 msgid "SponsorBlock Information"
 msgstr "Informace o službě SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informace o kódu jazyka"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Některé stránky používají dvoupísmenné jazykové kódy, jiné třípísmenné. "
 "Například pro angličtinu se používá „en“ i „eng“.\n"
@@ -831,15 +829,15 @@ msgstr ""
 "Pro dosažení nejlepších výsledků zadejte pro své jazyky dvoupísmenné i "
 "třípísmenné kódy."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "URL proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Soubor cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -847,15 +845,15 @@ msgstr ""
 "Programu yt-dlp lze poskytnout soubor s cookies pro stáhnutí médií, která "
 "vyžadují přihlášení."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Vymazat soubor s cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informace o souboru s cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -864,15 +862,15 @@ msgstr ""
 "můžete ze svého prohlížeče exportovat pomocí následujících rozšíření "
 "(používejte na vlastní nebezpečí):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konvertor"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Zakázat převody"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -882,15 +880,15 @@ msgstr ""
 "vybranou kvalitu bez převodu na jiné formáty. (Nebudete si moci vybrat "
 "formát souboru)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Vložení metadat"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Oříznutí miniatur zvuku"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -898,7 +896,17 @@ msgstr ""
 "Pokud je tato možnost povolena, aplikace Parabolic automaticky zapne "
 "pokročilou možnost oříznutí miniatur pro stahování zvuku"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Vkládání kapitol"
 
@@ -999,6 +1007,13 @@ msgstr "— Možnost stahovat několik videí najednou"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Podporuje stahování metadat a titulků videí"
+
+#~ msgid "Subtitle"
+#~ msgstr "Titulky"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Žádné"
 
 #~ msgid "Set Password"
 #~ msgstr "Nastavit heslo"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-26 16:10+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" wurde heruntergeladen."
 msgid "\"{0}\" has finished with an error!"
 msgstr "Bei \"{0}\" ist beim Herunterladen ein Fehler aufgetreten!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(In Einstellungen konfigurierbar)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} Download — {1:f1}% ({2})"
 msgstr[1] "{0} Downloads — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} von {1} Downloads"
 msgstr[1] "{0} von {1} Downloads"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Download hinzufügen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
@@ -85,12 +85,12 @@ msgstr "Erweiterte Optionen"
 msgid "All downloads have finished."
 msgstr "Alle Downloads abgeschlossen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Am besten"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Standard"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
@@ -134,11 +134,11 @@ msgstr "Download mit Fehler Beendet"
 msgid "Download log was copied to clipboard."
 msgstr "Download-Protokoll wurde in die Zwischenablage kopiert."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Download mit aria2 angefangen"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Download mit FFmpeg angefangen"
 
@@ -162,16 +162,16 @@ msgstr "Herunterladen: {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloads Finished"
 msgstr "Downloads Beendet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Endzeit"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Endzeit (Ungültig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Stelle sicher das Anmeldedaten korrekt sind."
 
@@ -179,12 +179,12 @@ msgstr "Stelle sicher das Anmeldedaten korrekt sind."
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Keyring konnte nicht deaktiviert werden."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Datei existiert bereits, und Überschreiben ist nicht erlaubt"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub-Repository"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Keyring gesperrt"
 
@@ -214,8 +214,8 @@ msgstr "Keyring gesperrt"
 msgid "List of supported sites"
 msgstr "Liste der unterstützten Seiten"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Anmeldung"
 
@@ -223,25 +223,25 @@ msgstr "Anmeldung"
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Höchste Qualität"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Medien-URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Video Url (ungültig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Name"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Name (Leer)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nein"
 
@@ -270,14 +270,14 @@ msgstr "Keine laufenden Downloads"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Passwort"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Passwort (Leer)"
 
@@ -285,7 +285,7 @@ msgstr "Passwort (Leer)"
 msgid "Play"
 msgstr "Abspielen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
@@ -297,34 +297,34 @@ msgstr "Vorbereiten..."
 msgid "Processing..."
 msgstr "Verarbeitung..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Keyring zurücksetzen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Starte die App neu um den Keyring zu entsperren."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Speicherordner"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Ordner speichern (ungültig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Cookie-Datei auswählen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Speicherordner wählen"
 
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Einige Downloads wurden mit Fehlern beendet!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Startzeit"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Startzeit (Ungültig)"
 
@@ -354,12 +354,12 @@ msgstr "Startzeit (Ungültig)"
 msgid "Stopped"
 msgstr "Angehalten"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Untertitelsprachen (durch Kommas getrennt)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Untertitel-Sprachen (Ungültig)"
 
@@ -378,13 +378,13 @@ msgstr ""
 "Gesetze verstoßen könnte. Die Verwendung dieser Anwendung erfolgt auf eigene "
 "Gefahr."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Diese Aktion kann nicht rückgängig gemacht werden. Bist du sicher dass du es "
 "löschen möchtest?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -398,11 +398,11 @@ msgstr ""
 "Feliks Weber <feliks@notabit.eu>\n"
 "Simon Hahne <simon@nicewaffel.dev>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Keyring konnte nicht deaktiviert werden."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Keyring konnte nicht zurückgesetzt werden."
 
@@ -417,35 +417,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Keyring ensperren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (Ungültig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Manuelle Anmeldedaten verwenden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nutzername"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nutzername (Leer)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validieren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -454,13 +454,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Warten..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Am schlechtesten"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Ja"
 
@@ -490,62 +490,58 @@ msgid "Audio Language"
 msgstr "Audiosprache"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Untertitel"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Downloader"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Keine"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Wähle Elemente zum heruntergeladen oder Dateinamen ändern."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Titelnummern"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Herunterladen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Alle auswählen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Auswahl aufheben"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Geschwindigkeitsbegrenzung"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "In Kapitel unterteilen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Teilt das Video in mehrere kürzere basierend auf den Kapiteln."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Vorschau zuschneiden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Vorschau quadratisch machen, nützlich bei Musik."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Bestimmten Zeitraum herunterladen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -555,11 +551,11 @@ msgstr ""
 "Aktivierung dieser Option deaktiviert aria2 als Downloader falls er "
 "aktiviert ist."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Leer lassen um von Anfang an herunterzuladen."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Leer lassen um bis zum Ende herunterzuladen."
 
@@ -817,17 +813,19 @@ msgstr "Benutze SponsorBlock für YouTube"
 msgid "SponsorBlock Information"
 msgstr "SponsorBlock-Information"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informationen zum Sprachcode"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Einige Websites verwenden Sprachcodes mit zwei Buchstaben, andere hingegen "
 "mit drei Buchstaben. Zum Beispiel werden \"en\" und \"eng\" beide für "
@@ -836,15 +834,15 @@ msgstr ""
 "Gib bitte für die besten Ergebnisse sowohl Codes mit zwei als auch mit drei "
 "Buchstaben für deine Sprachen an."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Proxy-URL"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Cookie-Datei"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -852,15 +850,15 @@ msgstr ""
 "Eine Cookie-Datei kann yt-dlp bereitgestellt werden um Medien "
 "herunterzuladen die einen Login benötigen."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Cookie-Datei zurücksetzen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informationen zur Cookie-Datei"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -869,15 +867,15 @@ msgstr ""
 "Cookies von deinem Browser mit den folgenden Erweiterungen (Verwendung auf "
 "eigene Gefahr):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konverter"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Umwandlungen nicht zulassen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -887,15 +885,15 @@ msgstr ""
 "gewählte Qualität herunter, ohne es in andere Formate umzuwandeln. (Du "
 "kannst kein Dateiformat auswählen)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Metadaten einbetten"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Audio-Vorschau Zuschneiden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -903,7 +901,17 @@ msgstr ""
 "Wenn aktiviert, schaltet Parabolic automatisch die erweiterte Option zum "
 "Zuschneiden der Vorschau für Audio-Downloads ein"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Kapitel Einbetten"
 
@@ -1006,6 +1014,13 @@ msgstr "— Lade mehrere Medien gleichzeitig herunter"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Unterstützt herunterladen von Metadaten und Videountertiteln"
+
+#~ msgid "Subtitle"
+#~ msgstr "Untertitel"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Keine"
 
 #~ msgid "Set Password"
 #~ msgstr "Passwort setzen"

--- a/NickvisionTubeConverter.Shared/Resources/po/el.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-23 16:26+0000\n"
 "Last-Translator: MOUSTAFA ALIOGLOU <moystafaa@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "ολοκληρώθηκε η λήψη του \"{0}\"."
 msgid "\"{0}\" has finished with an error!"
 msgstr "Το \"{0}\" τελείωσε με σφάλμα!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Δυνατότητα διαμόρφωσης στις προτιμήσεις)"
 
@@ -43,7 +43,7 @@ msgstr ""
 msgid "{0:f1} GiB/s"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} λήψει — {1:f1}% ({2})"
 msgstr[1] "{0} λήψεις — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} από {1} στοιχείο"
 msgstr[1] "{0} από {1} στοιχεία"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Προσθήκη λήψης"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Επιλογές για προχωρημένους"
 
@@ -85,12 +85,12 @@ msgstr "Επιλογές για προχωρημένους"
 msgid "All downloads have finished."
 msgstr "Όλες οι λήψεις έχουν ολοκληρωθεί."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Ήχος"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Καλύτερη"
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -134,11 +134,11 @@ msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr ""
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr ""
 
@@ -162,16 +162,16 @@ msgstr ""
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -179,11 +179,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr ""
 
@@ -199,13 +199,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -213,8 +213,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -222,25 +222,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -250,8 +250,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr ""
 
@@ -269,14 +269,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr ""
 
@@ -296,34 +296,34 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
@@ -337,12 +337,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr ""
 
@@ -350,12 +350,12 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr ""
 
@@ -370,11 +370,11 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -384,11 +384,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -401,35 +401,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr ""
 
@@ -438,13 +438,13 @@ msgstr ""
 msgid "Waiting..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr ""
 
@@ -474,73 +474,69 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr ""
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Η λήψη ολοκληρώθηκε"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr ""
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -786,77 +782,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -30,7 +30,7 @@ msgstr "\"{0}\" ha terminado de descargarse."
 msgid "\"{0}\" has finished with an error!"
 msgstr "¡\"{0}\" se completó con un error!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Configurable en las preferencias)"
 
@@ -44,7 +44,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -62,23 +62,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} descarga — {1:f1}% ({2})"
 msgstr[1] "{0} descargas — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} de {1} elemento"
 msgstr[1] "{0} de {1} elementos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Añadir descarga"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opciones avanzadas"
 
@@ -86,12 +86,12 @@ msgstr "Opciones avanzadas"
 msgid "All downloads have finished."
 msgstr "Todas las descargas han finalizado."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Mejor"
 
@@ -115,7 +115,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predeterminada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "¿Borrar credencial?"
 
@@ -135,11 +135,11 @@ msgstr "Descarga finalizada con error"
 msgid "Download log was copied to clipboard."
 msgstr "El registro de descargas se ha copiado al portapapeles."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "La descarga usando aria2 ha comenzado"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "La descarga usando ffmpeg ha comenzado"
 
@@ -163,16 +163,16 @@ msgstr "Descargando {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Descargas terminadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Hora de finalización"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Hora de finalización (no válida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Asegúrese de que las credenciales son correctas."
 
@@ -180,12 +180,12 @@ msgstr "Asegúrese de que las credenciales son correctas."
 msgid "Error"
 msgstr "Error"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "No se puede desactivar el llavero."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "El archivo ya existe y no está permitido sobreescribirlo"
 
@@ -201,13 +201,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Llavero"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Llavero bloqueado"
 
@@ -215,8 +215,8 @@ msgstr "Llavero bloqueado"
 msgid "List of supported sites"
 msgstr "Lista de sitios compatibles"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Inicio de sesión"
 
@@ -224,25 +224,25 @@ msgstr "Inicio de sesión"
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Máxima calidad"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL de los medios"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL a los medios (no válido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nombre"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nombre (vacío)"
 
@@ -252,8 +252,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "No"
 
@@ -271,14 +271,14 @@ msgstr "No hay descargas en curso"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Contraseña"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Contraseña (vacía)"
 
@@ -286,7 +286,7 @@ msgstr "Contraseña (vacía)"
 msgid "Play"
 msgstr "Reproducir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
@@ -298,34 +298,34 @@ msgstr "Preparando…"
 msgid "Processing..."
 msgstr "Procesando…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Restablecer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "¿Restablecer el llavero?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Reinicie la aplicación para desbloquear el llavero."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Guardar carpeta"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Guardar carpeta (no válida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Selecciona archivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleccione la carpeta de guardado"
 
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "¡Algunas descargas terminaron con errores!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Hora de inicio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Hora de inicio (no válida)"
 
@@ -354,12 +354,12 @@ msgstr "Hora de inicio (no válida)"
 msgid "Stopped"
 msgstr "Detenida"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Idiomas de los subtítulos (separados por comas)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Idiomas de los subtítulos (no válido)"
 
@@ -377,11 +377,11 @@ msgstr ""
 "mal uso de este programa que pueda violar las leyes locales del copyright/"
 "DMCA. Los usuarios usan esta aplicación bajo su propio riesgo."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Esta acción es irreversible. ¿Está seguro de que quiere borrarlo?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -395,11 +395,11 @@ msgstr ""
 "gallegonovato https://github.com/gallegonovato\n"
 "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "No se puede desactivar el llavero."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "No se puede restablecer el llavero."
 
@@ -414,35 +414,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Desbloquear llavero"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (no válida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Usar credencial manual"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nombre de usuario (vacío)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Vídeo"
 
@@ -451,13 +451,13 @@ msgstr "Vídeo"
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Peor"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Sí"
 
@@ -487,64 +487,60 @@ msgid "Audio Language"
 msgstr "Idioma del audio"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Subtítulo"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Descargador"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Ninguno"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 "Seleccione los elementos que desee descargar o cambie los nombres de los "
 "archivos."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Número de los títulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Descargar"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleccionar todo"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Límite de velocidad"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Separar los capítulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divida el vídeo en varios más pequeños en función de sus capítulos."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Hacer miniaturas cuadradas, útil al descargar música."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Descargar plazos específicos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -554,11 +550,11 @@ msgstr ""
 "Al activar esta opción se desactivará el uso de aria2 como descargador si "
 "está activado."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Dejar en blanco para descargar desde el inicio."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Dejar en blanco para descargar hasta el final."
 
@@ -818,32 +814,34 @@ msgstr "Usar SponsorBlock para YouTube"
 msgid "SponsorBlock Information"
 msgstr "Información sobre SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Información del código del idioma"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Algunos sitios usan códigos lingüísticos de dos letras, mientras que otros "
 "usan de tres letras. Por ejemplo, \"en\" y \"eng\" se usan para el inglés.\n"
 "\n"
 "Para obtener mejores resultados, especifique códigos de dos y tres letras."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "URL del proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Archivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -851,15 +849,15 @@ msgstr ""
 "Se puede proporcionar un archivo de cookies a yt-dlp para permitir la "
 "descarga de medios que requieren un inicio de sesión."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Borrar archivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Información del archivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -868,15 +866,15 @@ msgstr ""
 "cookies desde su navegador usando las siguientes extensiones (úselas bajo su "
 "propia responsabilidad):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Conversor"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "No permitir conversiones"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -886,15 +884,15 @@ msgstr ""
 "para la calidad seleccionada sin convertir a otros formatos. (No podrá "
 "seleccionar un formato de archivo)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Incrustar metadatos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Recortar miniaturas de audio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -902,7 +900,17 @@ msgstr ""
 "Si está activada, Parabolic activará automáticamente la opción avanzada de "
 "recortar miniaturas para las descargas de audio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Incrustar capítulos"
 
@@ -1006,6 +1014,13 @@ msgstr "— Ejecutar múltiples descargas a la vez"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Admite la descarga de los metadatos y subtítulos del video"
+
+#~ msgid "Subtitle"
+#~ msgstr "Subtítulo"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Ninguno"
 
 #~ msgid "Set Password"
 #~ msgstr "Establecer contraseña"

--- a/NickvisionTubeConverter.Shared/Resources/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 20:09+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" on ladattu."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" on valmistunut virheen kera!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Muokattavissa asetuksissa)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} t/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} lataus — {1:f1}% ({2})"
 msgstr[1] "{0} latausta — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0}/{1} kohde"
 msgstr[1] "{0}/{1} kohdetta"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Lisää lataus"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Lisävalinnat"
 
@@ -85,12 +85,12 @@ msgstr "Lisävalinnat"
 msgid "All downloads have finished."
 msgstr "Kaikki lataukset ovat valmistuneet."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Ääni"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Paras"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Oletus"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Poistetaanko kirjautumistieto?"
 
@@ -134,11 +134,11 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr "Latausloki kopioitiin leikepöydälle."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Lataus aria2:ta käyttäen alkoi"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Lataus ffmpeg:tä käyttäen alkoi"
 
@@ -162,16 +162,16 @@ msgstr "Ladataan {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Lataukset valmistuivat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Loppuaika"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Loppuaika (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Varmista, että kirjautumistiedot ovat oikein."
 
@@ -179,12 +179,12 @@ msgstr "Varmista, että kirjautumistiedot ovat oikein."
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Avainnippua ei voitu poistaa käytöstä."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Tiedosto on jo olemassa, ja korvaaminen ei ole sallittua"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Avainnippu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Avainnippu lukittu"
 
@@ -214,8 +214,8 @@ msgstr "Avainnippu lukittu"
 msgid "List of supported sites"
 msgstr "Luettelo tuetuista sivustoista"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Kirjaudu"
 
@@ -223,25 +223,25 @@ msgstr "Kirjaudu"
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Paras laatu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Median URL-osoite"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Median URL-osoite (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nimi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nimi (tyhjä)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Ei"
 
@@ -270,14 +270,14 @@ msgstr "Ei käynnissä olevia latauksia"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Salasana"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Salasana (tyhjä)"
 
@@ -285,7 +285,7 @@ msgstr "Salasana (tyhjä)"
 msgid "Play"
 msgstr "Toista"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Soittolista"
 
@@ -297,34 +297,34 @@ msgstr "Valmistellaan..."
 msgid "Processing..."
 msgstr "Käsitellään..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Nollaa"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Nollataanko avainnippu?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Käynnistä sovellus uudelleen avataksesi avainnipun lukituksen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Tallennuskansio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Tallennuskansio (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Valitse evästetiedosto"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Valitse tallennuskansio"
 
@@ -338,12 +338,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Alkuaika"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Alkuaika (virheellinen)"
 
@@ -351,12 +351,12 @@ msgstr "Alkuaika (virheellinen)"
 msgid "Stopped"
 msgstr "Pysäytetty"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Tekstityksen kieli (pilkuin erotettu)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Tekstityksen kielet (virheellinen)"
 
@@ -371,11 +371,11 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -385,11 +385,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Avainnippua ei voitu poistaa käytöstä."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Avainnippua ei voitu nollata."
 
@@ -402,35 +402,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Avaa avainnippu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL-osoite"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL-osoite (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Käyttäjätunnus (tyhjä)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validoi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -439,13 +439,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Odotetaan..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Huonoin"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -475,73 +475,69 @@ msgid "Audio Language"
 msgstr "Äänen kieli"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Tekstitys"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Lataaja"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Ei mitään"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Lataa"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Älä valitse mitään"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Nopeusrajoitus"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Jaa kappaleisiin"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Jakaa videon useisiin pienempiin videoihin kappaleisiin perustuen."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Rajaa pikkukuva"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Tee pikkukuvasta neliö, hyödyllinen musiikkia ladatessa."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Jätä tyhjäksi ladataksesi alusta lähtien."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Jätä tyhjäksi ladataksesi loppuun asti."
 
@@ -789,77 +785,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Evästetiedoston tiedot"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Välityspalvelimen URL-osoite"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Evästetiedosto"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Tyhjennä evästetiedosto"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Evästetiedoston tiedot"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Muuntaja"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Älä salli muunnosta"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Upota metatiedot"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Upota kappaleet"
 
@@ -958,6 +965,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "Tekstitys"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Ei mitään"
 
 #~ msgid "Set Password"
 #~ msgstr "Aseta salasana"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "« {0} » a été téléchargé."
 msgid "\"{0}\" has finished with an error!"
 msgstr "« {0} » s’est terminé avec une erreur !"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(modifiable dans les préférences)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} Gb/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} téléchargement — {1:f1}% ({2})"
 msgstr[1] "{0} téléchargements — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} sur {1} élément"
 msgstr[1] "{0} sur {1} éléments"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Ajouter un téléchargement"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Options avancées"
 
@@ -85,12 +85,12 @@ msgstr "Options avancées"
 msgid "All downloads have finished."
 msgstr "Tous les téléchargements sont terminés."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Meilleure"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Par défaut"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Supprimer ces identifiants ?"
 
@@ -134,11 +134,11 @@ msgstr "Téléchargement terminé avec une erreur"
 msgid "Download log was copied to clipboard."
 msgstr "Le journal de téléchargement a été copié vers le presse-papiers."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Le téléchargement via aria2 a débuté"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Le téléchargement via ffmpeg a débuté"
 
@@ -162,16 +162,16 @@ msgstr "Téléchargement {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Téléchargements terminés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Fin"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Fin (invalide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Assurez-vous que les identifiants soient corrects."
 
@@ -179,12 +179,12 @@ msgstr "Assurez-vous que les identifiants soient corrects."
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Impossible de désactiver le trousseau."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Le fichier existe déjà, et le remplacement n’a pas été activé"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Trousseau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Trousseau verrouillé"
 
@@ -214,8 +214,8 @@ msgstr "Trousseau verrouillé"
 msgid "List of supported sites"
 msgstr "Liste des sites pris en charge"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "S’identifier"
 
@@ -223,25 +223,25 @@ msgstr "S’identifier"
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Qualité maximale"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL du média"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL du média (invalide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nom"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Non"
 
@@ -270,14 +270,14 @@ msgstr "Aucun téléchargement en cours"
 msgid "Parabolic"
 msgstr "Parabole"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Mot de passe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Mot de passe (vide)"
 
@@ -285,7 +285,7 @@ msgstr "Mot de passe (vide)"
 msgid "Play"
 msgstr "Lire"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Liste de lecture"
 
@@ -297,34 +297,34 @@ msgstr "Préparation..."
 msgid "Processing..."
 msgstr "Traitement..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Réinitialiser le trousseau ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Redémarrez l’application pour déverrouiller le trousseau."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Dossier d’enregistrement"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Dossier de sauvegarde (invalide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Sélectionner un fichier de cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Sélectionner un dossier de sauvegarde"
 
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Certains téléchargements se sont terminés avec des erreurs !"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Point de départ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Point de départ (invalide)"
 
@@ -354,12 +354,12 @@ msgstr "Point de départ (invalide)"
 msgid "Stopped"
 msgstr "Arrêté"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Langages de sous-titres (séparés par une virgule)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Langages de sous-titres (invalides)"
 
@@ -378,12 +378,12 @@ msgstr ""
 "le copyright/DMCA. Les utilisateurs se servent de cette application à leurs "
 "propres risques."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Cette action est irréversible. Êtes-vous sûr⋅e de vouloir le supprimer ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -395,11 +395,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Impossible de désactiver le trousseau."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Impossible de réinitialiser le trousseau."
 
@@ -414,35 +414,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Déverrouiller le trousseau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (invalide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Identification manuelle"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nom d’utilisateur (vide)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valider"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Vidéo"
 
@@ -451,13 +451,13 @@ msgstr "Vidéo"
 msgid "Waiting..."
 msgstr "Attente..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Basse"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Oui"
 
@@ -487,63 +487,59 @@ msgid "Audio Language"
 msgstr "Langue de l’audio"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Sous-titres"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Téléchargeur"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Aucuns"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 "Sélectionnez les éléments à télécharger ou modifiez le nom des fichiers."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numéroter les titres"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Télécharger"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Sélectionner tout"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Désélectionner tout"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limitation de vitesse"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Diviser en chapitres"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Sépare la vidéo en plusieurs morceaux correspondant à ses chapitres."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Rogner la vignette"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Rend les vignettes carrées, utile pour le téléchargement de musiques."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Télécharger une séquence spécifique"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -553,11 +549,11 @@ msgstr ""
 "Le choix de cette option désactivera l’utilisation de aria2 comme "
 "téléchargeur s’il est activé."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Laisser vide pour télécharger à partir du début."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Laisser vide pour télécharger jusqu’à la fin."
 
@@ -820,17 +816,19 @@ msgstr "Utiliser SponsorBlock pour YouTube"
 msgid "SponsorBlock Information"
 msgstr "Informations sur SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informations sur les abréviations de langage"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Certains sites utilisent des abréviations de langages à deux lettres, alors "
 "que d’autres utilisent trois lettres. Par exemple, « en » et « eng » sont "
@@ -839,15 +837,15 @@ msgstr ""
 "Spécifiez les abréviations pour vos langages avec 2 et 3 lettres pour avoir "
 "de meilleurs résultats."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "URL de Proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Fichier de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -855,15 +853,15 @@ msgstr ""
 "Un fichier de cookies peut être fourni à yt-dlp pour permettre de "
 "télécharger les médias requérant une identification."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Effacer le fichier de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informations sur les fichiers de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -872,15 +870,15 @@ msgstr ""
 "Exportez les cookies depuis votre navigateur en utilisant les extensions "
 "suivantes (à vos propres risques) :"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Convertisseur"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Empêcher les conversions"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -890,15 +888,15 @@ msgstr ""
 "approprié pour la qualité sélectionnée, sans conversion dans un autre "
 "format. (Vous ne pourrez pas choisir le format de fichier)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Inclure les métadonnées"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Rogner les vignettes des fichiers audio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -906,7 +904,17 @@ msgstr ""
 "Si cette option est activée, Parabole rognera automatiquement les vignettes "
 "des téléchargements audios"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Inclure les chapitres"
 
@@ -1013,6 +1021,13 @@ msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Prend en charge le téléchargement des métadonnées et des sous-titres des "
 "vidéos"
+
+#~ msgid "Subtitle"
+#~ msgstr "Sous-titres"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Aucuns"
 
 #~ msgid "Set Password"
 #~ msgstr "Définir un mot de passe"

--- a/NickvisionTubeConverter.Shared/Resources/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "Concluíu a descarga de «{0}»."
 msgid "\"{0}\" has finished with an error!"
 msgstr "Concluíu a descarga de «{0}» cun erro!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Configurábel nas preferencias)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} descarga — {1:f1}% ({2})"
 msgstr[1] "{0} descargas — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} elemento de {1}"
 msgstr[1] "{0} elementos de {1}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Engadir descarga"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opcións avanzadas"
 
@@ -85,12 +85,12 @@ msgstr "Opcións avanzadas"
 msgid "All downloads have finished."
 msgstr "Remataron todas as descargas."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Son"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Mellor"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Eliminar credencial?"
 
@@ -134,11 +134,11 @@ msgstr "Descarga rematada con erros"
 msgid "Download log was copied to clipboard."
 msgstr "O rexistro de descarga foi copiado ao portapapeis."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Comezou a descarga empregando aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Comezou a descarga empregando ffmpeg"
 
@@ -162,16 +162,16 @@ msgstr "A descargar {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Descargas rematadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Hora de remate"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Hora de remate (incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Comprobe que as credenciais son correctas."
 
@@ -179,12 +179,12 @@ msgstr "Comprobe que as credenciais son correctas."
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "O ficheiro xa existo e a substitución non está permitida"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repositorio do GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Chaviero"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Chaveiro bloqueado"
 
@@ -214,8 +214,8 @@ msgstr "Chaveiro bloqueado"
 msgid "List of supported sites"
 msgstr "Listaxe de sitios admitidos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Rexistro"
 
@@ -223,25 +223,25 @@ msgstr "Rexistro"
 msgid "Matrix Chat"
 msgstr "Conversa en Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Calidade máxima"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL do recurso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL do recurso (incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nome (Baleiro)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Non"
 
@@ -270,14 +270,14 @@ msgstr "Non hai descargas en execución"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Contrasinal"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Contrasinal (Baleiro)"
 
@@ -285,7 +285,7 @@ msgstr "Contrasinal (Baleiro)"
 msgid "Play"
 msgstr "Reproducir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Lista de reprodución"
 
@@ -297,34 +297,34 @@ msgstr "A preparar..."
 msgid "Processing..."
 msgstr "A procesar..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Restaurar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Restaurar chaveiro?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Reiniciar o aplicativo para desbloquear o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Cartafol de destino"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Cartafol de destino (Incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Seleccionar ficheiro de cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleccionar cartafol de destino"
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Algunhas descargas remataron con erros!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Inicio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Inicio (Incorrecto)"
 
@@ -353,12 +353,12 @@ msgstr "Inicio (Incorrecto)"
 msgid "Stopped"
 msgstr "Parado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Idiomas dos subtítulos (separados por vírgulas)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Idiomas dos subtítulos (Incorrecto)"
 
@@ -376,11 +376,11 @@ msgstr ""
 "deste programa que poida violar as leis locais de dereitos de autor/DMCA. Os "
 "usuarios empregan esta aplicación pola súa propia conta e risco."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Esta acción é irreversíbel. Confirma que desexa eliminalo?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -392,11 +392,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Xosé <xosecalvo@gmail.com; proxecto@trasno.gal>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Non foi posíbel restaurar o chaveiro."
 
@@ -411,35 +411,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (Incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Empregar credencial manual"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nome de usuario (Baleiro)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Vídeo"
 
@@ -448,13 +448,13 @@ msgstr "Vídeo"
 msgid "Waiting..."
 msgstr "Á espera..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Peor"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Si"
 
@@ -484,62 +484,58 @@ msgid "Audio Language"
 msgstr "Idioma do son"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Subtítulo"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Descarga rematada"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Ningunha"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Seleccione elementos para descargar ou cambie os nomes dos ficheiros."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numerar títulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Descargar"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleccionar todo"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Límite de velocidade"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividir capítulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divide o vídeo en varios menores en función dos seus capítulos."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Crear miniatura cadrada, útil ao descargar música."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Descargar fragmento específico"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -549,11 +545,11 @@ msgstr ""
 "Activar esta opción desactivará o uso do aria2 como descargador, se este "
 "estiver activado."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Deixe en branco para descargar desde o inicio."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Deixe en branco para descargar até o fin."
 
@@ -804,77 +800,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -973,6 +980,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "Subtítulo"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Ningunha"
 
 #~ msgid "Set Password"
 #~ msgstr "Estabelecer contrasinal"

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -30,7 +30,7 @@ msgstr "הסתיימה הורדת „{0}”."
 msgid "\"{0}\" has finished with an error!"
 msgstr "הורדת „{0}” הסתיימה עם שגיאה!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(ניתן להתאמה בהעדפות)"
 
@@ -44,7 +44,7 @@ msgstr "‏{0:f1} בית/שנ׳"
 msgid "{0:f1} GiB/s"
 msgstr "‏{0:f1} גיב״ב/שנ׳"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -64,8 +64,8 @@ msgstr[1] "‏{0} יורד — ‏‎{1:f1}% ‏‎‏({2})"
 msgstr[2] "‏{0} יורד — ‏‎{1:f1}% ‏‎‏({2})"
 msgstr[3] "‏{0} יורד — ‏‎{1:f1}% ‏‎‏({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -74,15 +74,15 @@ msgstr[1] "{0} מתוך {1} פריטים"
 msgstr[2] "{0} מתוך {1} פריטים"
 msgstr[3] "{0} מתוך {1} פריטים"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "הוספת הורדה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "אפשרויות מתקדמות"
 
@@ -90,12 +90,12 @@ msgstr "אפשרויות מתקדמות"
 msgid "All downloads have finished."
 msgstr "הסתיימו כל ההורדות."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "שמע"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "הטוב ביותר"
 
@@ -119,7 +119,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "ברירת מחדל"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
@@ -139,11 +139,11 @@ msgstr "הורדה הסתיימה עם שגיאה"
 msgid "Download log was copied to clipboard."
 msgstr "יומן ההורדה הועתק ללוח הגזירים."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "התחילה הורדה באמצעות aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "התחילה הורדה באמצעות ffmpeg"
 
@@ -167,16 +167,16 @@ msgstr "מוריד ‏‏{0:f2}%‎ ‏({1})‎"
 msgid "Downloads Finished"
 msgstr "הסתיימות הורדות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "זמן סיום"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "זמן סיום (לא תקין)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "יש לוודא שפרטי הזיהוי תקינים."
 
@@ -184,12 +184,12 @@ msgstr "יש לוודא שפרטי הזיהוי תקינים."
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "הקובץ כבר קיים, והדריסה שלו לא מתאפשרת"
 
@@ -205,13 +205,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "קבוצת מפתחות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "קבוצת המפתחות ננעלה"
 
@@ -219,8 +219,8 @@ msgstr "קבוצת המפתחות ננעלה"
 msgid "List of supported sites"
 msgstr "רשימה של קבצים נתמכים"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "התחברות"
 
@@ -228,25 +228,25 @@ msgstr "התחברות"
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "איכות מרבית"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "כתובת מדיה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "כתובת מדיה (לא תקינה)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "שם"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "שם (ריק)"
 
@@ -256,8 +256,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "לא"
 
@@ -275,14 +275,14 @@ msgstr "אין הורדות פעילות"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "ססמה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "ססמה (ריק)"
 
@@ -290,7 +290,7 @@ msgstr "ססמה (ריק)"
 msgid "Play"
 msgstr "ניגון"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "רשימת השמעה"
 
@@ -302,34 +302,34 @@ msgstr "בהכנה…"
 msgid "Processing..."
 msgstr "בתהליך…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "איפוס"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "איפוס קבוצת המפתחות?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "יש להפעיל את היישום מחדש על מנת לשחרר את קבוצת המפתחות."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "תיקייה שמירה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "תיקיית שמירה (לא תקין)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "בחירת קובץ עוגיות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "בחירת תיקיית שמירה"
 
@@ -345,12 +345,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "כמה הורדות הסתיימו עם שגיאות!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "זמן התחלה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "זמן התחלה (לא תקין)"
 
@@ -358,12 +358,12 @@ msgstr "זמן התחלה (לא תקין)"
 msgid "Stopped"
 msgstr "נעצרה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "שפות לכתוביות (מופרד בפסיק)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "שפות לכתוביות (לא תקין)"
 
@@ -381,11 +381,11 @@ msgstr ""
 "זו שעשוי להפר את חוקי זכויות היוצרים המקומיים/חוקי DMCA. השימוש שמשתמשים "
 "עושים ביישום זה הוא על אחריותם הבלעדית בלבד."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "פעולה זו בלתי הפיכה. האם אכן ברצונך לבצע את המחיקה?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -399,11 +399,11 @@ msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "לא ניתן לאפס את קבוצת המפתחות."
 
@@ -416,35 +416,35 @@ msgstr "לא ניתן להגדיר תלויות. יש להפעיל מחדש את
 msgid "Unlock Keyring"
 msgstr "שחרור קבוצת מפתחות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "כתובת"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "כתובת (לא תקינה)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "שימוש מזהה גישה ידנית"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "שם משתמש"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "שם משתמש (ריק)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "תיקוף"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "סרט"
 
@@ -453,13 +453,13 @@ msgstr "סרט"
 msgid "Waiting..."
 msgstr "בהמתנה…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "גרוע ביותר"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "כן"
 
@@ -489,62 +489,58 @@ msgid "Audio Language"
 msgstr "שפת שמע"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "כתוביות"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "מוריד"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "אין"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "בחירת פריטים להורדה או שינוי שמות הקבצים."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "מספר בכותרות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "הורדה"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "בחירת הכול"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "ביטול בחירת הכול"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "הגבלת מהירות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "פיצול פרקים"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "פיצול הסרט למספר חלקים קטנים המבוססים על הפרקים שבו."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "חיתוך תמונה ממוזערת"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "להפוך את התמונה הממוזערת לריבוע. שימושי בהורדת מוזיקה."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "הורדת פרק זמן מוגדר"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -553,11 +549,11 @@ msgstr ""
 "המדיה עשויה להיחתך בצורה לא מדויקת.\n"
 "אפשור אפשרות זאת תשבית את השימוש ב־aria2 בתור המוריד."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "יש להשאיר ריק על מנת להוריד מההתחלה."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "יש להשאיר ריק על מנת להוריד עד הסוף."
 
@@ -813,17 +809,19 @@ msgstr "שימוש ב־SponsorBlock עבור YouTube"
 msgid "SponsorBlock Information"
 msgstr "מידע SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "קוד שפה"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "יש אתרים המשתמשים בקוד שפה בן שתי אותיות, בעוד אחרים משתמשים בשלוש אותיות. "
 "לדוגמה, „he” ו־„heb” שניהם משמשים עבור עברית.\n"
@@ -831,30 +829,30 @@ msgstr ""
 "יש להזין את שני הקודים, הן הקוד בן שתי האותיות והן הקוד בן שלוש האותיות, על "
 "מנת לקבל את התוצאות הטובות ביותר לשפה שלך."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "כתובת מתווך"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "קובץ עוגיות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 "ניתן לספק קובץ עוגיות ל־yt-dlp, על מנת לאפשר הורדת מדיה הדורשת התחברות."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "ניקוי קובץ העוגיות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "מידע קובץ עוגיות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -862,15 +860,15 @@ msgstr ""
 "ניתן להעביר עוגיות ל־yt-dlp בתבנית של קובצי טקסט (TEXT). ניתן לייצא עוגיות "
 "מהדפדפן שלך באמצעות ההרחבות הבאות (השימוש באחריותך הבלעדית בלבד):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "המרה"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "מניעת המרות"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -879,15 +877,15 @@ msgstr ""
 "אם מופעל, Parabolic יוריד את תבנית השמע/סרט המתבקש לאיכות הנבחרת ללא המרה "
 "לתבנית אחרת (לא תינתן האפשרות לבחור תבנית קובץ)."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "הטמעת נתוני מידע"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "חיתוך תמונה ממוזערה לשמע"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -895,7 +893,17 @@ msgstr ""
 "אם מופעל, Parabolic יפעיל באופן אוטומטי את האפשרות המתקדמת לחיתוך תמונה "
 "ממוזערת עבור הורדות שמע"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "הטמעת פרקים"
 
@@ -998,6 +1006,13 @@ msgstr "- הפעלת מספר הורדות במקביל"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- תמיכה בהורדת נתוני מידע וכתוביות לסרטים"
+
+#~ msgid "Subtitle"
+#~ msgstr "כתוביות"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "אין"
 
 #~ msgid "Set Password"
 #~ msgstr "הגדרת ססמה"

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -40,7 +40,7 @@ msgstr ""
 msgid "{0:f1} GiB/s"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -58,23 +58,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
@@ -82,12 +82,12 @@ msgstr ""
 msgid "All downloads have finished."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -131,11 +131,11 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr ""
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr ""
 
@@ -159,16 +159,16 @@ msgstr ""
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -176,11 +176,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr ""
 
@@ -196,13 +196,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -210,8 +210,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -219,25 +219,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -247,8 +247,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr ""
 
@@ -266,14 +266,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -281,7 +281,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr ""
 
@@ -293,34 +293,34 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
@@ -334,12 +334,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr ""
 
@@ -347,12 +347,12 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr ""
 
@@ -367,11 +367,11 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -381,11 +381,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -398,35 +398,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr ""
 
@@ -435,13 +435,13 @@ msgstr ""
 msgid "Waiting..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr ""
 
@@ -471,73 +471,68 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
+msgid "Download Subtitle"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr ""
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -783,77 +778,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" letöltése befejeződött."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" letöltése közben hiba történt."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Beállításokban módosítható)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/mp"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/mp"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} letöltés folyamatban — {1:f1}% ({2})"
 msgstr[1] "{0} letöltés folyamatban — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} / {1} elem"
 msgstr[1] "{0} / {1} elem"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Hozzáadás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Haladó beállítások"
 
@@ -85,12 +85,12 @@ msgstr "Haladó beállítások"
 msgid "All downloads have finished."
 msgstr "Minden letöltés befejeződött."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Hang"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Jó"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Alapértelmezett"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
@@ -134,11 +134,11 @@ msgstr "Hiba történt letöltés közben"
 msgid "Download log was copied to clipboard."
 msgstr "Letöltés napló vágólapra másolva."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Letöltés aria2 kódoló használatával megkezdődött"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Letöltés ffmpeg kódoló használatával megkezdődött"
 
@@ -162,16 +162,16 @@ msgstr "Letöltés folyamatban {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Részlet vége"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Részlet vége (hibás)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Győződjön meg arról, hogy az adatok helyesek!"
 
@@ -179,12 +179,12 @@ msgstr "Győződjön meg arról, hogy az adatok helyesek!"
 msgid "Error"
 msgstr "Hiba"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "A fájl már létezik, de felülírás nem engedélyezett"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub tároló"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Jelszókezelő"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Jelszókezelő zárolva"
 
@@ -214,8 +214,8 @@ msgstr "Jelszókezelő zárolva"
 msgid "List of supported sites"
 msgstr "Támogatott honlapok listája"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Bejelentkezés"
 
@@ -223,25 +223,25 @@ msgstr "Bejelentkezés"
 msgid "Matrix Chat"
 msgstr "Matrix csatorna"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Legjobb minőség"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Hivatkozás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Megnevezés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Megnevezés (üres)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nem"
 
@@ -270,14 +270,14 @@ msgstr "Nincs folyamatban letöltés"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Jelszó"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Jelszó (üres)"
 
@@ -285,7 +285,7 @@ msgstr "Jelszó (üres)"
 msgid "Play"
 msgstr "Lejátszás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Lejátszási lista"
 
@@ -297,34 +297,34 @@ msgstr "Előkészítés..."
 msgid "Processing..."
 msgstr "Feldolgozás..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Jelszókezelő visszaállítása"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Indítsa újra az alkalmazást a jelszókezelő feloldásához!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Letöltés helye"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Letöltés helye (hibás)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Süti fájl betöltése"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Letöltés helyének kiválasztása"
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Egyes letöltések közben hiba történt."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Részlet kezdete"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Részlet kezdete (hibás)"
 
@@ -353,12 +353,12 @@ msgstr "Részlet kezdete (hibás)"
 msgid "Stopped"
 msgstr "Letöltés megszakítva"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Feliratok (vesszővel elválasztva)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Feliratok (hibás)"
 
@@ -376,12 +376,12 @@ msgstr ""
 "használata során esetlegesen felmerülő jogsértésekért. A felhasználó saját "
 "felelősségére használja a programot."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "A művelet nem visszafordítható. Valóban törli a bejelentkezési adatokat?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -393,11 +393,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "ViBE"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Jelszókezelő visszaállítása nem lehetséges."
 
@@ -412,35 +412,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Jelszókezelő feloldása"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Hivatkozás"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Bejelentkezés másként"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Felhasználónév (üres)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Elemzés"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Videó"
 
@@ -449,13 +449,13 @@ msgstr "Videó"
 msgid "Waiting..."
 msgstr "Várakozik..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Rossz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Igen"
 
@@ -485,63 +485,59 @@ msgid "Audio Language"
 msgstr "Hangsáv"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Felirat"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Letöltő"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Nincs"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Elemek kijelölése letöltéshez vagy átnevezéshez."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Letöltés"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Összes kijelölése"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Kijelölés törlése"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Sávszélesség korlátozása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Fejezetek beágyazása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Borítókép javítása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Javítja a zenei tartalmak elnyújtott borítóképeit."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Részlet letöltése"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "A beállítás aria2 kódolóval nem lehetséges, így az átmenetileg letiltásra "
 "kerül."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Hagyja üresen, ha az elejétől szeretné letölteni a videót!"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Hagyja üresen, ha a végéig szeretné letölteni a videót!"
 
@@ -816,17 +812,19 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Információ a süti fájlról"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Információ a nyelvi kódlapokról"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Egyes oldalak kétbetűs ISO-szabvány szerinti nyelvkódokat használnak, míg "
 "más oldalak hárombetűs nyelvkódokat alkalmaznak. Például a „hu” és „hun” "
@@ -835,15 +833,15 @@ msgstr ""
 "Viszont a letölteni kívánt feliratok meghatározásához ajánlott mindkét "
 "szabványban használt nyelvkódokat megadni a jobb eredmény érdekében."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Proxy átjáró címe"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Süti fájl használata"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -851,15 +849,15 @@ msgstr ""
 "A yt-dlp képes külső fájlban tárolt bejelentkezési adatok betöltésére az azt "
 "igénylő oldalakhoz."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Süti fájl törlése"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Információ a süti fájlról"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -868,15 +866,15 @@ msgstr ""
 "adatokat használja. Ehhez egy bővítmény telepítése szükséges (saját "
 "felelősségre):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Kódoló"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Átkódolás tiltása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -885,21 +883,31 @@ msgstr ""
 "Átkódolás tiltása esetén a Parabolic az eredeti formátumban tölti le a "
 "tartalmakat. A kódolási beállítások nem lesznek elérhetőek."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Címke/adatok beágyazása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Borítókép javítása"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr "Automatikusan igazítja a zenei tartalmak borítóképeit."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Fejezetek beágyazása"
 
@@ -1001,6 +1009,13 @@ msgstr "— Párhuzamos letöltési lehetőség"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Támogatott a feliratok és egyebek beágyazása"
+
+#~ msgid "Subtitle"
+#~ msgstr "Felirat"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Nincs"
 
 #~ msgid "Set Password"
 #~ msgstr "Jelszó beállítása"

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" telah selesai diunduh."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" telah selesai dengan kesalahan!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Dapat dikonfigurasi di preferensi)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/dtk"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -60,22 +60,22 @@ msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} unduhan - {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} dari {1} item"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Tambah Unduhan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opsi Lanjutan"
 
@@ -83,12 +83,12 @@ msgstr "Opsi Lanjutan"
 msgid "All downloads have finished."
 msgstr "Semua unduhan selesai."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Suara"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Terbaik"
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Default"
 msgstr "Bawaan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
@@ -136,11 +136,11 @@ msgstr "Unduh Selesai Dengan Error"
 msgid "Download log was copied to clipboard."
 msgstr "Log unduhan disalin ke papan klip."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Pengunduhan menggunakan aria2 telah dimulai"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 #, fuzzy
 msgid "Download using ffmpeg has started"
 msgstr "Pengunduhan menggunakan aria2 telah dimulai"
@@ -165,17 +165,17 @@ msgstr "Mengunduh {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloads Finished"
 msgstr "Unduhan Selesai"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "URL Media (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 #, fuzzy
 msgid "Ensure credentials are correct."
 msgstr "Atur Kredensial di keyring anda."
@@ -184,12 +184,12 @@ msgstr "Atur Kredensial di keyring anda."
 msgid "Error"
 msgstr "Kesalahan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "File sudah ada, dan penimpaan tidak diperbolehkan"
 
@@ -205,13 +205,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "Repo GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 #, fuzzy
 msgid "Keyring locked"
 msgstr "Kredensial Keyring"
@@ -220,8 +220,8 @@ msgstr "Kredensial Keyring"
 msgid "List of supported sites"
 msgstr "Daftar situs yang didukung"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -229,25 +229,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr "Obrolan Matriks"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Kualitas Maksimum"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL Media"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL Media (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nama"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nama (Kosong)"
 
@@ -257,8 +257,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Tidak"
 
@@ -276,14 +276,14 @@ msgstr "Tidak ada unduhan yang berjalan"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Kata sandi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Kata sandi (Kosong)"
 
@@ -292,7 +292,7 @@ msgstr "Kata sandi (Kosong)"
 msgid "Play"
 msgstr "Daftar Putar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Daftar Putar"
 
@@ -304,35 +304,35 @@ msgstr "Menyiapkan..."
 msgid "Processing..."
 msgstr "Memproses..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Atur Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Folder Penyimpanan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Pilih File Cookie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Pilih Folder Simpan"
 
@@ -350,12 +350,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Beberapa unduhan selesai dengan error!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
@@ -364,12 +364,12 @@ msgstr "Folder Penyimpanan (tidak sah)"
 msgid "Stopped"
 msgstr "Dihentikan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
@@ -389,11 +389,11 @@ msgstr ""
 "penyalahgunaan program ini yang mungkin melanggar hak cipta lokal/hukum "
 "DMCA. Pengguna menggunakan aplikasi ini dengan risiko mereka sendiri."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Aksi ini tidak dapat diurungkan. Apakah anda yakin untuk menghapusnya?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -403,12 +403,12 @@ msgstr ""
 msgid "translator-credits"
 msgstr "kredit penerjemah"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -423,35 +423,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Buka Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Gunakan kredensial manual"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nama pengguna"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nama pengguna (Kosong)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Memvalidasi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -460,13 +460,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Menunggu..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Terburuk"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Iya"
 
@@ -496,74 +496,70 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Subtitel"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Pengunduh"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Tidak Ada"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Pilih item untuk diunduh atau ubah nama file."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Hitung Video"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Unduh"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "Hentikan Unduhan"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Batas Kecepatan"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Potong Keluku (Thumbnail)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Jadikan keluku berbentuk persegi, berguna ketika mengunduh musik."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -825,78 +821,89 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "File Kuki"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "File Kuki"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 #, fuzzy
 msgid "Cookies File Information"
 msgstr "File Kuki"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konverter"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Sematkan Metadata"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -1001,6 +1008,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "Subtitel"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Tidak Ada"
 
 #, fuzzy
 #~ msgid "Set Password"

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-09-10 21:21+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "Lo scaricamento di \"{0}\" è terminato."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" è terminato con un errore."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(configurabile nelle preferenze)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} scaricamento — {1:f1}% ({2})"
 msgstr[1] "{0} scaricamenti — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} di {1} elemento"
 msgstr[1] "{0} di {1} elementi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Aggiungi scaricamento"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opzioni avanzate"
 
@@ -85,12 +85,12 @@ msgstr "Opzioni avanzate"
 msgid "All downloads have finished."
 msgstr "Tutti gli scaricamenti sono terminati."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Migliore"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Predefinita"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
@@ -134,11 +134,11 @@ msgstr "Scaricamento terminato con errori"
 msgid "Download log was copied to clipboard."
 msgstr "Registro dello scaricamento copiato negli appunti."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Lo scaricamento con aria2 è iniziato"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Lo scaricamento con ffmpeg è iniziato"
 
@@ -162,16 +162,16 @@ msgstr "In scaricamento {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Scaricamenti terminati"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Ora di fine"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Ora di fine (non valida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Assicurati che le credenziali siano corrette."
 
@@ -179,12 +179,12 @@ msgstr "Assicurati che le credenziali siano corrette."
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Disattivazione del portachiavi non riuscita."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Il file esiste già, e la sovrascrittura è disabilitata"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Portachiavi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Portachiavi chiuso"
 
@@ -214,8 +214,8 @@ msgstr "Portachiavi chiuso"
 msgid "List of supported sites"
 msgstr "Elenco dei siti supportati"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Login"
 
@@ -223,25 +223,25 @@ msgstr "Login"
 msgid "Matrix Chat"
 msgstr "Chat di Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Massima qualità"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL del media"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL del media (non valido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nome (vuoto)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "No"
 
@@ -270,14 +270,14 @@ msgstr "Nessuno scaricamento in corso"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Password"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Password (vuota)"
 
@@ -285,7 +285,7 @@ msgstr "Password (vuota)"
 msgid "Play"
 msgstr "Avvia"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Playlist"
 
@@ -297,34 +297,34 @@ msgstr "In preparazione…"
 msgid "Processing..."
 msgstr "In lavorazione…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Azzera"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Azzera il portachiavi?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Riavvia l'app per aprire il portachiavi."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Cartella di salvataggio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Cartella di salvataggio (non valida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Seleziona file cookie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleziona cartella di salvataggio"
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Alcuni scaricamenti sono terminati con degli errori."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Ora di inizio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Ora di inizio (non valida)"
 
@@ -353,12 +353,12 @@ msgstr "Ora di inizio (non valida)"
 msgid "Stopped"
 msgstr "Fermato"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Lingue dei sottotitoli (separate da virgole)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Lingue sottotitoli (non valide)"
 
@@ -376,11 +376,11 @@ msgstr ""
 "improprio di questo programma che possa violare le leggi locali sul "
 "copyright/DMCA. Gli utenti utilizzano questa applicazione a proprio rischio."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Questa azione è irreversibile. Confermare l'eliminazione?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -394,11 +394,11 @@ msgstr ""
 "Albano Battistella\n"
 "Davide Ferracin <davide.ferracin@protonmail.com>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Disattivazione del portachiavi non riuscita."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Azzeramento del portachiavi non riuscito."
 
@@ -413,35 +413,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Sblocca portachiavi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (non valido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Usa un certificato manuale"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nome utente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nome utente (vuoto)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valida"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -450,13 +450,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "In attesa…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Peggiore"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Sì"
 
@@ -486,62 +486,58 @@ msgid "Audio Language"
 msgstr "Lingua dell'audio"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Sottotitoli"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Downloader"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Nessuno"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selezionare gli elementi da scaricare o modificare i nomi dei file."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numera i video"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Scarica"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleziona tutto"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite di velocità"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividi i capitoli"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Separa il video in più parti, una per ciascun capitolo."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Ritaglia miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Rende la miniatura quadrata, utile quando si scarica musica."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Scarica intervallo specifico"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "Attivare questa opzione disabiliterà l'uso di aria2 come downloader, se "
 "abilitato."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Lascia vuoto per scaricare dall'inizio."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Lascia vuoto per terminare il download."
 
@@ -814,17 +810,19 @@ msgstr "Usa SponsorBlock per YouTube"
 msgid "SponsorBlock Information"
 msgstr "Informazioni su SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informazioni sul codice della lingua"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Alcuni siti utilizzano codici lingua di due lettere, mentre altri utilizzano "
 "codici di tre lettere. Ad esempio, \"en\" e \"eng\" sono entrambi usati per "
@@ -833,15 +831,15 @@ msgstr ""
 "Si prega di specificare sia i codici di due lettere che quelli di tre "
 "lettere per le proprie lingue per ottenere i migliori risultati."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "URL proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "File di Cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -849,15 +847,15 @@ msgstr ""
 "È possibile fornire un file cookie a yt-dlp per consentire lo scaricamento "
 "di contenuti multimediali che richiedono un accesso."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Cancella file cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informazioni sui file dei cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -866,15 +864,15 @@ msgstr ""
 "seguenti estensioni per esportare i cookie dal browser (a proprio rischio e "
 "pericolo):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Convertitore"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Non consentire conversioni"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -884,15 +882,15 @@ msgstr ""
 "appropriato alla qualità selezionata, senza convertirlo in altri formati. "
 "(Non si potrà selezionare il formato del file)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Incorpora metadati"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Ritaglia miniature audio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -900,7 +898,17 @@ msgstr ""
 "Se abilitato, Parabolic ritaglierà automaticamente le miniature degli audio "
 "scaricati"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Includi i capitoli"
 
@@ -1004,6 +1012,13 @@ msgstr "— Scarica più di un file alla volta"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Supporta lo scaricamento di metadati e sottotitoli dei video"
+
+#~ msgid "Subtitle"
+#~ msgstr "Sottotitoli"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Nessuno"
 
 #~ msgid "Set Password"
 #~ msgstr "Imposta password"

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-09-09 03:22+0000\n"
 "Last-Translator: Gnuey56 <gnuey56@proton.me>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" はダウンロード完了です。"
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" のダウンロードはエラーで終了しました！"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "（後で再設定できます）"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/毎秒"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB /毎秒"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -60,22 +60,22 @@ msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} ダウンロード— {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{1} 個中 {0} 個のアイテム"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "ダウンロードを追加"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "詳細オプション"
 
@@ -83,12 +83,12 @@ msgstr "詳細オプション"
 msgid "All downloads have finished."
 msgstr "すべてのダウンロードが完了しました。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "音声"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "最高"
 
@@ -112,7 +112,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "デフォルト"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
@@ -132,11 +132,11 @@ msgstr "ダウンロードはエラーで終了"
 msgid "Download log was copied to clipboard."
 msgstr "ダウンロードログがクリップボードにコピーされました。"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Aria2 を使用したダウンロードが開始"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg を使用したダウンロードが開始"
 
@@ -160,16 +160,16 @@ msgstr "ダウンロード中 {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "ダウンロード完了"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "終わり"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "終わり (無効)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "資格情報が正しいか確認します。"
 
@@ -177,12 +177,12 @@ msgstr "資格情報が正しいか確認します。"
 msgid "Error"
 msgstr "エラー"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "キーリングを無効化できません。"
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "すでにファイルが存在しており、ファイルの上書きが無効になっています"
 
@@ -198,13 +198,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub リポジトリ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "キーリング"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "キーリングはロックされています"
 
@@ -212,8 +212,8 @@ msgstr "キーリングはロックされています"
 msgid "List of supported sites"
 msgstr "サポートされているサイト"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "ログイン"
 
@@ -221,25 +221,25 @@ msgstr "ログイン"
 msgid "Matrix Chat"
 msgstr "Matrix チャット"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "最高品質"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "メディアの URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "メディアの URL (無効)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "名前"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "名前（空）"
 
@@ -249,8 +249,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "いいえ"
 
@@ -268,14 +268,14 @@ msgstr "進行中のダウンロードはありません"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "パスワード"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "パスワード（空）"
 
@@ -283,7 +283,7 @@ msgstr "パスワード（空）"
 msgid "Play"
 msgstr "再生"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "再生リスト"
 
@@ -295,34 +295,34 @@ msgstr "準備中..."
 msgid "Processing..."
 msgstr "進行中..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "リセット"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "キーリングをリセットしますか？"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "キーリングを解除するにはアプリを再起動してください。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "保存フォルダー"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "保存フォルダー（不可）"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "クッキーのファイルを選択"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "保存するフォルダーを選択"
 
@@ -338,12 +338,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "一部のダウンロードはエラーで失敗しました！"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "開始"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "開始（無効）"
 
@@ -351,12 +351,12 @@ msgstr "開始（無効）"
 msgid "Stopped"
 msgstr "一時停止中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "字幕の言語（カンマで区切り）"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "字幕の言語（無効）"
 
@@ -374,11 +374,11 @@ msgstr ""
 "ニアム著作権法）に反する可能性のある、このプログラムの誤用について責任を負い"
 "ません。ユーザーによる、このアプリケーションの使用は自己責任です。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "このアクションは取り消せません。本当に削除しますか？"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -390,11 +390,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "翻訳者のクレジット"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "キーリングを無効化できません。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "キーリングをリセットできません。"
 
@@ -408,35 +408,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "キーリングをロック解除"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (無効)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "マニュアル資格情報を使う"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "ユーザー名"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "ユーザー名（空）"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "内容の確認"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "動画"
 
@@ -445,13 +445,13 @@ msgstr "動画"
 msgid "Waiting..."
 msgstr "待機中..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "最低"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "はい"
 
@@ -481,62 +481,58 @@ msgid "Audio Language"
 msgstr "音声の言語"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "字幕"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "ダウンローダー"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "(なし)"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "ダウンロードを選択またはファイル名を変更します。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "動画の数"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "ダウンロード"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "すべて選択"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "すべて選択解除"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "スピード制限"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "チャプター（章）で分ける"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "動画を複数の小さなチャプターごとに分割します。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "サムネイルを整形"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "サムネイルを四角に整えます。音楽をダウンロードする時に便利です。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "特定の時間枠をダウンロード"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -546,11 +542,11 @@ msgstr ""
 "このオプションを有効だと、aria2 を有効にしている場合、aria2 でのダウンロード"
 "は無効になります。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "オプションが空のままだと、動画の最初からダウンロードされます。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "オプションが空のままだと、動画の最後までダウンロードされます。"
 
@@ -805,17 +801,19 @@ msgstr "YouTube のダウンロードで SponsorBlock を使用"
 msgid "SponsorBlock Information"
 msgstr "SponsorBlock の情報"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "言語コードについて"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "いくつかのサイトは二文字の言語コードを使用していますが、三文字のサイトもあり"
 "ます。例: \"en\" と \"eng\" は英語の言語コードとして使用されます。\n"
@@ -823,15 +821,15 @@ msgstr ""
 "最良の結果を得るためには、言語コードを二文字と三文字の両方を指定してくださ"
 "い。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "プロキシ URL"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "クッキーファイル"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -839,15 +837,15 @@ msgstr ""
 "ログインが必要なメディアをダウンロードするために yt-dlp にクッキーファイルを"
 "渡すことができます。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "クッキーファイルを消去"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "クッキーファイルの情報"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -855,15 +853,15 @@ msgstr ""
 "クッキーは TXT ファイル形式で yt-dlp に渡すことができます。ブラウザの拡張機能"
 "を使ってクッキーをエクスポートできます(自己責任で使用してください):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "コンバーター"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "フォーマット変換を無効化"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -873,15 +871,15 @@ msgstr ""
 "した画質に適した動画フォーマットでダウンロードします。（ファイル形式は選択で"
 "きません）"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "メタデータを埋め込む"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "オーディオサムネイルを整形"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -889,7 +887,17 @@ msgstr ""
 "有効であれば、Parabolic はオーディオのダウンロードで自動的にサムネイルを整形"
 "する詳細オプションを有効にします"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "チャプター（章）を埋め込む"
 
@@ -991,6 +999,13 @@ msgstr "— 同時に複数のダウンロードが可能"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— メタデータと字幕のダウンロードに対応"
+
+#~ msgid "Subtitle"
+#~ msgstr "字幕"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "(なし)"
 
 #~ msgid "Set Password"
 #~ msgstr "パスワードを設定"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -29,7 +29,7 @@ msgstr "{0} er nedlastet."
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} fullført med feil."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #, fuzzy
 msgid "(Configurable in preferences)"
 msgstr "Kan tilpasses i egenskapene"
@@ -44,7 +44,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -62,23 +62,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "Nedlastinger: {0} — {1:f1}% ({2})"
 msgstr[1] "Nedlastinger: {0} — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Legg til nedlasting"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
@@ -87,12 +87,12 @@ msgstr ""
 msgid "All downloads have finished."
 msgstr "Nedlasting fullført"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Best"
 
@@ -116,7 +116,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -138,11 +138,11 @@ msgstr "Nedlasting fullført med feil"
 msgid "Download log was copied to clipboard."
 msgstr "Nedlastingslogg kopiert til utklippstavlen"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Nedlasting med aria2 har startet"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Nedlasting med FFmpeg har startet"
 
@@ -167,16 +167,16 @@ msgstr "Laster ned {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Nedlasting fullført"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Slutt-tid (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -184,11 +184,11 @@ msgstr ""
 msgid "Error"
 msgstr "Feil"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Filen finnes allerede, og overskriving er ikke tillatt"
 
@@ -205,13 +205,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "GitHub-kodelager"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -219,8 +219,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "Liste over støttede sider"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -228,27 +228,27 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr "Matrix-sludring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 #, fuzzy
 msgid "Maximum Quality"
 msgstr "Kvalitet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Videonettadresse"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "Filtype"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -258,8 +258,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nei"
 
@@ -277,14 +277,14 @@ msgstr "Ingen nedlastinger kjører"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr ""
 
@@ -304,35 +304,35 @@ msgstr "Forbereder …"
 msgid "Processing..."
 msgstr "Behandler …"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Lagre mappe (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 #, fuzzy
 msgid "Select Cookies File"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Velg lagringsmappe"
 
@@ -349,12 +349,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Noen nedlastinger ble fullført med feil."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Starttid (ugyldig)"
 
@@ -362,12 +362,12 @@ msgstr "Starttid (ugyldig)"
 msgid "Stopped"
 msgstr "Stoppet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "Starttid (ugyldig)"
@@ -387,11 +387,11 @@ msgstr ""
 "programmet for å bryte lokalt lovverk/DCMA-lover. Brukere anvender dette "
 "programmet på egen risiko."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -401,11 +401,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -419,38 +419,38 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
 msgid "Username"
 msgstr "Brukergrensesnitt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "Brukergrensesnitt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Bekreft"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr ""
 
@@ -459,13 +459,13 @@ msgstr ""
 msgid "Waiting..."
 msgstr "Venter …"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Dårlig"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Ja"
 
@@ -496,76 +496,71 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Undertekst"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
 #, fuzzy
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Ingen"
+msgid "Download Subtitle"
+msgstr "Nedlaster"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "Videoantall"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Last ned"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "Stopp alle nedlastinger"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hastighetsgrense"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -823,77 +818,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konverterer"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Bygg inn metadata"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -995,6 +1001,14 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "Undertekst"
+
+#, fuzzy
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Ingen"
 
 #, fuzzy
 #~ msgid "Unable to unlock keyring. Restart the app to try again."

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "‘{0}’ is klaar met downloaden"
 msgid "\"{0}\" has finished with an error!"
 msgstr "‘{0}’ is voltooid met een fout!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(configureerbaar in voorkeuren)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} download — {1:f1}% ({2})"
 msgstr[1] "{0} downloads — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} van {1} item"
 msgstr[1] "{0} van {1} items"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Download toevoegen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Geavanceerde opties"
 
@@ -85,12 +85,12 @@ msgstr "Geavanceerde opties"
 msgid "All downloads have finished."
 msgstr "Alle downloads zijn voltooid."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Best"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Standaard"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
@@ -134,11 +134,11 @@ msgstr "Download voltooid met fouten"
 msgid "Download log was copied to clipboard."
 msgstr "Downloadlogboek gekopieerd naar klembord"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Downloaden met aria2 is gestart"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Downloaden met FFmpeg is gestart"
 
@@ -162,16 +162,16 @@ msgstr "Downloaden — {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Downloads voltooid"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Eindtijd"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Eindtijd (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Zorg ervoor dat de inloggegevens correct zijn."
 
@@ -179,12 +179,12 @@ msgstr "Zorg ervoor dat de inloggegevens correct zijn."
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Bestand bestaat al en overschrijven is niet toegestaan"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Sleutelbos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 #, fuzzy
 msgid "Keyring locked"
 msgstr "Sleutelbos uitgeschakeld"
@@ -215,8 +215,8 @@ msgstr "Sleutelbos uitgeschakeld"
 msgid "List of supported sites"
 msgstr "Lijst met ondersteunde websites"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Inloggen"
 
@@ -224,25 +224,25 @@ msgstr "Inloggen"
 msgid "Matrix Chat"
 msgstr "Matrix-kamer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Maximale kwaliteit"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Media-URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Media-URL (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Naam"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Naam (leeg)"
 
@@ -252,8 +252,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nee"
 
@@ -271,14 +271,14 @@ msgstr "Geen actieve downloads"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Wachtwoord (leeg)"
 
@@ -286,7 +286,7 @@ msgstr "Wachtwoord (leeg)"
 msgid "Play"
 msgstr "Afspelen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Afspeellijst"
 
@@ -298,35 +298,35 @@ msgstr "Voorbereiden…"
 msgid "Processing..."
 msgstr "Verwerken…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Sleutelbos instellen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Opslagmap"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Opslagmap (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Cookies-bestand selecteren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Opslagmap selecteren"
 
@@ -343,12 +343,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Sommige downloads zijn voltooid met fouten!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Starttijd"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Begintijd (ongeldig)"
 
@@ -356,12 +356,12 @@ msgstr "Begintijd (ongeldig)"
 msgid "Stopped"
 msgstr "Gestopt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Ondertitel­talen (gescheiden door komma's)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Ondertitel­talen (ongeldig)"
 
@@ -379,11 +379,11 @@ msgstr ""
 "voor enig misbruik van deze app dat lokale auteursrecht-/DMCA-wetgeving kan "
 "schenden. Gebruikers gebruiken deze app op eigen risico."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Deze actie is onomkeerbaar. Weet u zeker dat u het wilt verwijderen?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -393,12 +393,12 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -412,35 +412,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Sleutelbos ontgrendelen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Handmatige inloggegevens gebruiken"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Gebruikersnaam (leeg)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valideren"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -449,13 +449,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Wachten…"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Slechtst"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Ja"
 
@@ -485,74 +485,70 @@ msgid "Audio Language"
 msgstr "Audio­taal"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Ondertiteling"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Downloader"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Geen"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selecteer items om te downloaden of de bestandsnaam van aan te passen."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Titels nummeren"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Downloaden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Alles deselecteren"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Snelheidslimiet"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Hoofdstukken invoegen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Miniatuur bijsnijden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Maakt het miniatuur vierkant, handig bij het downloaden van muziek"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Specifiek tijdsbestek downloaden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Laat leeg om vanaf het begin te downloaden."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Laat leeg om tot het einde te downloaden."
 
@@ -805,77 +801,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Cookies-bestand-informatie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Taalcode­informatie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Proxy-URL"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Cookies-bestand"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Cookies-bestand wissen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Cookies-bestand-informatie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Converter"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Conversie uitschakelen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Metagegevens invoegen"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Audio-miniaturen bijsnijden"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Hoofdstukken invoegen"
 
@@ -976,6 +983,13 @@ msgstr "— Voer meerdere downloads tegelijk uit"
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Ondersteuning voor het downloaden van video-metagegevens en -ondertitels"
+
+#~ msgid "Subtitle"
+#~ msgstr "Ondertiteling"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Geen"
 
 #~ msgid "Set Password"
 #~ msgstr "Wachtwoord instellen"

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -42,7 +42,7 @@ msgstr ""
 msgid "{0:f1} GiB/s"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -60,23 +60,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
@@ -84,12 +84,12 @@ msgstr ""
 msgid "All downloads have finished."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -133,11 +133,11 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr ""
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr ""
 
@@ -161,16 +161,16 @@ msgstr ""
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -178,11 +178,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr ""
 
@@ -198,13 +198,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -212,8 +212,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -221,25 +221,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -249,8 +249,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr ""
 
@@ -268,14 +268,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr ""
 
@@ -295,34 +295,34 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
@@ -336,12 +336,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr ""
 
@@ -349,12 +349,12 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr ""
 
@@ -369,11 +369,11 @@ msgid ""
 "this application at their own risk."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -383,11 +383,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -400,35 +400,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr ""
 
@@ -437,13 +437,13 @@ msgstr ""
 msgid "Waiting..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr ""
 
@@ -473,73 +473,68 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
+msgid "Download Subtitle"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr ""
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -785,77 +780,88 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-16 20:02+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -30,7 +30,7 @@ msgstr "Pobieranie \"{0}\" zostało zakończone."
 msgid "\"{0}\" has finished with an error!"
 msgstr "Pobieranie \"{0}\" zakończyło się błędem!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Konfigurowalne w preferencjach)"
 
@@ -44,7 +44,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -63,8 +63,8 @@ msgstr[0] "pobieranie - {1:f1}% ({2})"
 msgstr[1] "pobieranie - {1:f1}% ({2})"
 msgstr[2] "pobieranie - {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -72,15 +72,15 @@ msgstr[0] "{0} z {1}"
 msgstr[1] "{0} z {1}"
 msgstr[2] "{0} z {1}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opcje zaawansowane"
 
@@ -88,12 +88,12 @@ msgstr "Opcje zaawansowane"
 msgid "All downloads have finished."
 msgstr "Pobieranie wszystkich plików zostało zakończone."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Najlepsza"
 
@@ -117,7 +117,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Domyślne"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
@@ -137,11 +137,11 @@ msgstr "Pobieranie zostało zakończone z błędami"
 msgid "Download log was copied to clipboard."
 msgstr "Dziennik pobierania został skopiowany do schowka."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Rozpoczęto pobieranie za pomocą aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Rozpoczęto pobieranie za pomocą ffmpeg"
 
@@ -165,16 +165,16 @@ msgstr "Pobieranie {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Pobieranie zostało zakończone"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Koniec"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Koniec (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Upewnij się, że dane logowania są poprawne."
 
@@ -182,12 +182,12 @@ msgstr "Upewnij się, że dane logowania są poprawne."
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Nie można wyłączyć listy kluczy."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Plik już istnieje, a nadpisywanie istniejących plików jest wyłączone"
 
@@ -203,13 +203,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repozytorium na Githubie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Lista kluczy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Lista kluczy zablokowana"
 
@@ -217,8 +217,8 @@ msgstr "Lista kluczy zablokowana"
 msgid "List of supported sites"
 msgstr "Lista obsługiwanych stron internetowych"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Zaloguj"
 
@@ -226,25 +226,25 @@ msgstr "Zaloguj"
 msgid "Matrix Chat"
 msgstr "Czat Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Najwyższa jakość"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Adres URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nazwa (pusta)"
 
@@ -254,8 +254,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nie"
 
@@ -273,14 +273,14 @@ msgstr "Żadne pobieranie nie jest uruchomione"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Hasło"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Hasło (puste)"
 
@@ -288,7 +288,7 @@ msgstr "Hasło (puste)"
 msgid "Play"
 msgstr "Odtwórz"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Playlista"
 
@@ -300,34 +300,34 @@ msgstr "Przygotowanie..."
 msgid "Processing..."
 msgstr "Przetwarzanie..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Reset"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Zresetować listę kluczy?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Uruchom program ponownie, aby odblokować listę kluczy."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Folder docelowy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Folder docelowy (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Wybierz folder docelowy"
 
@@ -343,12 +343,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Niektóre procesy pobierania zostały zakończone z błędami!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Początek"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Początek (błędne dane)"
 
@@ -356,12 +356,12 @@ msgstr "Początek (błędne dane)"
 msgid "Stopped"
 msgstr "Zatrzymano"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Języki napisów (oddzielone przecinkami)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Języki napisów (błędne dane)"
 
@@ -380,11 +380,11 @@ msgstr ""
 "naruszyć lokalne prawa autorskie lub DMCA. Użytkownicy używają tej aplikacji "
 "na własne ryzyko."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "To działanie jest nieodwracalne. Czy na pewno chcesz usunąć te dane?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -396,11 +396,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Nie można wyłączyć listy kluczy."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Nie można zresetować listy kluczy."
 
@@ -415,35 +415,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Odblokuj listę kluczy"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Adres URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Wprowadź ręcznie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nazwa użytkownika (pusta)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Sprawdź"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Wideo"
 
@@ -452,13 +452,13 @@ msgstr "Wideo"
 msgid "Waiting..."
 msgstr "Oczekiwanie..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Najgorsza"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Tak"
 
@@ -488,63 +488,59 @@ msgid "Audio Language"
 msgstr "Język dźwięku"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Napisy"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Pobieranie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Brak"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Wybierz by pobrać lub zmienić nazwy plików."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numeruj tytuły"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Pobierz"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Odznacz wszystko"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limit prędkości pobierania"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Zapisuj rozdziały w plikach"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Przytnij miniaturę"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Pobierz określony fragment"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -554,11 +550,11 @@ msgstr ""
 "Włączenie tej opcji spowoduje, że narzędzie do pobierania aria2 zostanie "
 "wyłączone."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Pozostaw puste, aby pobrać od początku."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Pozostaw puste, aby pobrać do końca."
 
@@ -818,17 +814,19 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Informacje o ciasteczkach"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informacje o kodzie języka"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Strony internetowe używają zarówno dwuliterowych, jak i trzyliterowych kodów "
 "języka. Na przykład, dla języka angielskiego są to \"en\" i \"eng\".\n"
@@ -836,15 +834,15 @@ msgstr ""
 "Aby uzyskać najlepsze wyniki, należy podać zarówno dwuliterowe, jak i "
 "trzyliterowe kody wybranych języków."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Adres URL serwera proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Ciasteczka"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -852,15 +850,15 @@ msgstr ""
 "Ciasteczko może zostać udostępnione yt-dlp, aby umożliwić pobieranie plików "
 "dostępnych po zalogowaniu."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Wyczyść ciasteczka"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informacje o ciasteczkach"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -869,15 +867,15 @@ msgstr ""
 "ciasteczka (pliki cookie) z przeglądarki za pomocą następujących rozszerzeń "
 "(używasz na własne ryzyko):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konwersja"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Nie zezwalaj na konwersję"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -887,15 +885,15 @@ msgstr ""
 "wybranej jakości bez przeprowadzania konwersji na inne formaty. (Nie będzie "
 "można wybrać formatu pliku)."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Zapisuj metadane w plikach"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Przycinaj miniatury plików audio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -903,7 +901,17 @@ msgstr ""
 "Po włączeniu, Parabolic będzie automatycznie przycinał miniatury pobieranych "
 "plików audio."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Zapisuj rozdziały w plikach"
 
@@ -1004,6 +1012,13 @@ msgstr "- Obsługuje pobieranie wielu plików jednocześnie"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Obsługuje pobieranie metadanych i napisów do wideo"
+
+#~ msgid "Subtitle"
+#~ msgstr "Napisy"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Brak"
 
 #~ msgid "Set Password"
 #~ msgstr "Ustaw hasło"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" teve o seu download concluído."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" finalizou com um erro!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Pode ser alterado nas preferências)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "Download: {0} — {1:f1}% ({2})"
 msgstr[1] "Downloads: {0} — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} de {1} item"
 msgstr[1] "{0} de {1} itens"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Adicionar Download"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opções avançadas"
 
@@ -85,12 +85,12 @@ msgstr "Opções avançadas"
 msgid "All downloads have finished."
 msgstr "Todos os downloads foram finalizados."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Áudio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Melhor"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Padrão"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
@@ -134,11 +134,11 @@ msgstr "Download finalizado com erro"
 msgid "Download log was copied to clipboard."
 msgstr "O registro de download foi copiado para a área de transferência."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "O download utilizando aria2 foi inciado"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "O download utilizando FFmpeg foi inciado"
 
@@ -162,16 +162,16 @@ msgstr "Baixando {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloads Finished"
 msgstr "Downloads concluídos"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Fim"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Fim (inválido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Certifique-se de que as credenciais estão corretas."
 
@@ -179,12 +179,12 @@ msgstr "Certifique-se de que as credenciais estão corretas."
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "O arquivo já existe e a substituição não é permitida"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Chaveiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Chaveiro bloqueado"
 
@@ -214,8 +214,8 @@ msgstr "Chaveiro bloqueado"
 msgid "List of supported sites"
 msgstr "Lista de sites suportados"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Login"
 
@@ -223,25 +223,25 @@ msgstr "Login"
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Qualidade máxima"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL da mídia"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL de vídeo (inválida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Nome (vazio)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Não"
 
@@ -270,14 +270,14 @@ msgstr "Nenhum download em andamento"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Senha"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Senha (vazia)"
 
@@ -285,7 +285,7 @@ msgstr "Senha (vazia)"
 msgid "Play"
 msgstr "Reproduzir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Playlist"
 
@@ -297,34 +297,34 @@ msgstr "Preparando..."
 msgid "Processing..."
 msgstr "Processando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Redefinir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Redefinir o chaveiro?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Inicie novamente o app para desbloquear o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Pasta de destino"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Pasta de destino (Inválida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Selecione o arquivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Selecione a pasta de destino"
 
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Alguns downloads terminaram com erros!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Início"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Início (Inválido)"
 
@@ -354,12 +354,12 @@ msgstr "Início (Inválido)"
 msgid "Stopped"
 msgstr "Parado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Idiomas das legendas (separados por vírgulas)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Idiomas das legendas (inválido)"
 
@@ -377,11 +377,11 @@ msgstr ""
 "indevido deste programa que possa violar as leis locais de direitos autorais/"
 "DMCA. Os usuários usam este aplicativo por sua própria conta e risco."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Essa ação é irreversível. Tem certeza de que deseja excluí-lo?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -393,11 +393,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Lun3wi <lun3witch@gmail.com>"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Não foi possível redefinir o chaveiro."
 
@@ -412,35 +412,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (inválida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Utilizar outra credencial manualmente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Nome de usuário (vazio)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Vídeo"
 
@@ -449,13 +449,13 @@ msgstr "Vídeo"
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Pior"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Sim"
 
@@ -485,63 +485,59 @@ msgid "Audio Language"
 msgstr "Idioma do áudio"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Legenda"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Gerenciador de downloads"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Nenhum"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 "Selecione os itens que deseja fazer download ou altere os nomes dos arquivos."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numerar os títulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Baixar"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Selecionar todos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Desmarcar todos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite de velocidade"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividir capítulos"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divide o vídeo em vários vídeos menores com base nos capítulos."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cortar miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Cria miniaturas quadradas, útil ao fazer download de músicas."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Baixar trecho específico"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "Ao habilitar essa opção, você desabilitará o uso do aria2 como gerenciador "
 "de downloads, se ele estiver habilitado."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Deixe em branco para fazer o download do início."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Deixe em branco para fazer o download até o fim."
 
@@ -815,17 +811,19 @@ msgstr "Usar SponsorBlock para o YouTube"
 msgid "SponsorBlock Information"
 msgstr "Informações sobre o SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Informações sobre o código do idioma"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Alguns sites utilizam códigos de idioma de duas letras, enquanto outros "
 "utilizam códigos de três letras. Por exemplo, \"en\" e \"eng\" são usados "
@@ -834,15 +832,15 @@ msgstr ""
 "Para obter os melhores resultados, especifique códigos de duas e três letras "
 "para seus idiomas."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "URL da Proxy"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Aquivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -850,15 +848,15 @@ msgstr ""
 "Um arquivo de cookies pode ser fornecido ao yt-dlp para permitir o download "
 "de arquivos de mídia que exijam um login."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Limpar arquivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Informações sobre arquivo de cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -867,15 +865,15 @@ msgstr ""
 "Exporte os cookies de seu navegador usando as seguintes extensões (use por "
 "sua própria conta e risco):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Conversor"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Não permitir conversões"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -885,15 +883,15 @@ msgstr ""
 "para a qualidade selecionada. (Não será possível selecionar um formato do "
 "arquivo)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Incorporar Metadados"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Cortar miniaturas para áudio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -901,7 +899,17 @@ msgstr ""
 "Se ativado, o Parabolic irá cortar automaticamente as miniaturas para "
 "downloads de áudio"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Incorporar capítulos"
 
@@ -1002,6 +1010,13 @@ msgstr "— Execute vários downloads ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta o download de metadados e legendas"
+
+#~ msgid "Subtitle"
+#~ msgstr "Legenda"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Nenhum"
 
 #~ msgid "Set Password"
 #~ msgstr "Definir senha"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" terminou de ser transferido."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" terminou com um erro!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Configurável nas preferências)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} transferência — {1:f1}% ({2})"
 msgstr[1] "{0} transferências — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} de {1} itens"
 msgstr[1] "{0} de {1} itens"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Adicionar Transferência"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opções Avançadas"
 
@@ -85,12 +85,12 @@ msgstr "Opções Avançadas"
 msgid "All downloads have finished."
 msgstr "Terminaram todas as transferências."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Melhor"
 
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -138,11 +138,11 @@ msgstr "Transferência Terminada com Erro"
 msgid "Download log was copied to clipboard."
 msgstr "O Histórico de transferências for copiado para o clipboard."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Transferência a usar aria2 iniciou-se"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 #, fuzzy
 msgid "Download using ffmpeg has started"
 msgstr "Transferência a usar aria2 iniciou-se"
@@ -167,17 +167,17 @@ msgstr "A transferir {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Transferências Terminadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "URL da Media (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -185,11 +185,11 @@ msgstr ""
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "O ficheiro já existe, e a sobrescrita não é permitida"
 
@@ -205,13 +205,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -219,8 +219,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "Lista de sítios suportados"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -228,26 +228,26 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Qualidade Máxima"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL da Media"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL da Media (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "Nome do Ficheiro"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -257,8 +257,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Não"
 
@@ -276,14 +276,14 @@ msgstr "Não há transferências a decorrer"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Play"
 msgstr "Playlist"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Playlist"
 
@@ -304,34 +304,34 @@ msgstr "A preparar..."
 msgid "Processing..."
 msgstr "A processar..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Pasta de Destino"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Selecione Ficheiro de Cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Selecione Pasta de Destino"
 
@@ -349,12 +349,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Algumas transferências terminaram com erros!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
@@ -363,12 +363,12 @@ msgstr "Pasta de Destino (Inválida)"
 msgid "Stopped"
 msgstr "Parado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
@@ -389,11 +389,11 @@ msgstr ""
 "autor/DMCA. Os utilizadores usam esta aplicação por sua própria conta e "
 "risco."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -403,11 +403,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Ricardo Simões https://xmcorporation.com"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -422,38 +422,38 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "URL da Media (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
 msgid "Username"
 msgstr "Interface do Utilizador"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "Interface do Utilizador"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -462,13 +462,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "À espera..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Pior"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Sim"
 
@@ -499,75 +499,71 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Legenda"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Descarregador"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Nenhuma"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selecione itens para transferir ou altere os nomes dos ficheiros."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "Títulos de Números"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Transferência"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "Parar Tudo"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite de Velocidade"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cortar Miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Tornar miniatura quadrada, útil ao transferir músicas."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -823,28 +819,29 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Ficheiros de Cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Ficheiros de Cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -852,16 +849,16 @@ msgstr ""
 "Um ficheiro de cookies pode ser fornecido ao yt-dlp para permitir "
 "descarregar media que requer um login."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Limpar Ficheiro de Cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 #, fuzzy
 msgid "Cookies File Information"
 msgstr "Ficheiros de Cookies"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -870,15 +867,15 @@ msgstr ""
 "Exporte os cookies do seu navegador usando as seguintes extensões (use por "
 "sua própria conta e risco):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Converter"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Não Permitir Conversões"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 #, fuzzy
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
@@ -889,22 +886,32 @@ msgstr ""
 "apropriado para a qualidade selecionada sem converter para outros formatos. "
 "(Não poderá selecionar um formato de ficheiro)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Incorporar Metadados"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 #, fuzzy
 msgid "Crop Audio Thumbnails"
 msgstr "Cortar Miniatura"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -1005,6 +1012,13 @@ msgstr "— Corre múltiplas transferências ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta transferência de metadados e legendas de vídeo"
+
+#~ msgid "Subtitle"
+#~ msgstr "Legenda"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Nenhuma"
 
 #, fuzzy
 #~ msgid "Unable to unlock keyring. Restart the app to try again."

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -30,7 +30,7 @@ msgstr "\"{0}\" загружено."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершилось с ошибкой!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Изменяется в настройках)"
 
@@ -44,7 +44,7 @@ msgstr "{0:f1} Б/с"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} ГиБ/с"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -63,8 +63,8 @@ msgstr[0] "{0} загрузка — {1:f1}% ({2})"
 msgstr[1] "{0} загрузки — {1:f1}% ({2})"
 msgstr[2] "{0} загрузок — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -72,15 +72,15 @@ msgstr[0] "{0} из {1} элемента"
 msgstr[1] "{0} из {1} элементов"
 msgstr[2] "{0} из {1} элементов"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Добавить загрузку"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Дополнительные опции"
 
@@ -88,12 +88,12 @@ msgstr "Дополнительные опции"
 msgid "All downloads have finished."
 msgstr "Все загрузки завершены."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Аудио"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Лучшее"
 
@@ -117,7 +117,7 @@ msgstr "Давид Лапшин"
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
@@ -137,11 +137,11 @@ msgstr "Загрузка завершилась с ошибкой"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал загрузки скопирован в буфер обмена."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Началась загрузка с помощью aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Началась загрузка с помощью ffmpeg"
 
@@ -165,16 +165,16 @@ msgstr "Загрузка {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Загрузки завершены"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Время конца"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Время конца (Некорректное)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Убедитесь, что данные корректны."
 
@@ -182,12 +182,12 @@ msgstr "Убедитесь, что данные корректны."
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Невозможно отключить связку ключей."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Файл уже существует, а перезапись файлов не разрешена"
 
@@ -203,13 +203,13 @@ msgstr "Фёдор Соболев"
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Связка ключей"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Связка ключей заблокирована"
 
@@ -217,8 +217,8 @@ msgstr "Связка ключей заблокирована"
 msgid "List of supported sites"
 msgstr "Список поддерживаемых сайтов"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Учётные данные"
 
@@ -226,25 +226,25 @@ msgstr "Учётные данные"
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Максимальное качество"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Ссылка"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Имя"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Имя (пустое)"
 
@@ -254,8 +254,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Нет"
 
@@ -273,14 +273,14 @@ msgstr "Ничего не загружается"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Пароль"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Пароль (пустой)"
 
@@ -288,7 +288,7 @@ msgstr "Пароль (пустой)"
 msgid "Play"
 msgstr "Играть"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Плейлист"
 
@@ -300,34 +300,34 @@ msgstr "Подготовка..."
 msgid "Processing..."
 msgstr "Обработка..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Сбросить"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Сбросить связку ключей?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Перезапустите приложение для разблокировки связки ключей."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Папка сохранения"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Папка сохранения (Некорректная)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Выберите файл куки"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Выберите папку загрузки"
 
@@ -343,12 +343,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Некоторые загрузки завершились с ошибкой!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Время начала"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Время начала (Некорректное)"
 
@@ -356,12 +356,12 @@ msgstr "Время начала (Некорректное)"
 msgid "Stopped"
 msgstr "Остановлено"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Языки субтитров (Разделённые запятой)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Языки субтитров (Некорректные)"
 
@@ -379,11 +379,11 @@ msgstr ""
 "использование программы, которое может нарушать местные законы об авторском "
 "праве или DMCA. Пользователи используют это приложение на свой страх и риск."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Это действие необратимо. Вы уверены, что хотите удалить?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -395,11 +395,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Фёдор Соболев https://github.com/fsobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Невозможно отключить связку ключей."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Невозможно сбросить связку ключей."
 
@@ -414,35 +414,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Разблокировать связку ключей"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Ссылка"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Ввести данные вручную"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Имя пользователя (пустое)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Проверить"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Видео"
 
@@ -451,13 +451,13 @@ msgstr "Видео"
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Худшее"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Да"
 
@@ -487,62 +487,58 @@ msgid "Audio Language"
 msgstr "Язык аудио"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Субтитры"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Загрузчик"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Нет"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Выберите элементы для загрузки или смените имена файлов."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Пронумеровать заголовки"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Загрузка"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Выбрать всё"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Убрать всё"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Ограничение скорости"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Разделить по главам"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Разделить видео на несколько частей согласно оглавлению."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Обрезать миниатюру"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Сделать миниатюру квадратной, полезно при скачивании музыки."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Скачать фрагмент"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "Возможна неточная обрезка видео.\n"
 "При включении этой опции не будет использоваться загрузчик aria2."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Оставьте пустым, чтобы скачать с начала."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Оставьте пустым, чтобы скачать до конца."
 
@@ -812,17 +808,19 @@ msgstr "Использовать SponsorBlock для YouTube"
 msgid "SponsorBlock Information"
 msgstr "Информация о SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Информация о языковых кодах"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Некоторые сайты используют двух-символьные языковые коды, тогда как другие "
 "используют трёх-символьные. Например, \"ru\" и \"rus\" для русского языка.\n"
@@ -830,15 +828,15 @@ msgstr ""
 "Пожалуйста, указывайте оба варианта для необходимых языков, для достижения "
 "наилучшего результата."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Адрес прокси-сервера"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Файл куки"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -846,15 +844,15 @@ msgstr ""
 "Можно предоставить файл куки для yt-dlp, чтобы скачивать медиа, которые "
 "требуют входа на сайт."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Очистить файл куки"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Информация о файле куки"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -862,15 +860,15 @@ msgstr ""
 "Куки могут быть переданы yt-dlp в форме файла TXT. Экспортируйте куки из "
 "браузера, используя следующие расширения (используйте на свой страх и риск):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Конвертер"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Отключить конвертирование"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -880,15 +878,15 @@ msgstr ""
 "наиболее подходящем под заданное качество формате без конвертирования. (Вы "
 "не сможете выбрать формат файла)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Встраивать метаданные"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Обрезать миниатюры для аудио"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -896,7 +894,17 @@ msgstr ""
 "Если включено, Parabolic будет автоматически активировать обрезку миниатюр "
 "для аудио загрузок"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Встраивать главы"
 
@@ -997,6 +1005,13 @@ msgstr "— Запускайте несколько загрузок однов�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Возможно скачать метаданные и субтитры к видео"
+
+#~ msgid "Subtitle"
+#~ msgstr "Субтитры"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Нет"
 
 #~ msgid "Set Password"
 #~ msgstr "Установить пароль"

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-03 17:56+0000\n"
 "Last-Translator: micke <micke@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "{0} har laddats ned."
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} har avslutat med ett fel!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Konfigurerbar i inställningarna)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "Nedladdning: {0} — {1:f1}% ({2})"
 msgstr[1] "Nedladdningar: {0} — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} av {1} objekt"
 msgstr[1] "{0} av {1} objekt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Lägg till nedladdning"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Avancerade inställningar"
 
@@ -85,12 +85,12 @@ msgstr "Avancerade inställningar"
 msgid "All downloads have finished."
 msgstr "Alla nedladdningar är klara."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Ljud"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Bäst"
 
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -135,11 +135,11 @@ msgstr "Nedladdningen slutfördes med fel"
 msgid "Download log was copied to clipboard."
 msgstr "Nedladdningsloggen kopierades till urklipp."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Nedladdning med aria2 har startat"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Nedladdning med ffmpeg har startat"
 
@@ -163,16 +163,16 @@ msgstr "Laddar ned {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Nedladdningar klara"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Sluttidpunkt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Sluttidpunkt (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -180,11 +180,11 @@ msgstr ""
 msgid "Error"
 msgstr "Fel"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Filen finns redan och överskrivning är inte tillåten"
 
@@ -200,13 +200,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Nyckelring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 #, fuzzy
 msgid "Keyring locked"
 msgstr "Nyckelring"
@@ -215,8 +215,8 @@ msgstr "Nyckelring"
 msgid "List of supported sites"
 msgstr "Lista över webbplatser som stöds"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -224,26 +224,26 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr "Matrix-chatt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Högsta kvalitet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Media-URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Media-URL (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "Filnamn"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -253,8 +253,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Nej"
 
@@ -272,14 +272,14 @@ msgstr "Inga nedladdningar körs"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Lösenord"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "Play"
 msgstr "Spellista"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Spellista"
 
@@ -300,35 +300,35 @@ msgstr "Förbereder..."
 msgid "Processing..."
 msgstr "Bearbetar..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Nyckelring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Lagringsmapp"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Lagringsmapp (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Välj cookies-fil"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Välj lagringsmapp"
 
@@ -346,12 +346,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Vissa nedladdningar avslutades med fel!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Starttidpunkt"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "starttidpunkt (ogiltig)"
 
@@ -359,12 +359,12 @@ msgstr "starttidpunkt (ogiltig)"
 msgid "Stopped"
 msgstr "Stoppad"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "starttidpunkt (ogiltig)"
@@ -384,11 +384,11 @@ msgstr ""
 "detta program som kan bryta mot lokala upphovsrättslagar/DMCA-lagar. "
 "Användare använder detta program på egen risk."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -398,11 +398,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "Micke"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -416,36 +416,36 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Media-URL (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Användarnamn"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Användarnamn (tom)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validera"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -454,13 +454,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Sämst"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Ja"
 
@@ -490,64 +490,60 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Undertext"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Nedladdare"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Ingen"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Välj objekt att ladda ned eller ändra filnamn."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "Numrera namn"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Ladda ned"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "Stoppa alla nedladdningar"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hastighetsbegränsning"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Beskär miniatyrbild"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Gör miniatyrbilden fyrkantig, användbart när du laddar ner musik."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Ladda ner specifik tidsram"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 #, fuzzy
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -557,11 +553,11 @@ msgstr ""
 "Om du aktiverar det här alternativet inaktiveras användningen av aria2 som "
 "nedladdare om det är aktiverat."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Lämna tomt för att ladda ned från början."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Lämna tomt för att ladda ned till slutet."
 
@@ -817,78 +813,89 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Konverterare"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Bädda in metadata"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 #, fuzzy
 msgid "Crop Audio Thumbnails"
 msgstr "Beskär miniatyrbild"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -989,6 +996,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "Undertext"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Ingen"
 
 #, fuzzy
 #~ msgid "Unable to unlock keyring. Restart the app to try again."

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" வின் பதிவிறக்கம் முடிந�
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" பிழையுடன் முடிந்தது!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(விருப்பங்களில் கட்டமைக்கக்கூடியது)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} பைட்டுகள்/வினாடி (B/s)"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} ஜிபிபைட்/வினாடி (GiB/s)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} பதிவிறக்கம் — {1:f1}% ({2})"
 msgstr[1] "{0} பதிவிறக்கங்கள் — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{1} இல் {0} உருப்படிகள்"
 msgstr[1] "{1} இல் {0} உருப்படிகள்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "பதிவிறக்கத்தைச் சேர்க்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "மேம்பட்ட விருப்பங்கள்"
 
@@ -85,12 +85,12 @@ msgstr "மேம்பட்ட விருப்பங்கள்"
 msgid "All downloads have finished."
 msgstr "அனைத்து பதிவிறக்கங்களும் முடிந்துவிட்டன."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "ஒலி அமைவு"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "சிறந்த"
 
@@ -114,7 +114,7 @@ msgstr "டேவிட் லாப்ஷின்"
 msgid "Default"
 msgstr "இயல்புநிலை"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
@@ -134,11 +134,11 @@ msgstr "பதிவிறக்கம் பிழையுடன் முட�
 msgid "Download log was copied to clipboard."
 msgstr "பதிவிறக்கப் பதிவு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "aria2 ஐப் பயன்படுத்தி பதிவிறக்கம் தொடங்கப்பட்டது"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg ஐப் பயன்படுத்தி பதிவிறக்கம் தொடங்கப்பட்டது"
 
@@ -162,16 +162,16 @@ msgstr "பதிவிறக்குகிறது {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "பதிவிறக்கங்கள் முடிந்தது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "முடிவு நேரம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "முடிவு நேரம் (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "சான்றுகள் சரியானவை என்பதை உறுதிப்படுத்தவும்."
 
@@ -179,12 +179,12 @@ msgstr "சான்றுகள் சரியானவை என்பதை 
 msgid "Error"
 msgstr "பிழை"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "சாவி வலயத்தை முடக்க முடியவில்லை."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "கோப்பு ஏற்கனவே உள்ளது, மேலெழுத அனுமதிக்கப்படவில்லை"
 
@@ -200,13 +200,13 @@ msgstr "ஃபியோடர் சோபோலேவ்"
 msgid "GitHub Repo"
 msgstr "GitHub களஞ்சியம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "சாவி வளையம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "சாவி வளையம் பூட்டப்பட்டது"
 
@@ -214,8 +214,8 @@ msgstr "சாவி வளையம் பூட்டப்பட்டது"
 msgid "List of supported sites"
 msgstr "ஆதரிக்கப்படும் தளங்களின் பட்டியல்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "உள்நுழை"
 
@@ -223,25 +223,25 @@ msgstr "உள்நுழை"
 msgid "Matrix Chat"
 msgstr "மேட்ரிக்ஸ் மன்றம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "அதிகபட்ச தரம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "ஊடகத்தின் URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "ஊடகத்தின் URL (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "பெயர்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "பெயர் (காலி)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "நிக்கோலஸ் லோகோசோ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "இல்லை"
 
@@ -270,14 +270,14 @@ msgstr "பதிவிறக்கங்கள் எதுவும் இய�
 msgid "Parabolic"
 msgstr "பரபோலிக்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "கடவுச்சொல்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "கடவுச்சொல் (காலி)"
 
@@ -285,7 +285,7 @@ msgstr "கடவுச்சொல் (காலி)"
 msgid "Play"
 msgstr "தொடங்கு"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "பாடல் பட்டியல்"
 
@@ -297,34 +297,34 @@ msgstr "தயாராகிறது..."
 msgid "Processing..."
 msgstr "செயலாக்குகிறது..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "மீட்டமைக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "சாவி வளையத்தை மீட்டமைக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "சாவி வலயத்தை திறக்க, பயன்பாட்டை மறுதொடக்கம் செய்யவும்."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "கோப்புறையை சேமி"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "கோப்புறையைச் சேமி (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "குக்கீகள் கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "சேமி கோப்புறையை தேர்ந்தெடுக்கவும்"
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "சில பதிவிறக்கங்கள் பிழைகளுடன் முடிந்தது!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "ஆரம்பிக்கும் நேரம்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "தொடக்க நேரம் (செல்லாதது)"
 
@@ -353,12 +353,12 @@ msgstr "தொடக்க நேரம் (செல்லாதது)"
 msgid "Stopped"
 msgstr "நிறுத்தப்பட்டது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "வசன மொழிகள் (கமாவால் பிரிக்கப்பட்டவை)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "வசன மொழிகள் (செல்லாதது)"
 
@@ -376,11 +376,11 @@ msgstr ""
 "நிக்விஷன் பரபோலிக் இன் ஆசிரியர்கள் பொறுப்பல்ல/பொறுப்பேற்க மாட்டார்கள். பயனர்கள் இந்த "
 "பயன்பாட்டை தங்கள் சொந்த ஆபத்தில் பயன்படுத்துகின்றனர்."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "இந்த நடவடிக்கை மீள முடியாதது. நிச்சயமாக அதை நீக்க வேண்டுமா?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -392,11 +392,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>, 2023"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "சாவி வலயத்தை முடக்க முடியவில்லை."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "சாவி வலயத்தை மீட்டமைக்க முடியவில்லை."
 
@@ -409,35 +409,35 @@ msgstr "சார்புகளை அமைக்க முடியவில�
 msgid "Unlock Keyring"
 msgstr "சாவி வளையத்தைத் திறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "கைமுறை நற்சான்றிதழைப் பயன்படுத்தவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "பயனர் பெயர்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "பயனர் பெயர் (காலி)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "சரிபார்க்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "காணொளி"
 
@@ -446,13 +446,13 @@ msgstr "காணொளி"
 msgid "Waiting..."
 msgstr "காத்திருக்கிறது..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "மோசமான"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "ஆம்"
 
@@ -482,62 +482,58 @@ msgid "Audio Language"
 msgstr "ஒலி மொழி"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "வசனம்"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "பதிவிறக்குபவர்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "எதுவும் இல்லை"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "கோப்புப் பெயர்களைப் பதிவிறக்க அல்லது மாற்ற உருப்படிகளைத் தேர்ந்தெடுக்கவும்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "எண் தலைப்புகள்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "பதிவிறக்கு"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "அனைத்தையும் தெரிவுசெய்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "அனைத்து தெரிவுகளையும் நிராகரி"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "வேக வரம்பு"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "அத்தியாயங்களைப் பிரிக்கவும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "காணொளியை அதன் அத்தியாயங்களின் அடிப்படையில் பல சிறியதாகப் பிரிக்கிறது."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "சிறுபடத்தை வெட்டவும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "இசை பதிவிறக்கம் செய்யும் போது உபயோகமான சிறுபடவுரு சதுரத்தை உருவாக்கவும்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "குறிப்பிட்ட காலக்கெடுவைப் பதிவிறக்கவும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -547,11 +543,11 @@ msgstr ""
 "இந்த விருப்பத்தை இயக்குவது, அது இயக்கப்பட்டிருந்தால், பதிவிறக்கியாக aria2 ஐப் "
 "பயன்படுத்துவது முடக்கப்படும்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "தொடக்கத்தில் இருந்து பதிவிறக்கம் செய்ய காலியாக விடவும்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "இறுதிவரை பதிவிறக்கம் செய்ய காலியாக விடவும்."
 
@@ -809,17 +805,19 @@ msgstr "YouTubeக்கு SponsorBlock ஐப் பயன்படுத்�
 msgid "SponsorBlock Information"
 msgstr "SponsorBlock தகவல்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "மொழி குறியீடு தகவல்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "சில தளங்கள் இரண்டெழுத்து மொழிக் குறியீடுகளைப் பயன்படுத்துகின்றன, மற்றவை மூன்றெழுத்துகளைப் "
 "பயன்படுத்துகின்றன. எடுத்துக்காட்டாக, \"en\" மற்றும் \"eng\" இரண்டும் ஆங்கிலத்திற்குப் "
@@ -828,15 +826,15 @@ msgstr ""
 "சிறந்த முடிவுகளுக்கு உங்கள் மொழிகளுக்கான இரண்டு எழுத்து மற்றும் மூன்றெழுத்து குறியீடுகள் "
 "இரண்டையும் குறிப்பிடவும்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "ப்ராக்ஸி URL"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "குக்கீகள் கோப்பு"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -844,15 +842,15 @@ msgstr ""
 "உள்நுழைவு தேவைப்படும் மீடியாவைப் பதிவிறக்க அனுமதிக்க குக்கீகள் கோப்பு yt-dlp க்கு "
 "வழங்கப்படலாம்."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "குக்கீகள் கோப்பை அழிக்கவும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "குக்கீகள் கோப்பு தகவல்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -861,15 +859,15 @@ msgstr ""
 "பயன்படுத்தி உங்கள் உலாவியில் இருந்து குக்கீகளை ஏற்றுமதி செய்யவும் (உங்கள் சொந்த ஆபத்தில் "
 "பயன்படுத்தவும்):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "மாற்றி"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "மாற்றங்களை அனுமதிக்காதே"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -879,15 +877,15 @@ msgstr ""
 "ஆடியோ வடிவமைப்பை பரபோலிக் பதிவிறக்கும். (நீங்கள் ஒரு கோப்பு வடிவமைப்பைத் தேர்ந்தெடுக்க "
 "முடியாது)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "மெட்டாடேட்டாவை உட்பொதிக்கவும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "ஒலி அமைப்பு சிறுபடங்களை செதுக்கு"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -895,7 +893,17 @@ msgstr ""
 "இயக்கப்பட்டால், பரபோலிக் ஒலி அமைப்பு பதிவிறக்கங்களுக்கான செதுக்கப்பட்ட சிறுபட மேம்பட்ட "
 "விருப்பத்தை தானாகவே இயக்கும்"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "அத்தியாயங்களை உட்பொதிக்கவும்"
 
@@ -996,6 +1004,13 @@ msgstr "- ஒரே நேரத்தில் பல பதிவிறக்�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— மெட்டாடேட்டா மற்றும் காணொளி வசனங்களைப் பதிவிறக்குவதை ஆதரிக்கிறது"
+
+#~ msgid "Subtitle"
+#~ msgstr "வசனம்"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "எதுவும் இல்லை"
 
 #~ msgid "Set Password"
 #~ msgstr "கடவுச்சொல்லை அமைக்கவும்"

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" indirmeyi tamamladı."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" bir hatayla tamamlandı!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Tercihlerden yapılandırılabilir)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "İndirmeler: {0} — %{1:f1} ({2})"
 msgstr[1] "İndirmeler: {0} — %{1:f1} ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} / {1} öge"
 msgstr[1] "{0} / {1} öge"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "İndirme Ekle"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Gelişmiş Seçenekler"
 
@@ -85,12 +85,12 @@ msgstr "Gelişmiş Seçenekler"
 msgid "All downloads have finished."
 msgstr "Tüm indirmeler tamamlandı."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Ses"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "En İyi"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "Öntanımlı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
@@ -134,11 +134,11 @@ msgstr "İndirme Hata İle Tamamlandı"
 msgid "Download log was copied to clipboard."
 msgstr "İndirme günlüğü panoya kopyalandı."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Aria2 kullanarak indirme işlemi başladı"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg kullanarak indirme işlemi başladı"
 
@@ -162,16 +162,16 @@ msgstr "İndiriliyor %{0:f2} ({1})"
 msgid "Downloads Finished"
 msgstr "İndirmeler Tamamlandı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Bitiş Zamanı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Bitiş Zamanı (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Kimlik bilgilerinin doğru olduğundan emin olun."
 
@@ -179,12 +179,12 @@ msgstr "Kimlik bilgilerinin doğru olduğundan emin olun."
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Anahtarlık devre dışı bırakılamadı."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Dosya zaten var ve üzerine yazılmasına izin verilmiyor"
 
@@ -200,13 +200,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Anahtarlık"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Anahtarlık kilitli"
 
@@ -214,8 +214,8 @@ msgstr "Anahtarlık kilitli"
 msgid "List of supported sites"
 msgstr "Desteklenen sitelerin listesi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Giriş"
 
@@ -223,25 +223,25 @@ msgstr "Giriş"
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Azami Kalite"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Ortam URLʼsi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Ortam URLʼsi (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Ad"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Ad (Boş)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Hayır"
 
@@ -270,14 +270,14 @@ msgstr "Çalışan indirme yok"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Parola"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Parola (Boş)"
 
@@ -285,7 +285,7 @@ msgstr "Parola (Boş)"
 msgid "Play"
 msgstr "Oynat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
@@ -297,34 +297,34 @@ msgstr "Hazırlanıyor..."
 msgid "Processing..."
 msgstr "İşleniyor..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Anahtarlık Sıfırlansın Mı?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Anahtarlığı sıfırlamak için uygulamayı yeniden başlatın."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Kayıt Klasörü"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Kayıt Klasörü (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Çerez Dosyasını Seç"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Kayıt Klasörünü Seçin"
 
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Bazı indirmeler hatalarla tamamlandı!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Başlangıç Zamanı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Başlangıç Zamanı (Geçersiz)"
 
@@ -354,12 +354,12 @@ msgstr "Başlangıç Zamanı (Geçersiz)"
 msgid "Stopped"
 msgstr "Durduruldu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Altyazı Dilleri (Virgülle Ayrılmış)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Altyazı Dilleri (Geçersiz)"
 
@@ -378,11 +378,11 @@ msgstr ""
 "değildir. Kullanıcılar bu uygulamayı riski kendilerine ait olmak üzere "
 "kullanırlar."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Bu işlem geri alınamaz. Silmek istediğinizden emin misiniz?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -396,11 +396,11 @@ msgstr ""
 "Sabri Ünal <libreajans@gmail.com>\n"
 "Anonim Weblate Çevirmenleri"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Anahtarlık devre dışı bırakılamadı."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Anahtarlık sıfırlanamadı."
 
@@ -415,35 +415,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Anahtarlık Kilidini Aç"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "El ile kimlik bilgisi kullan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Kullanıcı adı (Boş)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Doğrula"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Video"
 
@@ -452,13 +452,13 @@ msgstr "Video"
 msgid "Waiting..."
 msgstr "Bekliyor..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "En Kötü"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Evet"
 
@@ -488,62 +488,58 @@ msgid "Audio Language"
 msgstr "Ses Dili"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Alt Yazı"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "İndirici"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Hiçbiri"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "İndirmek veya dosya adlarını değiştirmek için ögeleri seçin."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Başlıkları Numaralandır"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "İndir"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Tüm Seçimi Kaldır"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hız Sınırı"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Bölümleri Ayır"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Videoyu bölümlerine göre birden çok küçük parçaya böler."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Küçük Resmi Kırp"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Küçük resmi kare yap, müzik indirirken kullanışlıdır."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Belirli Zaman Dilimini İndir"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -553,11 +549,11 @@ msgstr ""
 "Bu seçeneğin etkinleştirilmesi, etkinleştirilmişse indirici olarak aria2'nin "
 "kullanımını devre dışı bırakır."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Başlangıçtan indirmek için boş bırakın."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Sonuna kadar indirmek için boş bırakın."
 
@@ -817,17 +813,19 @@ msgstr "YouTube için SponsorBlock kullan"
 msgid "SponsorBlock Information"
 msgstr "SponsorBlock Bilgileri"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Dil Kodu Bilgisi"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Bazı siteler iki harfli dil kodları kullanırken, diğerleri üç harfli dil "
 "kodları kullanır. Örneğin, \"en\" ve \"eng\" İngilizce için kullanılır.\n"
@@ -835,15 +833,15 @@ msgstr ""
 "En iyi sonuçları elde etmek için lütfen dilleriniz için hem iki harfli hem "
 "de üç harfli kodlar belirtin."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Proxy URLʼsi"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Çerez Dosyası"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -851,15 +849,15 @@ msgstr ""
 "Oturum açma gerektiren ortamın indirilmesine izin vermek için yt-dlp'ye bir "
 "çerez dosyası sağlanabilir."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Çerez Dosyasını Temizle"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Çerez Dosyası Bilgileri"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -868,15 +866,15 @@ msgstr ""
 "uzantıları kullanarak tarayıcınızdan çerezleri dışa aktarabilir (riski size "
 "ait olmak üzere) kullanabilirsiniz:"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Dönüştürücü"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Dönüşümlere İzin Verme"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -885,15 +883,15 @@ msgstr ""
 "Etkinleştirilirse, Parabolic diğer biçimlere dönüştürmeden seçilen kalite "
 "için uygun video/ses biçimini indirecektir. (Bir dosya biçimi seçemezsiniz)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Üst Verileri Göm"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Ses Küçük Resimlerini Kırp"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -901,7 +899,17 @@ msgstr ""
 "Etkinleştirilirse, Parabolic ses indirmeleri için gelişmiş küçük resim "
 "kırpma seçeneğini kendiliğinden açacaktır"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Bölümleri Göm"
 
@@ -1004,6 +1012,13 @@ msgstr "— Aynı anda birden fazla indirme çalıştırın"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Üst veri ve video altyazı indirmeyi destekler"
+
+#~ msgid "Subtitle"
+#~ msgstr "Alt Yazı"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
 
 #~ msgid "Set Password"
 #~ msgstr "Parola Ayarla"

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -30,7 +30,7 @@ msgstr "\"{0}\" завершено завантаження."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершився з помилкою!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Налаштовується в параметрах)"
 
@@ -44,7 +44,7 @@ msgstr "{0:f1} Б/с"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} ГіБ/с"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -63,8 +63,8 @@ msgstr[0] "{0} завантаження - {1:f1}% ({2})"
 msgstr[1] "{0} завантаження - {1:f1}% ({2})"
 msgstr[2] "{0} завантажень - {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -72,15 +72,15 @@ msgstr[0] "{0} з {1} елемента"
 msgstr[1] "{0} з {1} елементів"
 msgstr[2] "{0} з {1} елементів"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Додати завантаження"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Додаткові параметри"
 
@@ -88,12 +88,12 @@ msgstr "Додаткові параметри"
 msgid "All downloads have finished."
 msgstr "Всі завантаження завершено."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Аудіо"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Найкраще"
 
@@ -119,7 +119,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "За замовчуванням"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
@@ -139,11 +139,11 @@ msgstr "Завантаження завершено з помилкою"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал завантажень скопійовано до буфера обміну."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Розпочато завантаження за допомогою aria2"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Розпочато завантаження за допомогою ffmpeg"
 
@@ -167,16 +167,16 @@ msgstr "Завантаження {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "Завантаження завершені"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Час закінчення"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Час закінчення (неправильний)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "Переконайтеся, що облікові дані правильні."
 
@@ -184,12 +184,12 @@ msgstr "Переконайтеся, що облікові дані правил�
 msgid "Error"
 msgstr "Помилка"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Неможливо вимкнути keyring."
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Файл вже існує, і його перезапис заборонено"
 
@@ -205,13 +205,13 @@ msgstr "Fyodor Sobolev"
 msgid "GitHub Repo"
 msgstr "Репозиторій GitHub"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "Keyring заблоковано"
 
@@ -219,8 +219,8 @@ msgstr "Keyring заблоковано"
 msgid "List of supported sites"
 msgstr "Список підтримуваних сайтів"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "Логін"
 
@@ -228,25 +228,25 @@ msgstr "Логін"
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Максимальна якість"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL-адреса медіа"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "URL-адреса медіа (неправильна)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Ім'я"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Ім'я (Порожньо)"
 
@@ -256,8 +256,8 @@ msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Ні"
 
@@ -275,14 +275,14 @@ msgstr "Немає завантажень"
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Пароль"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Пароль (Порожньо)"
 
@@ -290,7 +290,7 @@ msgstr "Пароль (Порожньо)"
 msgid "Play"
 msgstr "Відтворити"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Список відтворення"
 
@@ -302,34 +302,34 @@ msgstr "Підготовка..."
 msgid "Processing..."
 msgstr "Обробка..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "Скинути"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "Скинути Keyring?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "Перезапустіть застосунок, щоб розблокувати keyring."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Зберегти теку"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Зберегти папку (неправильно)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Виберіть файл cookies"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Натисніть \"Зберегти папку\""
 
@@ -345,12 +345,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Деякі завантаження завершено з помилками!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Час початку"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Час початку (неправильний)"
 
@@ -358,12 +358,12 @@ msgstr "Час початку (неправильний)"
 msgid "Stopped"
 msgstr "Зупинено"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "Мови субтитрів (через кому)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "Мови субтитрів (неправильні)"
 
@@ -382,11 +382,11 @@ msgstr ""
 "закони про авторське право/DMCA. Користувачі використовують цей застосунок "
 "на власний ризик."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Ця дія є незворотною. Ви впевнені, що хочете його видалити?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -400,11 +400,11 @@ msgstr ""
 "kefir2105\n"
 "denqwerta@gmail.com"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "Неможливо вимкнути keyring."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "Не вдалося скинути keyring."
 
@@ -419,35 +419,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Розблокувати Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "URL (Неправильна)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Використання облікових даних вручну"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Ім'я користувача (Порожнє)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Підтвердити"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Відео"
 
@@ -456,13 +456,13 @@ msgstr "Відео"
 msgid "Waiting..."
 msgstr "Очікування..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Найгірше"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Так"
 
@@ -492,62 +492,58 @@ msgid "Audio Language"
 msgstr "Мова аудіо"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Субтитри"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "Завантажувач"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Немає"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Виберіть елементи для завантаження або зміни назв файлів."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Пронумерувати заголовки"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Завантаження"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Вибрати все"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Зняти все"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Обмеження швидкості"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Розділити розділи"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Розділяє відео на кілька менших на основі його розділів."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Обрізати мініатюру"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Зробіть мініатюру квадратною, корисно при завантаженні музики."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Завантажити конкретний часовий проміжок"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -557,11 +553,11 @@ msgstr ""
 "Ввімкнення цієї опції вимкне використання aria2 як завантажувача, якщо він "
 "ввімкнений."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Залиште порожнім, щоб завантажити з самого початку."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Залиште поле порожнім, щоб завантаження завершилося."
 
@@ -818,17 +814,19 @@ msgstr "Використовувати SponsorBlock для YouTube"
 msgid "SponsorBlock Information"
 msgstr "Інформація про SponsorBlock"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "Інформація про мовний код"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "Деякі сайти використовують двобуквені мовні коди, тоді як інші - трибуквені. "
 "Наприклад, \"en\" та \"eng\" використовуються для англійської мови.\n"
@@ -836,15 +834,15 @@ msgstr ""
 "Будь ласка, вказуйте як двобуквені, так і трибуквені коди для ваших мов, щоб "
 "отримати найкращі результати."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "Проксі URL"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Файл cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -852,15 +850,15 @@ msgstr ""
 "Файл cookies може бути наданий yt-dlp, щоб дозволити завантажувати медіа, "
 "які потребують входу."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Очистити файл cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "Інформація про файл cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -869,15 +867,15 @@ msgstr ""
 "файли cookie з вашого браузера за допомогою наступних розширень "
 "(використовуйте на свій страх і ризик):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Конвертер"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Заборонити конвертацію"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -887,15 +885,15 @@ msgstr ""
 "вибраної якості без конвертації в інші формати. (Ви не зможете вибрати "
 "формат файлу)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Вставити метадані"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Обрізати мініатюри аудіо"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -903,7 +901,17 @@ msgstr ""
 "Якщо ввімкнено, Parabolic автоматично вмикає розширену опцію мініатюр для "
 "завантаження аудіо"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Вставити розділи"
 
@@ -1006,6 +1014,13 @@ msgstr "- Запуск декількох завантажень одночас�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Підтримує завантаження метаданих і субтитрів до відео"
+
+#~ msgid "Subtitle"
+#~ msgstr "Субтитри"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Немає"
 
 #~ msgid "Set Password"
 #~ msgstr "Встановити пароль"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-08-12 17:19+0000\n"
 "Last-Translator: duckienome <xvchattw@duck.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -29,7 +29,7 @@ msgstr "{0} کا ڈاؤن لوڈ مکمل کر لیا ہے۔"
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} ایک خرابی کے ساتھ ختم ہو گیا ہے!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "ترجیحات میں قابل ترتیب"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,23 +61,23 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "ڈاؤن لوڈ : {0} — {1:f1}%{{2}}"
 msgstr[1] "ڈاؤن لوڈز : {0} — {1:f1}%{{2}}"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} میں سے {1} چیز"
 msgstr[1] "{0} میں سے {1} چیزیں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "نئی ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "اعلی درجے کے اختیارات"
 
@@ -85,12 +85,12 @@ msgstr "اعلی درجے کے اختیارات"
 msgid "All downloads have finished."
 msgstr "تمام ڈاؤن لوڈز مکمل ہو چکے ہیں۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "آڈیو"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "بہترین"
 
@@ -114,7 +114,7 @@ msgstr "David Lapshin"
 msgid "Default"
 msgstr "طے شدہ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "اسناد کو حذف کریں؟"
 
@@ -134,11 +134,11 @@ msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 msgid "Download log was copied to clipboard."
 msgstr "ڈاؤن لوڈ لاگ کو کلپ بورڈ پر کاپی کرلیاگیا۔"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "aria2 کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہو گیا ہے"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہو گیا ہے"
 
@@ -162,16 +162,16 @@ msgstr "ڈاؤن لوڈ ہو رہا ہے {0:f2}% ({1})"
 msgid "Downloads Finished"
 msgstr "ڈاؤن لوڈز مکمل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "اختتامی وقت"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "اختتامی وقت (غلط)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr "یقینی بنائیں کہ اسناد درست ہیں."
 
@@ -179,12 +179,12 @@ msgstr "یقینی بنائیں کہ اسناد درست ہیں."
 msgid "Error"
 msgstr "خرابی"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "فائل پہلے سے موجود ہے، اور دوبارہ لکھنے کی اجازت نہیں ہے"
 
@@ -200,13 +200,13 @@ msgstr "فیوڈور سوبولیف"
 msgid "GitHub Repo"
 msgstr "گٹ ہب رجسٹر(ریپوسٹری)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "کیڑیگ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr "کیرنگ مقفل ہے"
 
@@ -214,8 +214,8 @@ msgstr "کیرنگ مقفل ہے"
 msgid "List of supported sites"
 msgstr "ہم آہنگ سائٹس کی فہرست"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr "لاگ ان"
 
@@ -223,25 +223,25 @@ msgstr "لاگ ان"
 msgid "Matrix Chat"
 msgstr "میٹرکس چیٹ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "اعلیٰ ترین معیار"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "میڈیا یو-آر-ایل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "میڈیا یو-آر-ایل (غلط)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "نام"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "نام (خالی)"
 
@@ -251,8 +251,8 @@ msgid "Nicholas Logozzo"
 msgstr "نکولس لوگوزو"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "نہیں"
 
@@ -270,14 +270,14 @@ msgstr "کوئی ڈاؤن لوڈ نہیں چل رہی ہے"
 msgid "Parabolic"
 msgstr "پیرابولک"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "پاس ورڈ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "پاس ورڈ (خالی)"
 
@@ -285,7 +285,7 @@ msgstr "پاس ورڈ (خالی)"
 msgid "Play"
 msgstr "چلاؤ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "پلے لیٹ"
 
@@ -297,34 +297,34 @@ msgstr "تیاری چل رہی ہے..."
 msgid "Processing..."
 msgstr "عمل کر رہے ہیں ..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr "دوبارہ ترتیب دیں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr "کی رینگ کو دوبارہ ترتیب کریں؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr "کیرنگ کو غیر مقفل کرنے کے لیے ایپ کو دوبارہ شروع کریں۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "فولڈر محفوظ کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "محفوظہ فولڈر (غلط)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "کوکیز فائل کو منتخب کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "مطلوبہ جگہ فراہم کریں"
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "کچھ ڈاؤن لوڈز خرابیوں کے ساتھ ختم ہو گئے!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "ابتدائی وقت"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "ابتدائی وقت (غلط)"
 
@@ -353,12 +353,12 @@ msgstr "ابتدائی وقت (غلط)"
 msgid "Stopped"
 msgstr "رک گیا"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr "سب ٹایٹل کی زبانیں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 msgid "Subtitle Languages (Invalid)"
 msgstr "سب ٹائٹل کی زبانیں (غلط)"
 
@@ -376,12 +376,12 @@ msgstr ""
 "دار نہیں ہیں جو مقامی کاپی رائٹ/DMCA قوانین کی خلاف ورزی کر سکتا ہے۔ صارفین "
 "اس ایپلی کیشن کو اپنی ذمہ داری پر استعمال کرتے ہیں۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "اس عمل کر بعد کوئی واپسی نہیں ہے۔ کیا آپ اسے یقینی طور پر کرنا چاہتے ہیں؟"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -393,11 +393,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr "مترجم کی خدمات کا اعتراف"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr "کیرنگ کو دوبارہ ترتیب دینے سے قاصر۔"
 
@@ -412,35 +412,35 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "کی ڑینگ کو کھولیں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "یو-آر-ایل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr "یو-آر-ایل (غلط)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "دستی اسناد کا استعمال کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "صارف کا نام"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "صارف کا نام (خالی)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "توثیق کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "ویڈیو"
 
@@ -449,13 +449,13 @@ msgstr "ویڈیو"
 msgid "Waiting..."
 msgstr "منتظر..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "بدتر"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "ہاں"
 
@@ -485,63 +485,59 @@ msgid "Audio Language"
 msgstr "آڈیو کی زبان"
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "سب ٹائٹل"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "ڈاؤن لوڈر"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "کچھ نہیں"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "ڈاؤن لوڈ کرنے یا نام بدلنے کے لیے چیزیں منتخب کریں-"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "نمبر ٹائٹلز"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "ڈاؤن لوڈ کریں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "تمام چیزوں کو چنیں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "تمام چیزوں کو نہ چنیں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "رفتار کی حد"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "ابواب کو شامل کریں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "تھمب نیل کو تراشیں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "تھمب نیل مربع بنائیں، موسیقی ڈاؤن لوڈ کرتے وقت کارآمد۔"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "مخصوص ٹائم فریم ڈاؤن لوڈ کریں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
@@ -551,11 +547,11 @@ msgstr ""
 "اس اختیار کو فعال کرنے سے ڈاؤن لوڈر کے طور پر aria2 کا استعمال غیر فعال ہو "
 "جائے گا۔"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "شروع سے ڈاؤن لوڈ کرنے کے لیے خالی چھوڑ دیں۔"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "آخر تک ڈاؤن لوڈ کرنے کے لیے خالی چھوڑ دیں۔"
 
@@ -813,17 +809,19 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "کوکیز فائل کی معلومات"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr "زبان کے کوڈ کی معلومات"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
+#, fuzzy
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 "کچھ سائٹیں دو حرفی زبان کے کوڈ استعمال کرتی ہیں، جبکہ دیگر تین حرفی استعمال "
 "کرتی ہیں۔ مثال کے طور پر، \"en\" اور \"eng\" دونوں انگریزی کے لیے استعمال "
@@ -832,15 +830,15 @@ msgstr ""
 "بہترین نتائج کے لیے براہ کرم اپنی زبانوں کے لیے دو حرفی اور تین حرفی کوڈز کی "
 "وضاحت کریں۔"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr "پراکسی یو-آر-ایل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "کوکیز فائل"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -848,15 +846,15 @@ msgstr ""
 "ایک کوکیز فائل yt-dlp کو فراہم کی جا سکتی ہے تاکہ میڈیا کو ڈاؤن لوڈ کرنے کی "
 "اجازت دی جا سکے جس کے لیے لاگ ان کی ضرورت ہوتی ہے۔"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "کوکیز فائل کو صاف کریں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 msgid "Cookies File Information"
 msgstr "کوکیز فائل کی معلومات"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -865,15 +863,15 @@ msgstr ""
 "ایکسٹینشنز کا استعمال کرتے ہوئے اپنے براؤزر سے کوکیز برآمد کریں (اپنے ذمہ "
 "داری پر استعمال کریں):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "تبدیل کرنے والے"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "تبادلوں کی اجازت نہ دیں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
@@ -883,15 +881,15 @@ msgstr ""
 "لیے مناسب ویڈیو/آڈیو فارمیٹ ڈاؤن لوڈ کرے گا۔ (آپ فائل فارمیٹ کو منتخب کرنے "
 "سے قاصر ہوں گے)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "میٹا ڈیٹا شامل کریں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "آڈیو تھمب نیلز کو تراشیں"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
@@ -899,7 +897,17 @@ msgstr ""
 "اگر فعال ہو تو، پیرابولک آڈیو ڈاؤن لوڈز کے لیے کراپ تھمب نیل ایڈوانس آپشن کو "
 "خود بخود آن کر دے گا"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "ابواب کو شامل کریں"
 
@@ -1000,6 +1008,13 @@ msgstr "- ایک وقت میں متعدد ڈاؤن لوڈز چلائیں"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- میٹا ڈیٹا اور ویڈیو سب ٹائٹلز کو ڈاؤن لوڈ کرنے کی معرفت رکھتا ہے"
+
+#~ msgid "Subtitle"
+#~ msgstr "سب ٹائٹل"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "کچھ نہیں"
 
 #~ msgid "Set Password"
 #~ msgstr "پاس ورڈ لگائیں"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -29,7 +29,7 @@ msgstr "\"{0}\" đã được hoàn thành."
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" đã kết thúc với lỗi!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr "(Có thể thay đổi trong tùy thích)"
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -60,22 +60,22 @@ msgid "{0} download — {1:f1}% ({2})"
 msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] "{0} tải xuống — {1:f1}% ({2})"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] "{0} trên {1} mục"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
 msgid "Add Download"
 msgstr "Thêm Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Tùy chọn Nâng cao"
 
@@ -83,12 +83,12 @@ msgstr "Tùy chọn Nâng cao"
 msgid "All downloads have finished."
 msgstr "Tất cả tải xuống đều đã hoàn thành."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "Âm thanh"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr "Tốt nhất"
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Default"
 msgstr "Mặc định"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
@@ -133,11 +133,11 @@ msgstr "Tải xuống kết thúc với lỗi"
 msgid "Download log was copied to clipboard."
 msgstr "Nhật ký tải xuống đã được lưu vào bảng ghi tạm."
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "Tải xuống bằng aria2 đã bắt đầu"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 msgid "Download using ffmpeg has started"
 msgstr "Tải xuống bằng ffmpeg đã bắt đầu"
 
@@ -161,16 +161,16 @@ msgstr "Đang tải về {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloads Finished"
 msgstr "Hoàn thành Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Thời điểm Kết thúc"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 msgid "End Time (Invalid)"
 msgstr "Thời điểm Kết thúc (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 #, fuzzy
 msgid "Ensure credentials are correct."
 msgstr "Quản lý credentials trong keyring của bạn."
@@ -179,12 +179,12 @@ msgstr "Quản lý credentials trong keyring của bạn."
 msgid "Error"
 msgstr "Lỗi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 #, fuzzy
 msgid "Failed to enable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "Tệp đã tồn tại, ghi đè không được cho phép"
 
@@ -200,13 +200,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 #, fuzzy
 msgid "Keyring locked"
 msgstr "Chứng chỉ Keyring"
@@ -215,8 +215,8 @@ msgstr "Chứng chỉ Keyring"
 msgid "List of supported sites"
 msgstr "Danh sách các trang được hỗ trợ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -224,25 +224,25 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "Chất lượng Tối đa"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Địa chỉ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Tên"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr "Tên (Trống)"
 
@@ -252,8 +252,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr "Không"
 
@@ -271,14 +271,14 @@ msgstr "Không có tải xuống nào đang chạy"
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr "Mật khẩu (Trống)"
 
@@ -287,7 +287,7 @@ msgstr "Mật khẩu (Trống)"
 msgid "Play"
 msgstr "Danh sách phát"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "Danh sách phát"
 
@@ -299,35 +299,35 @@ msgstr "Đang chuẩn bị..."
 msgid "Processing..."
 msgstr "Đang xử lý..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Thiết lập Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Thư mục Lưu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "Thư mục Lưu (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "Chọn Tệp Cookie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Chọn Thư mục Lưu"
 
@@ -344,12 +344,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Một số tải xuống kết thúc với lỗi!"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Thời điểm Bắt đầu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 msgid "Start Time (Invalid)"
 msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 
@@ -357,12 +357,12 @@ msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 msgid "Stopped"
 msgstr "Đã dừng"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
@@ -382,11 +382,11 @@ msgstr ""
 "với mọi hành vi lạm dụng chương trình này mà có thể vi phạm luật bản quyền "
 "hoặc luật DMCA sở tại. Người dùng tự chịu rủi ro khi sử dụng ứng dụng này."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Hành động này không thể đảo ngược. Bạn chắc chắn muốn xóa nó chứ?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -396,12 +396,12 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -416,36 +416,36 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr "Mở khóa Keyring"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Địa chỉ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr "Dùng chứng chỉ thủ công"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Tên tài khoản"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 msgid "Username (Empty)"
 msgstr "Tên tài khoản (Trống)"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Xác thực"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "Băng hình"
 
@@ -454,13 +454,13 @@ msgstr "Băng hình"
 msgid "Waiting..."
 msgstr "Đang chờ..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "Tệ nhất"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr "Có"
 
@@ -490,76 +490,71 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "Phụ đề"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
 #, fuzzy
-msgctxt "Subtitle"
-msgid "None"
-msgstr "Không"
+msgid "Download Subtitle"
+msgstr "Trình tải xuống"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Chọn mục để tải xuống hoặc đổi tên tệp."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Đánh số Tiêu đề"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "Tải xuống"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "Dừng Tất cả"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Giới hạn Tốc độ"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Nhúng Chương"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cắt Thumbnail"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Làm thumbnail vuông, hữu ích khi tải nhạc."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Tải Khung thời gian Cụ thể"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Để trống để tải xuống từ đầu."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr "Để trống để tải xuống đến cuối."
 
@@ -818,28 +813,29 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Tệp Cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 msgid "Cookies File"
 msgstr "Tệp Cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
@@ -847,16 +843,16 @@ msgstr ""
 "Một tệp cookie có thể được cung cấp cho yt-dlp để tải những phương tiện "
 "truyền thông có yêu cầu đăng nhập."
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr "Xóa Tệp Cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 #, fuzzy
 msgid "Cookies File Information"
 msgstr "Tệp Cookie"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
@@ -864,15 +860,15 @@ msgstr ""
 "Cookie có thể được chuyển cho yt-dlp dưới dạng tệp TXT. Xuất Cookie từ trình "
 "duyệt bằng những phần mở rộng sau (bạn tự chịu mọi rủi ro):"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr "Bộ chuyển đổi"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr "Không cho phép Chuyển đổi"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 #, fuzzy
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
@@ -883,15 +879,15 @@ msgstr ""
 "chất lượng được chọn mà không chuyển đổi sang định dạng khác. (Bạn sẽ không "
 "thể chọn định dạng của tệp)"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "Nhúng Siêu dữ liệu"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 msgid "Crop Audio Thumbnails"
 msgstr "Cắt Thumbnail Âm thanh"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 #, fuzzy
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
@@ -900,7 +896,17 @@ msgstr ""
 "Nếu bật, Tube Converter sẽ tự động bật các lựa chọn cắt thumbnail nâng cao "
 "dành cho âm thanh được tải xuống"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr "Nhúng Chương"
 
@@ -1003,6 +1009,14 @@ msgstr "— Chạy nhiều tải xuống cùng một lúc"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Hỗ trợ tải về siêu dữ liệu và phụ đề"
+
+#~ msgid "Subtitle"
+#~ msgstr "Phụ đề"
+
+#, fuzzy
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "Không"
 
 #, fuzzy
 #~ msgid "Set Password"

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 23:17-0400\n"
+"POT-Creation-Date: 2023-09-11 01:21+0300\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -43,7 +43,7 @@ msgstr "{0:f1} B/s"
 msgid "{0:f1} GiB/s"
 msgstr "{0:f1} GiB/s"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:235
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:237
 #: ../../../Helpers/SpeedFormatter.cs:28
 #, csharp-format
 msgid "{0:f1} KiB/s"
@@ -61,15 +61,15 @@ msgid_plural "{0} downloads — {1:f1}% ({2})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:430
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:538
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:432
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:540
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -77,8 +77,8 @@ msgstr[1] ""
 msgid "Add Download"
 msgstr "添加下载"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:157
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:100
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "高级选项"
 
@@ -86,12 +86,12 @@ msgstr "高级选项"
 msgid "All downloads have finished."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:387
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:389
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Audio"
 msgstr "音频"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Best"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "Delete Credential?"
 msgstr ""
 
@@ -136,11 +136,11 @@ msgstr "下载完成，但出现错误"
 msgid "Download log was copied to clipboard."
 msgstr "下载日志已复制到剪贴板。"
 
-#: ../../../Models/Download.cs:370
+#: ../../../Models/Download.cs:388
 msgid "Download using aria2 has started"
 msgstr "使用 aria2 的下载已经开始"
 
-#: ../../../Models/Download.cs:381
+#: ../../../Models/Download.cs:399
 #, fuzzy
 msgid "Download using ffmpeg has started"
 msgstr "使用 aria2 的下载已经开始"
@@ -165,17 +165,17 @@ msgstr ""
 msgid "Downloads Finished"
 msgstr "已完成的下载"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:338
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:461
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:479
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:481
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "保存文件夹（无效）"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:378
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:380
 msgid "Ensure credentials are correct."
 msgstr ""
 
@@ -183,11 +183,11 @@ msgstr ""
 msgid "Error"
 msgstr "错误"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:73
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:72
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../Models/Download.cs:189
+#: ../../../Models/Download.cs:181
 msgid "File already exists, and overwriting is disallowed"
 msgstr "文件已经存在，且不允许覆盖"
 
@@ -203,13 +203,13 @@ msgstr ""
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:137
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:136
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:41
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:90
 msgid "Keyring locked"
 msgstr ""
 
@@ -217,8 +217,8 @@ msgstr ""
 msgid "List of supported sites"
 msgstr "支持的网站列表"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:181
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:199
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:180
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:198
 msgid "Login"
 msgstr ""
 
@@ -226,26 +226,26 @@ msgstr ""
 msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:431
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:433
 msgid "Maximum Quality"
 msgstr "最高质量"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:370
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:377
 msgid "Media URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:217
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:216
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "文件名"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:227
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:226
 msgid "Name (Empty)"
 msgstr ""
 
@@ -255,8 +255,8 @@ msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:251
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:314
 msgid "No"
 msgstr ""
 
@@ -274,14 +274,14 @@ msgstr ""
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:222
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
 msgid "Password"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:233
 msgid "Password (Empty)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Play"
 msgstr "播放列表"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:99
 msgid "Playlist"
 msgstr "播放列表"
 
@@ -302,34 +302,34 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:92
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:91
 msgid "Reset"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid "Reset Keyring?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:95
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:94
 msgid "Restart the app to unlock the keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:143
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "保存文件夹"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:469
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:471
 msgid "Save Folder (Invalid)"
 msgstr "保存文件夹（无效）"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:197
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:305
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:203
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:304
 msgid "Select Cookies File"
 msgstr "选择 Cookie 文件"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:512
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:150
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:514
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "选择保存文件夹"
 
@@ -346,12 +346,12 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:333
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:459
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:474
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:476
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "保存文件夹（无效）"
@@ -360,12 +360,12 @@ msgstr "保存文件夹（无效）"
 msgid "Stopped"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:172
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:179
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:245
 msgid "Subtitle Languages (Comma-Separated)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:182
+#: ../../../../NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs:188
 #, fuzzy
 msgid "Subtitle Languages (Invalid)"
 msgstr "保存文件夹（无效）"
@@ -384,11 +384,11 @@ msgstr ""
 "Nickvision Tube Converter 的作者对任何可能违反当地版权/DMCA 法律的滥用本程序"
 "的行为概不负责。用户使用本程序的风险由他们自己承担。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:312
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:250
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:249
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -398,11 +398,11 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:285
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:267
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:266
 msgid "Unable to reset keyring."
 msgstr ""
 
@@ -415,37 +415,37 @@ msgstr ""
 msgid "Unlock Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:218
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:239
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:238
 msgid "URL (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:304
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:306
 msgid "Use manual credential"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:220
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
 msgid "Username"
 msgstr "用户界面"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:232
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:231
 #, fuzzy
 msgid "Username (Empty)"
 msgstr "用户界面"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:371
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:373
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "验证"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:400
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:402
 msgid "Video"
 msgstr "视频"
 
@@ -454,13 +454,13 @@ msgstr "视频"
 msgid "Waiting..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:84
+#: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:85
 msgid "Worst"
 msgstr "最差"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:279
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:255
-#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
+#: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 msgid "Yes"
 msgstr ""
 
@@ -491,74 +491,70 @@ msgid "Audio Language"
 msgstr ""
 
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
-msgid "Subtitle"
-msgstr "字幕"
+#, fuzzy
+msgid "Download Subtitle"
+msgstr "下载器"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:133
-msgctxt "Subtitle"
-msgid "None"
-msgstr "无"
-
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:180
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "选择要下载的项目或更改文件名。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:192
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:226
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:205
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:14
 msgid "Download"
 msgstr "下载"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:244
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
 msgstr "全部停止"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:251
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:292
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:303
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:304
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "裁剪缩略图"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:316
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "使缩略图成正方形，在下载音乐时很有用。"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:327
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:328
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
 "Enabling this option will disable the use of aria2 as the downloader if it "
 "is enabled."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:334
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:339
+#: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:342
 msgid "Leave empty to download to end."
 msgstr ""
 
@@ -813,80 +809,91 @@ msgstr ""
 msgid "SponsorBlock Information"
 msgstr "Cookie 文件"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:258
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:257
 msgid "Language Code Information"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:273
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:272
 msgid ""
-"Some sites use two-letter language codes, whereas others use three-letter. "
-"For example, \"en\" and \"eng\" are both used for English.\n"
+"Different sites can use different language code formats for the same "
+"language. You may encounter one of the following three types: two-letter, "
+"two-letter with region, or three-letter. For example, \"en\", \"en-US\" and "
+"\"eng\" are all used for English.\n"
 "\n"
-"Please specify both two-letter and three-letter codes for your languages for "
-"the best results."
+"Please specify all valid codes for your languages for the best results."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:284
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:283
 msgid "Proxy URL"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:292
 #, fuzzy
 msgid "Cookies File"
 msgstr "Cookie 文件"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:294
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:293
 msgid ""
 "A cookies file can be provided to yt-dlp to allow downloading media that "
 "requires a login."
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:315
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:314
 msgid "Clear Cookies File"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:325
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:324
 #, fuzzy
 msgid "Cookies File Information"
 msgstr "Cookie 文件"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:340
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:339
 msgid ""
 "Cookies can be passed to yt-dlp in the form of TXT files. Export cookies "
 "from your browser using the following extensions (use at your own risk):"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:377
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:376
 msgid "Converter"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:379
 msgid "Disallow Conversions"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:381
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:380
 msgid ""
 "If enabled, Parabolic will download the appropriate video/audio format for "
 "the selected quality without converting to other formats. (You will be "
 "unable to select a file format)"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:396
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:395
 msgid "Embed Metadata"
 msgstr "嵌入元数据"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:404
 #, fuzzy
 msgid "Crop Audio Thumbnails"
 msgstr "裁剪缩略图"
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:406
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:405
 msgid ""
 "If enabled, Parabolic will automatically turn on the crop thumbnail advanced "
 "option for audio downloads"
 msgstr ""
 
-#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:422
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:420
+msgid "Remove data about media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:421
+msgid ""
+"Clear metadata fields containing URL and another data that can lead to the "
+"media source"
+msgstr ""
+
+#: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:437
 msgid "Embed Chapters"
 msgstr ""
 
@@ -990,6 +997,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#~ msgid "Subtitle"
+#~ msgstr "字幕"
+
+#~ msgctxt "Subtitle"
+#~ msgid "None"
+#~ msgstr "无"
 
 #, fuzzy
 #~ msgid "Open"


### PR DESCRIPTION
- Closes #568
  No, the option to download only subtitles wasn't added, but instead now there's no format selection, it's chosen by the app to ensure subtitle will be embedded (SRT for MP4 and VTT for WEBM). The state of "Download Subtitle" switch is now also saved to help users who always download video with subtitles.
- Closes #572
  Two-letter codes with region are now supported. Can be tested with [this video](https://www.youtube.com/watch?v=Y-rmzh0PI3c) and `pt-BR` language code.
  Also I removed apply button in the entry, it's a bit confusing and doesn't really serve any purpose: we will save configuration on window closing anyway, no need to save it at some other point.
- Closes #574
  `ffprobe` output for the video linked in the issue:
  ```
  Input #0, matroska,webm, from 'Ваш топинамбур.webm':
  Metadata:
    title           : Ваш топинамбур
    ARTIST          : Первый образовательный телеканал
    track           : 0
    DATE            : 20210615
    ENCODER         : Lavf60.3.100
  ```
  You can see ARTIST is now in Russian.
  This is done by finding current culture's name or two-letter code in a hardcoded list of youtube's supported languages. We have to do this, because giving unsupported language code causes yt-dlp to fail, even with `ignoreerrors`.
- Closes #576
  A switch was added to preferences:
  ![image](https://github.com/NickvisionApps/Parabolic/assets/117388856/3e52eb96-224c-4ab9-89e5-f503bfa3fd25)
  Off by default. I also noticed there was `handler_name` field in streams' metadata containing info about Google in case of youtube videos, so this is now cleared too.