### PR TITLE
Use Aura in DependencyManager + Fix arte support

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ "main", "aura" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
     types: [ "review_requested", "ready_for_review" ]

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "aura" ]
   pull_request:
     branches: [ "main" ]
     types: [ "review_requested", "ready_for_review" ]
@@ -13,10 +13,6 @@ jobs:
   snap:
     name: "GNOME on Snap"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [x86_64]
-      fail-fast: false
     steps:
       - name: Checkout Git repository
         uses: actions/checkout@v3

--- a/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
+++ b/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.9.3" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.9.4" />
     <PackageReference Include="Nickvision.GirExt" Version="2023.7.3" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.GNOME/nuget-sources.json
+++ b/NickvisionTubeConverter.GNOME/nuget-sources.json
@@ -155,10 +155,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.9.3/nickvision.aura.2023.9.3.nupkg",
-    "sha512": "4f2d37373baf8a86ab30ddb5aea90e0ce905cb660cc1978a10d59c422d5f501227bcdf492fa57bfe853eabb5fc6248ae20ab933ec1dd1d773bb54088f329a5ca",
+    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.9.4/nickvision.aura.2023.9.4.nupkg",
+    "sha512": "aaa593da2f1f23c391dad72d1a4e69a4d88d132211f31e6be8d25a6bb76df492eda05c640be1d97d2b0153af106998a1cd32ba48f668af61d1f4ea291c5902b6",
     "dest": "nuget-sources",
-    "dest-filename": "nickvision.aura.2023.9.3.nupkg"
+    "dest-filename": "nickvision.aura.2023.9.4.nupkg"
   },
   {
     "type": "file",

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -74,19 +74,19 @@ internal static class DependencyManager
     {
         try
         {
-                var process = new Process
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "python3",
-                        Arguments = "-c \"import sysconfig; import os; print(('/snap/tube-converter/current/gnome-platform' if os.environ.get('SNAP') else '') + ('/'.join(sysconfig.get_config_vars('LIBDIR', 'INSTSONAME'))))\"",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true
-                    }
-                };
-                process.Start();
-                Runtime.PythonDLL = process.StandardOutput.ReadToEnd().Trim();
-                process.WaitForExit();
+                    FileName = "python3",
+                    Arguments = "-c \"import sysconfig; import os; print(('/snap/tube-converter/current/gnome-platform' if os.environ.get('SNAP') else '') + ('/'.join(sysconfig.get_config_vars('LIBDIR', 'INSTSONAME'))))\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true
+                }
+            };
+            process.Start();
+            Runtime.PythonDLL = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
             // Install yt-dlp plugin
             var pluginPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}yt-dlp{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}tubeconverter{Path.DirectorySeparatorChar}yt_dlp_plugins{Path.DirectorySeparatorChar}postprocessor{Path.DirectorySeparatorChar}tubeconverter.py";
             Directory.CreateDirectory(pluginPath.Substring(0, pluginPath.LastIndexOf(Path.DirectorySeparatorChar)));

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using Nickvision.Aura;
 namespace NickvisionTubeConverter.Shared.Helpers;
 
 internal static class DependencyManager
@@ -14,22 +15,16 @@ internal static class DependencyManager
     public static string PythonPath
     {
         get
-        {
-            var prefixes = new List<string>() {
-                Directory.GetParent(Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName)!.FullName,
-                Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName,
-                "/usr",
-                "snap/tube-converter/current/usr"
-            };
-            foreach (var prefix in prefixes)
+        { 
+            foreach (var dir in SystemDirectories.Path)
             {
-                var path = $"{prefix}/bin/python3";
+                var path = $"{dir}{Path.DirectorySeparatorChar}python3";
                 if (File.Exists(path))
                 {
                     return path;
                 }
             }
-            return "python3";
+            throw new Exception("python3 not in path");
         }
     }
 
@@ -39,23 +34,16 @@ internal static class DependencyManager
     public static string FfmpegPath
     {
         get
-        {
-
-            var prefixes = new List<string>() {
-                Directory.GetParent(Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName)!.FullName,
-                Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName,
-                "/usr",
-                "snap/tube-converter/current/usr"
-            };
-            foreach (var prefix in prefixes)
+        { 
+            foreach (var dir in SystemDirectories.Path)
             {
-                var path = $"{prefix}/bin/ffmpeg";
+                var path = $"{dir}{Path.DirectorySeparatorChar}ffmpeg";
                 if (File.Exists(path))
                 {
                     return path;
                 }
             }
-            return "ffmpeg";
+            throw new Exception("ffmpeg not found in path");
         }
     }
 
@@ -66,20 +54,15 @@ internal static class DependencyManager
     {
         get
         {
-            var prefixes = new List<string>() {
-                Directory.GetParent(Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName)!.FullName,
-                Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName,
-                "/usr"
-            };
-            foreach (var prefix in prefixes)
+            foreach (var dir in SystemDirectories.Path)
             {
-                var path = $"{prefix}/bin/aria2c";
+                var path = $"{dir}{Path.DirectorySeparatorChar}aria2c";
                 if (File.Exists(path))
                 {
                     return path;
                 }
             }
-            return "aria2c";
+            throw new Exception("aria2c not found in path");
         }
     }
 
@@ -91,12 +74,6 @@ internal static class DependencyManager
     {
         try
         {
-            if (File.Exists(Environment.GetEnvironmentVariable("TC_PYTHON_SO")))
-            {
-                Runtime.PythonDLL = Environment.GetEnvironmentVariable("TC_PYTHON_SO");
-            }
-            else
-            {
                 var process = new Process
                 {
                     StartInfo = new ProcessStartInfo
@@ -110,7 +87,6 @@ internal static class DependencyManager
                 process.Start();
                 Runtime.PythonDLL = process.StandardOutput.ReadToEnd().Trim();
                 process.WaitForExit();
-            }
             // Install yt-dlp plugin
             var pluginPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}yt-dlp{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}tubeconverter{Path.DirectorySeparatorChar}yt_dlp_plugins{Path.DirectorySeparatorChar}postprocessor{Path.DirectorySeparatorChar}tubeconverter.py";
             Directory.CreateDirectory(pluginPath.Substring(0, pluginPath.LastIndexOf(Path.DirectorySeparatorChar)));

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -18,7 +18,8 @@ internal static class DependencyManager
             var prefixes = new List<string>() {
                 Directory.GetParent(Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName)!.FullName,
                 Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName,
-                "/usr"
+                "/usr",
+                "snap/tube-converter/current/usr"
             };
             foreach (var prefix in prefixes)
             {

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -79,7 +79,7 @@ internal static class DependencyManager
                     StartInfo = new ProcessStartInfo
                     {
                         FileName = "python3",
-                        Arguments = "-c \"import sysconfig; print('/'.join(sysconfig.get_config_vars('LIBDIR', 'INSTSONAME')))\"",
+                        Arguments = "-c \"import sysconfig; import os; print(('/snap/tube-converter/current/gnome-platform' if os.environ.get('SNAP') else '') + ('/'.join(sysconfig.get_config_vars('LIBDIR', 'INSTSONAME'))))\"",
                         UseShellExecute = false,
                         RedirectStandardOutput = true
                     }

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -40,10 +40,12 @@ internal static class DependencyManager
     {
         get
         {
+
             var prefixes = new List<string>() {
                 Directory.GetParent(Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName)!.FullName,
                 Directory.GetParent(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!))!.FullName,
-                "/usr"
+                "/usr",
+                "snap/tube-converter/current/usr"
             };
             foreach (var prefix in prefixes)
             {

--- a/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
+++ b/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="GetText.NET" Version="1.9.14" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.9.3" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.9.4" />
     <PackageReference Include="pythonnet" Version="3.0.2" />
   </ItemGroup>
 

--- a/flatpak/python3-modules.json
+++ b/flatpak/python3-modules.json
@@ -18,41 +18,91 @@
             ]
         },
         {
-            "name": "python3-yt-dlp",
+            "name": "python3-brotli",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"yt-dlp\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"brotli\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip",
                     "sha256": "4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"
-                },
+                }
+            ]
+        },
+        {
+            "name": "python3-certifi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"certifi\" --no-build-isolation"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/9d/19/59961b522e6757f0c9097e4493fa906031b95b3ebe9360b2c3083561a6b4/certifi-2023.5.7-py3-none-any.whl",
                     "sha256": "c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
-                },
+                }
+            ]
+        },
+        {
+            "name": "python3-mutagen",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mutagen\" --no-build-isolation"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/03/ee/114d7016d2e34f341e212fefb5e7bd87785077ebcfff0ad23a497c70eea1/mutagen-1.46.0-py3-none-any.whl",
                     "sha256": "8af0728aa2d5c3ee5a727e28d0627966641fddfe804c23eabb5926a4d770aed5"
-                },
+                }
+            ]
+        },
+        {
+            "name": "python3-pycryptodomex",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pycryptodomex\" --no-build-isolation"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/40/92/efd675dba957315d705f792b28d900bddc36f39252f6713961b4221ee9af/pycryptodomex-3.18.0.tar.gz",
                     "sha256": "3e3ecb5fe979e7c1bb0027e518340acf7ee60415d79295e5251d13c68dde576e"
-                },
+                }
+            ]
+        },
+        {
+            "name": "python3-websockets",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"websockets\" --no-build-isolation"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/d8/3b/2ed38e52eed4cf277f9df5f0463a99199a04d9e29c9e227cfafa57bd3993/websockets-11.0.3.tar.gz",
                     "sha256": "88fc51d9a26b10fc331be344f1781224a375b78488fc343620184e95a4b27016"
+                }
+            ]
+        },
+        {
+            "name": "python3-yt-dlp",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py build",
+                "python3 setup.py install --skip-build --prefix=/app --root=/"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/yt-dlp/yt-dlp",
+                    "tag": "2023.07.06"
                 },
                 {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/5c/da/ef08140cea3392288a8f6cd60f6f12510a4c5776eead53e90151f139af19/yt_dlp-2023.7.6-py2.py3-none-any.whl",
-                    "sha256": "b33b3f68751f33dd8290f1f61f7a011679b3b512aa223df3bff496688bc0bd19"
+                    "type": "patch",
+                    "path": "yt-dlp_arte.patch"
                 }
             ]
         }

--- a/flatpak/yt-dlp_arte.patch
+++ b/flatpak/yt-dlp_arte.patch
@@ -1,0 +1,13 @@
+diff --git a/yt_dlp/extractor/arte.py b/yt_dlp/extractor/arte.py
+index e3cc5afb0..a19cd2a3a 100644
+--- a/yt_dlp/extractor/arte.py
++++ b/yt_dlp/extractor/arte.py
+@@ -169,7 +169,7 @@ def _real_extract(self, url):
+                 )))
+
+             short_label = traverse_obj(stream_version, 'shortLabel', expected_type=str, default='?')
+-            if stream['protocol'].startswith('HLS'):
++            if 'HLS' in stream['protocol']:
+                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                     stream['url'], video_id=video_id, ext='mp4', m3u8_id=stream_version_code, fatal=False)
+                 for fmt in fmts:

--- a/snap/arte-tv.patch
+++ b/snap/arte-tv.patch
@@ -1,0 +1,13 @@
+diff --git a/yt_dlp/extractor/arte.py b/yt_dlp/extractor/arte.py
+index e3cc5afb0..a19cd2a3a 100644
+--- a/yt_dlp/extractor/arte.py
++++ b/yt_dlp/extractor/arte.py
+@@ -169,7 +169,7 @@ def _real_extract(self, url):
+                 )))
+ 
+             short_label = traverse_obj(stream_version, 'shortLabel', expected_type=str, default='?')
+-            if stream['protocol'].startswith('HLS'):
++            if 'HLS' in stream['protocol']:
+                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                     stream['url'], video_id=video_id, ext='mp4', m3u8_id=stream_version_code, fatal=False)
+                 for fmt in fmts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,9 @@ parts:
       - PYTHONPATH: ""
     python-packages:
       - psutil==5.9.5
+    override-pull: |
+      craftctl default
+      patch -p1 < $CRAFT_PROJECT_DIR/snap/arte-tv.patch
     prime:
       # WORKAROUND: Skip venv from python plugin
       - -usr/bin/activate

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,6 @@ parts:
       dotnet tool restore
       dotnet cake --target=Publish --prefix=/snap/tube-converter/current/usr --ui=gnome --self-contained
       dotnet cake --target=Install --destdir=$CRAFT_PART_INSTALL
-      sed -i "2 i export TC_PYTHON_SO=\$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/libpython3.10.so.1.0" $CRAFT_PART_INSTALL/snap/tube-converter/current/usr/bin/org.nickvision.tubeconverter
       mkdir -p $CRAFT_PART_INSTALL/meta/gui
       cp -r $CRAFT_PART_INSTALL/snap/tube-converter/current/usr/share/icons $CRAFT_PART_INSTALL/meta/gui/
       for i in `find $CRAFT_PART_INSTALL/meta/gui/icons -name "*.svg" -o -name "*.png"`; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -111,7 +111,6 @@ apps:
       - gnome
     common-id: org.nickvision.tubeconverter
     environment:
-      TC_PYTHON_SO: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/libpython3.10.so.1.0
       PYTHONPATH: $SNAP/usr/lib/python3.10/dist-packages:$PYTHONPATH
       PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
       LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,13 +9,6 @@ architectures:
   - build-on: arm64
   - build-on: armhf
 
-layout:
-  $SNAP/usr/bin/ffmpeg:
-    symlink: $SNAP/ffmpeg-platform/usr/bin/ffmpeg
-  $SNAP/usr/bin/ffplay:
-    symlink: $SNAP/ffmpeg-platform/usr/bin/ffplay
-  $SNAP/usr/bin/ffprobe:
-    symlink: $SNAP/ffmpeg-platform/usr/bin/ffprobe
 parts:
   yt-dlp:
     # Missing optional dependencies atomicparsley, mpv, phantomjs and rtmpdump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,7 @@ parts:
   tube-converter:
     after: [ yt-dlp ]
     plugin: nil
-    source: https://github.com/NickvisionApps/Parabolic.git
-    source-depth: 1
+    source: .
     build-packages:
       - brotli
       - blueprint-compiler


### PR DESCRIPTION
1. Uses the `PATH` environment variable to find dependencies
2. No need of layouts and environment variables in snap
3. Removed the matrix in snap workflow
4. Fix arte.tv support by applying a patch to yt-dlp (Closes #598)