### PR TITLE
URL as CLI Arg + WinUI Improvements

### DIFF
--- a/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
+++ b/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <PackageReference Include="Nickvision.GirExt" Version="2023.7.3" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
+++ b/NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.1" />
     <PackageReference Include="Nickvision.GirExt" Version="2023.7.3" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -23,7 +23,7 @@ public partial class Program
     /// </summary>
     /// <param name="args">string[]</param>
     /// <returns>Return code from Adw.Application.Run()</returns>
-    public static int Main(string[] args) => new Program(args).Run(args);
+    public static int Main(string[] args) => new Program(args).Run();
 
     /// <summary>
     /// Constructs a Program
@@ -33,9 +33,10 @@ public partial class Program
     {
         _application = Adw.Application.New("org.nickvision.tubeconverter", Gio.ApplicationFlags.FlagsNone);
         _mainWindow = null;
-        _mainWindowController = new MainWindowController();
+        _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
-            @"* Fixed an issue where aria's max connections per server preference was allowed to be greater than 16
+            @"* A URL can now be passed to Parabolic via the command-line or the freedesktop application open protocol to trigger its validation of startup
+              * Fixed an issue where aria's max connections per server preference was allowed to be greater than 16
               * Fixed an issue where enabling the ""Download Specific Timeframe"" advanced option would cause a crash for certain media downloads
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
@@ -60,17 +61,15 @@ public partial class Program
     /// <summary>
     /// Runs the program
     /// </summary>
-    /// <param name="args">Command-line arguments</param>
     /// <returns>Return code from Adw.Application.Run()</returns>
-    public int Run(string[] args)
+    public int Run()
     {
         try
         {
             SynchronizationContext.SetSynchronizationContext(new GLib.Internal.MainLoopSynchronizationContext());
-            var argc = args.Length + 1;
+            var argc = 1;
             var argv = new string[argc];
             argv[0] = "org.nickvision.tubeconverter";
-            args.CopyTo(argv, 1);
             return _application.Run(argc, argv);
         }
         catch (Exception ex)

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -67,11 +67,7 @@ public partial class Program
     {
         try
         {
-            SynchronizationContext.SetSynchronizationContext(new GLib.Internal.MainLoopSynchronizationContext());
-            var argc = 1;
-            var argv = new string[argc];
-            argv[0] = "org.nickvision.tubeconverter";
-            return _application.Run(argc, argv);
+            return _application.RunWithSynchronizationContext();
         }
         catch (Exception ex)
         {
@@ -101,6 +97,11 @@ public partial class Program
         {
             _mainWindow!.SetVisible(true);
             _mainWindow!.Present();
+            if (!string.IsNullOrEmpty(_mainWindowController.UrlToLaunch))
+            {
+                await _mainWindow.AddDownloadAsync(_mainWindowController.UrlToLaunch);
+                _mainWindowController.UrlToLaunch = null;
+            }
         }
         else
         {

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -31,7 +31,7 @@ public partial class Program
     /// <param name="args">Command-line arguments</param>
     public Program(string[] args)
     {
-        _application = Adw.Application.New("org.nickvision.tubeconverter", Gio.ApplicationFlags.FlagsNone);
+        _application = Adw.Application.New("org.nickvision.tubeconverter", Gio.ApplicationFlags.HandlesOpen);
         _mainWindow = null;
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
@@ -40,6 +40,7 @@ public partial class Program
               * Fixed an issue where enabling the ""Download Specific Timeframe"" advanced option would cause a crash for certain media downloads
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
+        _application.OnOpen += OnOpen;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!) + "/org.nickvision.tubeconverter.gresource"))
         {
             //Load file from program directory, required for `dotnet run`
@@ -106,5 +107,16 @@ public partial class Program
             _mainWindow = new MainWindow(_mainWindowController, _application);
             await _mainWindow.StartAsync();
         }
+    }
+
+    /// <summary>
+    /// Occurs when the application is opened
+    /// </summary>
+    /// <param name="sender">Gio.Application</param>
+    /// <param name="e">Gio.Application.OpenSignalArgs</param>
+    private void OnOpen(Gio.Application sender, Gio.Application.OpenSignalArgs e)
+    {
+        _mainWindowController.UrlToLaunch = e.Files[0].GetUri();
+        _application.Activate();
     }
 }

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -192,6 +192,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         if (!string.IsNullOrEmpty(urlToLaunch))
         {
             await AddDownloadAsync(urlToLaunch);
+            _controller.UrlToLaunch = null;
         }
     }
 
@@ -308,7 +309,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// Prompts the AddDownloadDialog
     /// </summary>
     /// <param name="url">A url to pass to the dialog</param>
-    private async Task AddDownloadAsync(string? url)
+    public async Task AddDownloadAsync(string? url)
     {
         var addController = _controller.CreateAddDownloadDialogController();
         var addDialog = new AddDownloadDialog(addController, this);

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -182,13 +182,17 @@ public partial class MainWindow : Adw.ApplicationWindow
         _spinnerContainer.SetVisible(true);
         _mainBox.SetVisible(false);
         _spinner.Start();
-        await _controller.StartupAsync();
+        var urlToValidate = await _controller.StartupAsync();
         _controller.TaskbarItem = await TaskbarItem.ConnectLinuxAsync(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNAP")) ? $"{_controller.AppInfo.ID}.desktop" : "tube-converter_tube-converter.desktop");
         _spinner.Stop();
         _spinnerContainer.SetVisible(false);
         _mainBox.SetVisible(true);
         PreventSuspendWhenDownloadingChanged();
         RunInBackgroundChanged();
+        if (!string.IsNullOrEmpty(urlToValidate))
+        {
+            await AddDownloadAsync(urlToValidate);
+        }
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -182,16 +182,16 @@ public partial class MainWindow : Adw.ApplicationWindow
         _spinnerContainer.SetVisible(true);
         _mainBox.SetVisible(false);
         _spinner.Start();
-        var urlToValidate = await _controller.StartupAsync();
+        var urlToLaunch = await _controller.StartupAsync();
         _controller.TaskbarItem = await TaskbarItem.ConnectLinuxAsync(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNAP")) ? $"{_controller.AppInfo.ID}.desktop" : "tube-converter_tube-converter.desktop");
         _spinner.Stop();
         _spinnerContainer.SetVisible(false);
         _mainBox.SetVisible(true);
         PreventSuspendWhenDownloadingChanged();
         RunInBackgroundChanged();
-        if (!string.IsNullOrEmpty(urlToValidate))
+        if (!string.IsNullOrEmpty(urlToLaunch))
         {
-            await AddDownloadAsync(urlToValidate);
+            await AddDownloadAsync(urlToLaunch);
         }
     }
 

--- a/NickvisionTubeConverter.GNOME/nuget-sources.json
+++ b/NickvisionTubeConverter.GNOME/nuget-sources.json
@@ -162,10 +162,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.10.2/nickvision.aura.2023.10.2.nupkg",
-    "sha512": "830ab163b59643b28673b5f816dd1274d22182ec4c010d929fb6498d43c254279dca8dab27913ac7a323a15a1a766ce24e8f81d4b0fab6660b58ff5a26e15a40",
+    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.11.0/nickvision.aura.2023.11.0.nupkg",
+    "sha512": "7788d1565cfe5670bd993e91d994d077ed1ebe97f5f2d3d190857328778920a13a0deb9ce0b20ee77f2b3f74887456f05f903b838489b6cb1fbabf531de13041",
     "dest": "nuget-sources",
-    "dest-filename": "nickvision.aura.2023.10.2.nupkg"
+    "dest-filename": "nickvision.aura.2023.11.0.nupkg"
   },
   {
     "type": "file",

--- a/NickvisionTubeConverter.GNOME/nuget-sources.json
+++ b/NickvisionTubeConverter.GNOME/nuget-sources.json
@@ -134,10 +134,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/7.0.12/microsoft.data.sqlite.core.7.0.12.nupkg",
-    "sha512": "4c0a8239cced13a1d22b9166dab97996546ef3b0f7a45948d7f123f5b2421b91d8f53199790a9e56cff79831b032221094af742b4a67a6cf2da3baf3cbcd8183",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.data.sqlite.core/7.0.13/microsoft.data.sqlite.core.7.0.13.nupkg",
+    "sha512": "cf20ba56a11be80936da443db31c205d3c8563ddba5ed921b9f3dc1856c5b5fb5338e7cc4d8fffc651bf64349bc2c712078b6bdd8091aa3ec43880ff165203fe",
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.data.sqlite.core.7.0.12.nupkg"
+    "dest-filename": "microsoft.data.sqlite.core.7.0.13.nupkg"
   },
   {
     "type": "file",
@@ -162,10 +162,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.11.0/nickvision.aura.2023.11.0.nupkg",
-    "sha512": "7788d1565cfe5670bd993e91d994d077ed1ebe97f5f2d3d190857328778920a13a0deb9ce0b20ee77f2b3f74887456f05f903b838489b6cb1fbabf531de13041",
+    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.11.1/nickvision.aura.2023.11.1.nupkg",
+    "sha512": "7e426ebe7e78e49095e72762419a2a71786bce376fa76bfb876855fa184674dcb24dc7ff684d935c33436dcbee1fd2858b3463e40e3a7683baca7254a4c2b1b9",
     "dest": "nuget-sources",
-    "dest-filename": "nickvision.aura.2023.11.0.nupkg"
+    "dest-filename": "nickvision.aura.2023.11.1.nupkg"
   },
   {
     "type": "file",
@@ -176,10 +176,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/octokit/8.0.1/octokit.8.0.1.nupkg",
-    "sha512": "b6ed73fc01621174d68906b92b9f19394bed2b48474cf0385870959cba496bce36b3918b5821232a0809c2c6a4e4c54fb0cfdab8cc7dedfa801ea675fd97b704",
+    "url": "https://api.nuget.org/v3-flatcontainer/octokit/9.0.0/octokit.9.0.0.nupkg",
+    "sha512": "fc12c80130652c89c4789ff30fe9a0649288aac65ab17b85dd0c7bca6f75d30ff3aca97e933d6aaf062e467ca9774d739a00688d23e832add3c7da048c790ea7",
     "dest": "nuget-sources",
-    "dest-filename": "octokit.8.0.1.nupkg"
+    "dest-filename": "octokit.9.0.0.nupkg"
   },
   {
     "type": "file",

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -8,7 +8,6 @@ using NickvisionTubeConverter.Shared.Helpers;
 using NickvisionTubeConverter.Shared.Models;
 using Python.Runtime;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -150,6 +150,10 @@ public class MainWindowController : IDisposable
             {
                 _urlToLaunch = value;
             }
+            else
+            {
+                _urlToLaunch = null;
+            }
         }
     }
 

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -91,11 +91,7 @@ public class MainWindowController : IDisposable
         _disposed = false;
         if (args.Length > 0)
         {
-            var result = Uri.TryCreate(args[0], UriKind.Absolute, out var uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
-            if (result)
-            {
-                _urlToLaunch = args[0];
-            }
+            UrlToLaunch = args[0];
         }
         _pythonThreadState = IntPtr.Zero;
         _taskbarStopwatch = new Stopwatch();
@@ -139,6 +135,23 @@ public class MainWindowController : IDisposable
     /// Finalizes the MainWindowController
     /// </summary>
     ~MainWindowController() => Dispose(false);
+
+    /// <summary>
+    /// A url to set to launch on startup
+    /// </summary>
+    public string? UrlToLaunch
+    {
+        get => _urlToLaunch;
+
+        set
+        {
+            var result = Uri.TryCreate(value, UriKind.Absolute, out var uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+            if (result)
+            {
+                _urlToLaunch = value;
+            }
+        }
+    }
 
     /// <summary>
     /// The TaskbarItem to show progress
@@ -296,7 +309,7 @@ public class MainWindowController : IDisposable
             Configuration.Current.AriaMaxConnectionsPerServer = 16;
             Aura.Active.SaveConfig("config");
         }
-        return _urlToLaunch;
+        return UrlToLaunch;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -137,6 +137,16 @@ public class MainWindowController : IDisposable
     ~MainWindowController() => Dispose(false);
 
     /// <summary>
+    /// Whether or not to show the disclaimer on startup
+    /// </summary>
+    public bool ShowDisclaimerOnStartup
+    {
+        get => Configuration.Current.ShowDisclaimerOnStartup;
+
+        set => Configuration.Current.ShowDisclaimerOnStartup = value;
+    }
+
+    /// <summary>
     /// A url to set to launch on startup
     /// </summary>
     public string? UrlToLaunch
@@ -315,6 +325,11 @@ public class MainWindowController : IDisposable
         }
         return UrlToLaunch;
     }
+
+    /// <summary>
+    /// Saves the app's configuration file to disk
+    /// </summary>
+    public void SaveConfig() => Aura.Active.SaveConfig("config");
 
     /// <summary>
     /// Checks for an application update and notifies the user if one is available

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -24,6 +24,7 @@ namespace NickvisionTubeConverter.Shared.Controllers;
 public class MainWindowController : IDisposable
 {
     private bool _disposed;
+    private string? _urlToLaunch;
     private nint _pythonThreadState;
     private Keyring? _keyring;
     private NetworkMonitor? _netmon;
@@ -86,9 +87,17 @@ public class MainWindowController : IDisposable
     /// <summary>
     /// Constructs a MainWindowController
     /// </summary>
-    public MainWindowController()
+    public MainWindowController(string[] args)
     {
         _disposed = false;
+        if (args.Length > 0)
+        {
+            var result = Uri.TryCreate(args[0], UriKind.Absolute, out var uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+            if (result)
+            {
+                _urlToLaunch = args[0];
+            }
+        }
         _pythonThreadState = IntPtr.Zero;
         _taskbarStopwatch = new Stopwatch();
         DownloadManager = new DownloadManager(5);
@@ -206,7 +215,8 @@ public class MainWindowController : IDisposable
     /// <summary>
     /// Starts the application
     /// </summary>
-    public async Task StartupAsync()
+    /// <returns>A URL to validate on startup</returns>
+    public async Task<string> StartupAsync()
     {
         //Update app
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Configuration.Current.AutomaticallyCheckForUpdates)
@@ -306,6 +316,7 @@ public class MainWindowController : IDisposable
             Configuration.Current.AriaMaxConnectionsPerServer = 16;
             Aura.Active.SaveConfig("config");
         }
+        return _urlToLaunch;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -237,7 +237,7 @@ public class MainWindowController : IDisposable
         //Setup Dependencies
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Runtime.PythonDLL = DependencyLocator.Find("python")!.Replace("python.exe", "python311.dll");
+            Runtime.PythonDLL = DependencyLocator.Find("python311.dll")!;
         }
         else
         {
@@ -305,17 +305,14 @@ public class MainWindowController : IDisposable
     /// </summary>
     public async Task CheckForUpdatesAsync()
     {
-        if (!AppInfo.IsDevVersion)
+        if (_updater == null)
         {
-            if (_updater == null)
-            {
-                _updater = await Updater.NewAsync();
-            }
-            var version = await _updater!.GetCurrentStableVersionAsync();
-            if (version != null && version > new Version(AppInfo.Version))
-            {
-                NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("New update available."), NotificationSeverity.Success, "update"));
-            }
+            _updater = await Updater.NewAsync();
+        }
+        var version = await _updater!.GetCurrentStableVersionAsync();
+        if (version != null && (!AppInfo.IsDevVersion ? version > new Version(AppInfo.Version) : version >= new Version(AppInfo.Version.Remove(AppInfo.Version.IndexOf('-')))))
+        {
+            NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("New update available."), NotificationSeverity.Success, "update"));
         }
     }
 

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -119,6 +119,11 @@ public class Configuration : ConfigurationBase
     /// Whether or not to number titles
     /// </summary>
     public bool NumberTitles { get; set; }
+    /// <summary>
+    /// Whether or not to show the disclaimer on startup
+    /// </summary>
+    /// <remarks>Used on WinUI only</remarks>
+    public bool ShowDisclaimerOnStartup { get; set; }
 
     /// <summary>
     /// Constructs a Configuration
@@ -152,6 +157,7 @@ public class Configuration : ConfigurationBase
         PreviousVideoResolution = "";
         PreviousSubtitleState = false;
         NumberTitles = false;
+        ShowDisclaimerOnStartup = true;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
+++ b/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="GetText.NET" Version="1.9.14" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.1" />
     <PackageReference Include="pythonnet" Version="3.0.3" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
+++ b/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="GetText.NET" Version="1.9.14" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <PackageReference Include="pythonnet" Version="3.0.3" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,20 +20,20 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "انتهى تنزيل «{0}»."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "انتهى «{0}» بخطأ!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(يُضبط في التفضيلات)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} جيجابايت\\ث"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} ك‌بايت\\ث"
@@ -72,8 +72,8 @@ msgstr[5] "{0} تنزيل — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -98,7 +98,7 @@ msgstr ""
 "لك أن تدخل ملف تعريف ارتباط في yt-dlp، وعندها تستطيع أن تنزِّل الوسائط التي "
 "تتطلب الولوج."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "عن {0}"
@@ -109,18 +109,18 @@ msgstr "عن {0}"
 msgid "Add"
 msgstr "أضف"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "أضف رابط مقطع أو صوت أو قائمة تشغيل تنزِّله"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,14 +134,14 @@ msgid "Add Login"
 msgstr "أضف ولوجًا"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "خيارات متقدمة"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "انتهت كل التنزيلات."
 
@@ -160,17 +160,17 @@ msgstr "طبِّق"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "صوت"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "لغة الصوت"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "المصادقة"
@@ -179,7 +179,7 @@ msgstr "المصادقة"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -187,7 +187,7 @@ msgid "Back"
 msgstr "عُد"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "الأفضل"
 
@@ -199,7 +199,7 @@ msgstr "ألغِ"
 msgid "Changelog"
 msgstr "التغييرات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -208,8 +208,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "امحُ التنزيلات المكتملة"
@@ -226,21 +226,21 @@ msgid ""
 "of the media source"
 msgstr "امحُ البيانات الوصفية التي فيها الرابط وغيره من الأخبار عن مصدر الوسائط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "امسح التنزيلات التي في قائمة الانتظار"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "أغلق"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "أأغلق التطبيق وأوقف التنزيلات؟"
 
@@ -248,8 +248,8 @@ msgstr "أأغلق التطبيق وأوقف التنزيلات؟"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "تمَّ"
@@ -259,7 +259,7 @@ msgstr "تمَّ"
 msgid "Completed Notification Trigger"
 msgstr "سبب إشعار الانتهاء"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "مساهمو جت‌هب ❤️"
 
@@ -307,16 +307,16 @@ msgstr "بيانات الاعتماد"
 msgid "Crop Audio Thumbnails"
 msgstr "قص الصور المصغرة لصوتيات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "قص الصور المصغرة"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -334,7 +334,7 @@ msgstr "حذف"
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "ألغِ تحديد الكلِّ"
@@ -404,15 +404,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "امنع التحويلات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "النقاشات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +423,13 @@ msgstr "نزِّل"
 msgid "Download Again"
 msgstr "نزِّل مرةً أخرى"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "انتهى التنزيل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "انتهى التنزيل بخطأ"
 
@@ -438,17 +438,17 @@ msgstr "انتهى التنزيل بخطأ"
 msgid "Download log was copied to clipboard."
 msgstr "نُسخ سجل التنزيل إلى الحافظة."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "نزِّل وسائط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "تحميل جزء معين"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "نزِّل الترجمة"
@@ -461,20 +461,20 @@ msgstr "بدأ التنزيل باستخدام آريا٢"
 msgid "Download using ffmpeg has started"
 msgstr "بدأ التنزيل باستخدام ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "نزِّل مقاطع وأصواتًا من الوب"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "المنزِّل"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ينزَّل"
@@ -491,12 +491,12 @@ msgstr "ينزَّل {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ينزَّل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "انتهت التنزيلات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "تحرير"
 
@@ -528,28 +528,28 @@ msgid ""
 msgstr "مكِّنه لتستخدم منزِّل آريا٢، فربما يكون أسرع، ولكنك لن ترى سير التنزيل."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "وقت النهاية"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "وقت الانتهاء (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "أدخل رابط الوسائط هنا"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "تأكد من بيانات اعتمادك."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "أدخل رابط الوسائط هنا"
@@ -559,7 +559,7 @@ msgstr "أدخل رابط الوسائط هنا"
 msgid "Enter name here"
 msgstr "أدخل رابط الوسائط هنا"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -570,7 +570,7 @@ msgstr "أدخل رابط الوسائط هنا"
 msgid "Enter proxy url here"
 msgstr "أدخل رابط الوسائط هنا"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "أدخل رابط الوسائط هنا"
@@ -580,7 +580,7 @@ msgstr "أدخل رابط الوسائط هنا"
 msgid "Enter url here"
 msgstr "أدخل رابط الوسائط هنا"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -591,8 +591,8 @@ msgstr "أدخل رابط الوسائط هنا"
 msgid "Error"
 msgstr "خطأ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "اخرج"
 
@@ -601,7 +601,7 @@ msgstr "اخرج"
 msgid "Failed to enable keyring."
 msgstr "تعذَّر تمكين حلقة المفاتيح."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "ملف"
 
@@ -614,7 +614,7 @@ msgstr "يوجد الملفُّ بالفعل ولا يسمح بالكتابة ف
 msgid "File Name"
 msgstr "اسم الملف"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "نوع المِلَفّ"
@@ -624,23 +624,23 @@ msgstr "نوع المِلَفّ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "مستودع جت‌هب"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "مساعدة"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -684,13 +684,13 @@ msgstr "تظهر إشعارات الانتهاء فقط حال حدوث سببه
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "حلقة مفاتيح"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "الاعتماد حلقة مفاتيح"
@@ -710,13 +710,13 @@ msgstr "حلقة مفاتيح مقفلة"
 msgid "Language Code Information"
 msgstr "معلومات رمز اللغة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "اتركه فارغًا للتنزيل من البداية."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "قائمة المواقع المدعومة"
 
@@ -732,7 +732,7 @@ msgstr "لُج"
 msgid "Login"
 msgstr "لُج"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "اجعل الصورة المصغرة مربعة، مفيدة عند تنزيل الموسيقى."
@@ -742,7 +742,7 @@ msgstr "اجعل الصورة المصغرة مربعة، مفيدة عند تن
 msgid "Manage previously downloaded media."
 msgstr "أدر الوسائط المنزَّلة."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "دردشة ماتركس"
 
@@ -757,11 +757,11 @@ msgid "Max Number of Active Downloads"
 msgstr "أقصى عدد للتنزيلات النشطة"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "أقصى جودة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -772,14 +772,13 @@ msgstr ""
 "تمكين هذا الخيار يعطِّل استخدام آريا٢ منزِّلًا."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "رابط الوسائط"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "رابط الوسائط (غير صالح)"
 
@@ -806,30 +805,30 @@ msgstr "اسم"
 msgid "Name (Empty)"
 msgstr "الاسم (فارغ)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "لا"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "لا يوجد اتصال إنترنت"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "امحُ التنزيلات المكتملة"
@@ -843,7 +842,7 @@ msgstr "لا يوجد أوراق اعتماد"
 msgid "No downloads running"
 msgstr "لا يوجد ما ينزَّل الآن"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "لا يوجد ما ينزَّل الآن"
@@ -858,26 +857,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "لا توجد تنزيلات سابقة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "امسح التنزيلات التي في قائمة الانتظار"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "ترقِّيم العناوين"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -898,14 +897,14 @@ msgstr ""
 msgid "OK"
 msgstr "حسنًا"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -937,21 +936,21 @@ msgstr "افتح مجلدًّا"
 msgid "Overwrite Existing Files"
 msgstr "اكتب فوق الملفات الموجودة"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -971,11 +970,15 @@ msgid "Play"
 msgstr "شغِّل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "قائمة التشغيل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "يجهِّز..."
@@ -990,7 +993,7 @@ msgstr "يجهِّز..."
 msgid "Prevent Suspend"
 msgstr "امنع التعليق"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1004,19 +1007,19 @@ msgstr "يعالج..."
 msgid "Proxy URL"
 msgstr "رابط الوكيل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "الجودة"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "في قائمة الانتظار"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "التنزيلات المتبقية : {0}"
@@ -1026,7 +1029,7 @@ msgstr "التنزيلات المتبقية : {0}"
 msgid "Remove Source Data"
 msgstr "أزل بيانات المصدر"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "الإبلاغ عن خلل"
 
@@ -1061,22 +1064,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "حاول إعادة التنزيل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "أعد تنزيل التنزيلات الفاشلة"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "موقع الحفظ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "مجلد الحفظ (غير صالح)"
 
@@ -1086,7 +1089,7 @@ msgstr "مجلد الحفظ (غير صالح)"
 msgid "Search history"
 msgstr "امسح السجلَّ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "حدِّد الكلَّ"
@@ -1097,30 +1100,30 @@ msgstr "حدِّد الكلَّ"
 msgid "Select Cookies File"
 msgstr "حدِّد ملف تعريف الارتباط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "حدد العناصر لتنزِّلها أو لتغيِّر أسماءها."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "اختر مجلد الحفظ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1132,19 +1135,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "انتهت بعض التنزيلات بخطأ!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "حدُّ السرعة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "تقسيم الفصول"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "قسِّم المقطع إلى عدة مقاطع أصغر حسب فصوله."
@@ -1155,19 +1158,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "أخبار SponsorBlock (تُفتَح في المتصفح)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "وقت البَدْء"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "وقت البدء (غير صالح)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1204,7 +1207,7 @@ msgstr "لغات الترجمة (غير صالح)"
 msgid "Success"
 msgstr "نجاح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1238,7 +1241,7 @@ msgstr ""
 "يطبَّق هذا الحدُّ (بالكيلوبايت\\ثانية) على التنزيلات التي مُكِّن فيها. لا يؤثِّر "
 "تغيير هذه القيمة على التنزيلات القائمة."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1251,7 +1254,7 @@ msgstr ""
 "سيؤدي هذا إلى حذف حلقة المفاتيح السابقة وإزالة جميع كلمات المرور معها. هذا "
 "الإجراء لا رجعة فيه."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "علي الجشي <ahj696@hotmail.com>"
 
@@ -1260,7 +1263,7 @@ msgstr "علي الجشي <ahj696@hotmail.com>"
 msgid "Unable to disable keyring."
 msgstr "تعذَّر تعطيل حلقة المفاتيح."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1269,7 +1272,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "تعذَّر تصفير حلقة المفاتيح."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr "تعذر تثبيت التبعيات. أعد تشغيل التطبيق وحاول مرةً أخرى."
 
@@ -1278,7 +1281,7 @@ msgstr "تعذر تثبيت التبعيات. أعد تشغيل التطبيق �
 msgid "Undo Title Editing"
 msgstr "تراجع عن تحرير العناوين"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "فتح حلقة مفاتيح"
 
@@ -1287,7 +1290,7 @@ msgstr "فتح حلقة مفاتيح"
 msgid "Unset Cookies File"
 msgstr "حدِّد ملف تعريف الارتباط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1339,7 +1342,7 @@ msgid "User Name (Empty)"
 msgstr "اسم المستخدم (فارغ)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1348,13 +1351,18 @@ msgid "Username"
 msgstr "اسم المستخدم"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "تحقَّق"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "تحقَّق"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "مقطع"
 
@@ -1372,7 +1380,7 @@ msgid "Waiting..."
 msgstr "ينتظر..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "الأسوأ"
 
@@ -1385,10 +1393,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "نعم"

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -21,13 +21,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "انتهى تنزيل «{0}»."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "انتهى «{0}» بخطأ!"
@@ -109,7 +109,7 @@ msgstr "عن {0}"
 msgid "Add"
 msgstr "أضف"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "أضف رابط مقطع أو صوت أو قائمة تشغيل تنزِّله"
@@ -118,9 +118,9 @@ msgstr "أضف رابط مقطع أو صوت أو قائمة تشغيل تنزّ
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -141,7 +141,7 @@ msgid "Advanced Options"
 msgstr "خيارات متقدمة"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "انتهت كل التنزيلات."
 
@@ -209,7 +209,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "امحُ التنزيلات المكتملة"
@@ -227,7 +227,7 @@ msgid ""
 msgstr "امحُ البيانات الوصفية التي فيها الرابط وغيره من الأخبار عن مصدر الوسائط"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -240,7 +240,7 @@ msgid "Close"
 msgstr "أغلق"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "أأغلق التطبيق وأوقف التنزيلات؟"
 
@@ -248,8 +248,8 @@ msgstr "أأغلق التطبيق وأوقف التنزيلات؟"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "تمَّ"
@@ -259,7 +259,7 @@ msgstr "تمَّ"
 msgid "Completed Notification Trigger"
 msgstr "سبب إشعار الانتهاء"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "مساهمو جت‌هب ❤️"
 
@@ -312,11 +312,11 @@ msgstr "قص الصور المصغرة لصوتيات"
 msgid "Crop Thumbnail"
 msgstr "قص الصور المصغرة"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -330,7 +330,7 @@ msgid "Delete"
 msgstr "حذف"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "هل تريد حذف الاعتمادات؟"
 
@@ -424,12 +424,12 @@ msgid "Download Again"
 msgstr "نزِّل مرةً أخرى"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "انتهى التنزيل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "انتهى التنزيل بخطأ"
 
@@ -438,7 +438,7 @@ msgstr "انتهى التنزيل بخطأ"
 msgid "Download log was copied to clipboard."
 msgstr "نُسخ سجل التنزيل إلى الحافظة."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "نزِّل وسائط"
@@ -461,7 +461,7 @@ msgstr "بدأ التنزيل باستخدام آريا٢"
 msgid "Download using ffmpeg has started"
 msgstr "بدأ التنزيل باستخدام ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -473,8 +473,8 @@ msgstr "نزِّل مقاطع وأصواتًا من الوب"
 msgid "Downloader"
 msgstr "المنزِّل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ينزَّل"
@@ -492,7 +492,7 @@ msgid "Downloading..."
 msgstr "ينزَّل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "انتهت التنزيلات"
 
@@ -592,7 +592,7 @@ msgid "Error"
 msgstr "خطأ"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "اخرج"
 
@@ -624,7 +624,7 @@ msgstr "نوع المِلَفّ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -683,7 +683,7 @@ msgstr "تظهر إشعارات الانتهاء فقط حال حدوث سببه
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -716,7 +716,7 @@ msgstr "معلومات رمز اللغة"
 msgid "Leave empty to download from start."
 msgstr "اتركه فارغًا للتنزيل من البداية."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "قائمة المواقع المدعومة"
 
@@ -727,8 +727,8 @@ msgstr "لُج"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "لُج"
 
@@ -742,7 +742,7 @@ msgstr "اجعل الصورة المصغرة مربعة، مفيدة عند تن
 msgid "Manage previously downloaded media."
 msgstr "أدر الوسائط المنزَّلة."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "دردشة ماتركس"
 
@@ -795,40 +795,40 @@ msgstr "أصغر حجم تقسيمات (k-)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "اسم"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "الاسم (فارغ)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "لا"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "لا يوجد اتصال إنترنت"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "امحُ التنزيلات المكتملة"
@@ -842,7 +842,7 @@ msgstr "لا يوجد أوراق اعتماد"
 msgid "No downloads running"
 msgstr "لا يوجد ما ينزَّل الآن"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "لا يوجد ما ينزَّل الآن"
@@ -857,7 +857,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "لا توجد تنزيلات سابقة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "امسح التنزيلات التي في قائمة الانتظار"
@@ -936,14 +936,14 @@ msgstr "افتح مجلدًّا"
 msgid "Overwrite Existing Files"
 msgstr "اكتب فوق الملفات الموجودة"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -952,7 +952,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -960,7 +960,7 @@ msgid "Password"
 msgstr "كلمة السر"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "كلمة السر (فارغة)"
 
@@ -977,11 +977,6 @@ msgstr "قائمة التشغيل"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "يجهِّز..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1012,14 +1007,14 @@ msgstr "رابط الوكيل"
 msgid "Quality"
 msgstr "الجودة"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "في قائمة الانتظار"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "التنزيلات المتبقية : {0}"
@@ -1039,7 +1034,7 @@ msgid "Reset"
 msgstr "صفِّر"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "أأصفِّر حلقة المفاتيح؟"
 
@@ -1065,7 +1060,7 @@ msgid "Retry Download"
 msgstr "حاول إعادة التنزيل"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1112,18 +1107,18 @@ msgid "Select Save Folder"
 msgstr "اختر مجلد الحفظ"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1170,7 +1165,7 @@ msgid "Start Time (Invalid)"
 msgstr "وقت البدء (غير صالح)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1228,7 +1223,7 @@ msgid "Theme"
 msgstr "السمة"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "هذه الخطوة لا رجوع فيها. هل أنت متأكد أنك تريد حذفه؟"
 
@@ -1241,12 +1236,8 @@ msgstr ""
 "يطبَّق هذا الحدُّ (بالكيلوبايت\\ثانية) على التنزيلات التي مُكِّن فيها. لا يؤثِّر "
 "تغيير هذه القيمة على التنزيلات القائمة."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1254,34 +1245,30 @@ msgstr ""
 "سيؤدي هذا إلى حذف حلقة المفاتيح السابقة وإزالة جميع كلمات المرور معها. هذا "
 "الإجراء لا رجعة فيه."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "علي الجشي <ahj696@hotmail.com>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "تعذَّر تعطيل حلقة المفاتيح."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "تعذَّر تصفير حلقة المفاتيح."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr "تعذر تثبيت التبعيات. أعد تشغيل التطبيق وحاول مرةً أخرى."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "تراجع عن تحرير العناوين"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "فتح حلقة مفاتيح"
 
@@ -1290,19 +1277,19 @@ msgstr "فتح حلقة مفاتيح"
 msgid "Unset Cookies File"
 msgstr "حدِّد ملف تعريف الارتباط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "الرابط (غير صالح)"
 
@@ -1336,7 +1323,7 @@ msgid "User Interface"
 msgstr "واجهة المستخدم"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "اسم المستخدم (فارغ)"
@@ -1344,7 +1331,7 @@ msgstr "اسم المستخدم (فارغ)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1394,9 +1381,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "نعم"
@@ -1541,6 +1528,13 @@ msgstr "— ينزِّل أكثر من تنزيل آنًا"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— يدعم تنزيل بيانات الوصف وترجمات المقاطع"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "يجهِّز..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr "تعذر تثبيت التبعيات. أعد تشغيل التطبيق وحاول مرةً أخرى."
 
 #~ msgid "Search..."
 #~ msgstr "يبحث..."

--- a/NickvisionTubeConverter.Shared/Resources/po/ar.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,14 +20,14 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "انتهى تنزيل «{0}»."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "انتهى «{0}» بخطأ!"
@@ -140,8 +140,8 @@ msgstr "أضف ولوجًا"
 msgid "Advanced Options"
 msgstr "خيارات متقدمة"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "انتهت كل التنزيلات."
 
@@ -239,8 +239,8 @@ msgstr "امسح التنزيلات التي في قائمة الانتظار"
 msgid "Close"
 msgstr "أغلق"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "أأغلق التطبيق وأوقف التنزيلات؟"
 
@@ -404,12 +404,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "امنع التحويلات"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "النقاشات"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -423,13 +431,13 @@ msgstr "نزِّل"
 msgid "Download Again"
 msgstr "نزِّل مرةً أخرى"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "انتهى التنزيل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "انتهى التنزيل بخطأ"
 
@@ -491,8 +499,8 @@ msgstr "ينزَّل {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ينزَّل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "انتهت التنزيلات"
 
@@ -628,7 +636,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "مستودع جت‌هب"
@@ -805,7 +813,7 @@ msgstr "اسم"
 msgid "Name (Empty)"
 msgstr "الاسم (فارغ)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -816,15 +824,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "لا"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "لا يوجد اتصال إنترنت"
 
@@ -894,6 +902,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "حسنًا"
 
@@ -1014,7 +1023,7 @@ msgid "Queued"
 msgstr "في قائمة الانتظار"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "التنزيلات المتبقية : {0}"
@@ -1117,8 +1126,8 @@ msgstr "الإعدادات"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1202,7 +1211,8 @@ msgstr "لغات الترجمة (غير صالح)"
 msgid "Success"
 msgstr "نجاح"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1254,7 +1264,7 @@ msgstr "علي الجشي <ahj696@hotmail.com>"
 msgid "Unable to disable keyring."
 msgstr "تعذَّر تعطيل حلقة المفاتيح."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1268,7 +1278,7 @@ msgstr "تعذَّر تصفير حلقة المفاتيح."
 msgid "Undo Title Editing"
 msgstr "تراجع عن تحرير العناوين"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "فتح حلقة مفاتيح"
 
@@ -1277,7 +1287,7 @@ msgstr "فتح حلقة مفاتيح"
 msgid "Unset Cookies File"
 msgstr "حدِّد ملف تعريف الارتباط"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1380,10 +1390,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "نعم"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-10-02 18:59+0000\n"
 "Last-Translator: Soumyadeep Ghosh <soumyadeepghosh2004@zohomail.in>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{০} অধঃগৃহীত হয়েছে।"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{০} একটি সমস্যার সহিত অধঃগৃহীত হয়েছে!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -48,7 +48,7 @@ msgstr ""
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr ""
@@ -67,8 +67,8 @@ msgstr[1] "অধঃগৃহীত {০:f২}% ({১:N০} কিবাইট/�
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, fuzzy, csharp-format
 msgid "About {0}"
 msgstr "সম্বন্ধে {০}"
@@ -98,18 +98,18 @@ msgstr "সম্বন্ধে {০}"
 msgid "Add"
 msgstr "যোগ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -123,14 +123,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "উচ্চতর বিকল্পাদি"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "সকল অধঃগ্রহণ সমাপ্ত"
 
@@ -149,17 +149,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "গান"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "শব্দের ভাষা"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "বৈধতা যাচাই"
@@ -168,7 +168,7 @@ msgstr "বৈধতা যাচাই"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -176,7 +176,7 @@ msgid "Back"
 msgstr "পুর্বে"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "সর্বোত্তম"
 
@@ -188,7 +188,7 @@ msgstr "বাতিল"
 msgid "Changelog"
 msgstr "পরিবর্ধন সূচি"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -216,8 +216,8 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -225,13 +225,13 @@ msgid "Clear Queued Downloads"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "বন্ধ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
 
@@ -239,8 +239,8 @@ msgstr "অধঃগ্রহণাদি থামান ও বন্ধ ক�
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "সম্পূর্ণ"
@@ -250,7 +250,7 @@ msgstr "সম্পূর্ণ"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "গিটহাবের সাহায্যকারীরা ❤️"
 
@@ -296,16 +296,16 @@ msgstr "পুরস্কৃতি"
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -323,7 +323,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr "গুরুত্বপূর্ণ তথ্য মুছুন?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -386,15 +386,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "আলোচনা"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -406,13 +406,13 @@ msgstr "অধঃগ্রহণ"
 msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, fuzzy
 msgid "Download Finished With Error"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -423,18 +423,18 @@ msgstr "অধঃগ্রহণ সমাপ্ত"
 msgid "Download log was copied to clipboard."
 msgstr "অধঃগ্রহণের ক্রিয়াকর্ম লেখনপট্টিকাতে প্রতিলিপিত হয়েছে"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
 msgstr "অধঃগ্রহণ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "উপশীর্ষকের অধঃগ্রহণ"
@@ -449,21 +449,21 @@ msgstr "অধঃগ্রহণ সমাপ্ত"
 msgid "Download using ffmpeg has started"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "অন্তর্জালের ভিডিও ও গান অধঃগ্রহণ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 #, fuzzy
 msgid "Downloader"
 msgstr "অধঃগ্রহণ"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "অধঃগৃহীত হচ্ছে"
@@ -480,13 +480,13 @@ msgstr "অধিঃগৃহীত {০:f২}% ({১:N০} কিবাইট/�
 msgid "Downloading..."
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -519,27 +519,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "শেষ হওয়ার সময়"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "শেষ হওয়ার সময় (অবৈধ)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "তথ্যগুলি সঠিক কিনা যাচাই করে নিন।"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -574,8 +574,8 @@ msgstr ""
 msgid "Error"
 msgstr "বিফল"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "কিরিং চালু করতে অসমর্থ।"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "তথ্যের নাম"
@@ -598,7 +598,7 @@ msgstr "তথ্য ইতিমধ্যেই বর্তমান এবং
 msgid "File Name"
 msgstr "তথ্যের নাম"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "তথ্যের ধরণ"
@@ -608,23 +608,23 @@ msgstr "তথ্যের ধরণ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "গিটহাবের ভান্ডার"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -663,13 +663,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "কিরিং"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "কিরিঙের গুরুত্বপূর্ণ তথ্য"
@@ -689,13 +689,13 @@ msgstr "কিরিং মুক্ত নয়"
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "সক্ষম সাইটগুলির তালিকা"
 
@@ -711,7 +711,7 @@ msgstr "লগিন"
 msgid "Login"
 msgstr "লগিন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
@@ -721,7 +721,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "ম্যাট্রিক্সের কথোপকথন"
 
@@ -736,11 +736,11 @@ msgid "Max Number of Active Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "সর্বোত্তম গুনমান"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -749,14 +749,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "মিডিয়ার URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "মিডিয়ার URL (অবৈধ)"
 
@@ -783,30 +782,30 @@ msgstr "নাম"
 msgid "Name (Empty)"
 msgstr "নাম (খালি)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "না"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "সক্রিয় অন্তর্জাল সংযোগ নেই"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
@@ -820,7 +819,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "কোনো অধঃগৃহণ চলছে না"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "কোনো অধঃগৃহণ চলছে না"
@@ -836,27 +835,27 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "অধঃগ্রহণ থামান"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "ভিডিও সংখ্যা"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -877,14 +876,14 @@ msgstr ""
 msgid "OK"
 msgstr "ঠিক আছে"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -918,21 +917,21 @@ msgstr "অধঃগ্রহণের তথ্যপথটি খুলুন"
 msgid "Overwrite Existing Files"
 msgstr "পূর্বস্থিত তথ্যের পুনর্লিখন"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "প্যারাবোলিক"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -952,11 +951,15 @@ msgid "Play"
 msgstr "চালাও"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "গীতিতালিকা"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "প্রস্তুতি..।"
@@ -971,7 +974,7 @@ msgstr "প্রস্তুতি..।"
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -985,19 +988,19 @@ msgstr "ক্রিয়ান্বয়ন..।"
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "গুণমান"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "সারিবদ্ধিত"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "পুনঃ অধঃগ্রহণ"
@@ -1007,7 +1010,7 @@ msgstr "পুনঃ অধঃগ্রহণ"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "সমস্যার নিবন্ধীকরণ করুন"
 
@@ -1042,8 +1045,8 @@ msgstr ""
 msgid "Retry Download"
 msgstr "পুনঃ অধঃগ্রহণ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 #, fuzzy
@@ -1051,14 +1054,14 @@ msgid "Retry Failed Downloads"
 msgstr "পুনঃ অধঃগ্রহণ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "অধঃগ্রহণের তথ্যপথ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "অধঃগ্রহণের তথ্যপথ (অবৈধ)"
 
@@ -1067,7 +1070,7 @@ msgstr "অধঃগ্রহণের তথ্যপথ (অবৈধ)"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1079,30 +1082,30 @@ msgstr "অধঃগ্রহণ থামান"
 msgid "Select Cookies File"
 msgstr "কুকিসের তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "সংগ্রাহক তথ্যপথ বাছুন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "সমযোজনাদি(সেটিংস)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1114,19 +1117,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "কিছু অধঃগ্রহণ সমস্যার সহিত সমাপ্ত হয়েছে!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1137,19 +1140,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "সূচনার সময়"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "সূচনার সময় (অবৈধ)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 #, fuzzy
@@ -1187,7 +1190,7 @@ msgstr ""
 msgid "Success"
 msgstr "সফল"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1220,7 +1223,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1231,7 +1234,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1240,7 +1243,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1249,7 +1252,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ্রহণে অসমর্থ। অ্যাপটির পুনরাম্ভ করুন।"
 
@@ -1258,7 +1261,7 @@ msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ�
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1267,7 +1270,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "কুকিসের তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1316,7 +1319,7 @@ msgid "User Name (Empty)"
 msgstr "ব্যবহারকারীর নাম (খালি)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1325,13 +1328,18 @@ msgid "Username"
 msgstr "ব্যবহারকারীর নাম"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "যাচাই করুন"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "যাচাই করুন"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "ভিডিও"
 
@@ -1349,7 +1357,7 @@ msgid "Waiting..."
 msgstr "অপেক্ষা করুন...।"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "চলনশই"
 
@@ -1362,10 +1370,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "হ্যাঁ"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-10-02 18:59+0000\n"
 "Last-Translator: Soumyadeep Ghosh <soumyadeepghosh2004@zohomail.in>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{০} অধঃগৃহীত হয়েছে।"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{০} একটি সমস্যার সহিত অধঃগৃহীত হয়েছে!"
@@ -98,7 +98,7 @@ msgstr "সম্বন্ধে {০}"
 msgid "Add"
 msgstr "যোগ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -107,9 +107,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,7 +130,7 @@ msgid "Advanced Options"
 msgstr "উচ্চতর বিকল্পাদি"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "সকল অধঃগ্রহণ সমাপ্ত"
 
@@ -198,7 +198,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -217,7 +217,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -231,7 +231,7 @@ msgid "Close"
 msgstr "বন্ধ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
 
@@ -239,8 +239,8 @@ msgstr "অধঃগ্রহণাদি থামান ও বন্ধ ক�
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "সম্পূর্ণ"
@@ -250,7 +250,7 @@ msgstr "সম্পূর্ণ"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "গিটহাবের সাহায্যকারীরা ❤️"
 
@@ -301,11 +301,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -319,7 +319,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "গুরুত্বপূর্ণ তথ্য মুছুন?"
 
@@ -407,12 +407,12 @@ msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, fuzzy
 msgid "Download Finished With Error"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -423,7 +423,7 @@ msgstr "অধঃগ্রহণ সমাপ্ত"
 msgid "Download log was copied to clipboard."
 msgstr "অধঃগ্রহণের ক্রিয়াকর্ম লেখনপট্টিকাতে প্রতিলিপিত হয়েছে"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
@@ -449,7 +449,7 @@ msgstr "অধঃগ্রহণ সমাপ্ত"
 msgid "Download using ffmpeg has started"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -462,8 +462,8 @@ msgstr "অন্তর্জালের ভিডিও ও গান অধ�
 msgid "Downloader"
 msgstr "অধঃগ্রহণ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "অধঃগৃহীত হচ্ছে"
@@ -481,7 +481,7 @@ msgid "Downloading..."
 msgstr "অধঃগৃহীত হচ্ছে"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -575,7 +575,7 @@ msgid "Error"
 msgstr "বিফল"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -608,7 +608,7 @@ msgstr "তথ্যের ধরণ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -662,7 +662,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "সক্ষম সাইটগুলির তালিকা"
 
@@ -706,8 +706,8 @@ msgstr "লগিন"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "লগিন"
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "ম্যাট্রিক্সের কথোপকথন"
 
@@ -772,40 +772,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "নাম"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "নাম (খালি)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "না"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "সক্রিয় অন্তর্জাল সংযোগ নেই"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
@@ -819,7 +819,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "কোনো অধঃগৃহণ চলছে না"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "কোনো অধঃগৃহণ চলছে না"
@@ -835,7 +835,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "অধঃগ্রহণ থামান"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
@@ -917,14 +917,14 @@ msgstr "অধঃগ্রহণের তথ্যপথটি খুলুন"
 msgid "Overwrite Existing Files"
 msgstr "পূর্বস্থিত তথ্যের পুনর্লিখন"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "প্যারাবোলিক"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -933,7 +933,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -941,7 +941,7 @@ msgid "Password"
 msgstr "পাসওয়ার্ড"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "পাসওয়ার্ড (খালি)"
 
@@ -958,11 +958,6 @@ msgstr "গীতিতালিকা"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "প্রস্তুতি..।"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -993,14 +988,14 @@ msgstr ""
 msgid "Quality"
 msgstr "গুণমান"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "সারিবদ্ধিত"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "পুনঃ অধঃগ্রহণ"
@@ -1020,7 +1015,7 @@ msgid "Reset"
 msgstr "রিসেট"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "কিরিং রিসেট করুন?"
 
@@ -1046,7 +1041,7 @@ msgid "Retry Download"
 msgstr "পুনঃ অধঃগ্রহণ"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 #, fuzzy
@@ -1094,18 +1089,18 @@ msgid "Select Save Folder"
 msgstr "সংগ্রাহক তথ্যপথ বাছুন"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "সমযোজনাদি(সেটিংস)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1152,7 +1147,7 @@ msgid "Start Time (Invalid)"
 msgstr "সূচনার সময় (অবৈধ)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 #, fuzzy
@@ -1212,7 +1207,7 @@ msgid "Theme"
 msgstr "রঙের ধরণ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1223,45 +1218,37 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ্রহণে অসমর্থ। অ্যাপটির পুনরাম্ভ করুন।"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1270,19 +1257,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "কুকিসের তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -1313,7 +1300,7 @@ msgid "User Interface"
 msgstr "ব্যবহারকারীর দৃষ্টিতে"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "ব্যবহারকারীর নাম (খালি)"
@@ -1321,7 +1308,7 @@ msgstr "ব্যবহারকারীর নাম (খালি)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1371,9 +1358,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "হ্যাঁ"
@@ -1523,6 +1510,13 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "প্রস্তুতি..।"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr "প্রয়োজনীয় অবয়বতাগুলি অধঃগ্রহণে অসমর্থ। অ্যাপটির পুনরাম্ভ করুন।"
 
 #, fuzzy
 #~ msgctxt "Subtitle"

--- a/NickvisionTubeConverter.Shared/Resources/po/bn.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-10-02 18:59+0000\n"
 "Last-Translator: Soumyadeep Ghosh <soumyadeepghosh2004@zohomail.in>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{০} অধঃগৃহীত হয়েছে।"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{০} একটি সমস্যার সহিত অধঃগৃহীত হয়েছে!"
@@ -129,8 +129,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "উচ্চতর বিকল্পাদি"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "সকল অধঃগ্রহণ সমাপ্ত"
 
@@ -230,8 +230,8 @@ msgstr "অধঃগ্রহণাদি থামান ও বন্ধ ক�
 msgid "Close"
 msgstr "বন্ধ"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "অধঃগ্রহণাদি থামান ও বন্ধ করুন?"
 
@@ -386,12 +386,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "আলোচনা"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -406,13 +414,13 @@ msgstr "অধঃগ্রহণ"
 msgid "Download Again"
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, fuzzy
 msgid "Download Finished With Error"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -480,8 +488,8 @@ msgstr "অধিঃগৃহীত {০:f২}% ({১:N০} কিবাইট/�
 msgid "Downloading..."
 msgstr "অধঃগৃহীত হচ্ছে"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "অধঃগ্রহণ সমাপ্ত"
@@ -612,7 +620,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "গিটহাবের ভান্ডার"
@@ -782,7 +790,7 @@ msgstr "নাম"
 msgid "Name (Empty)"
 msgstr "নাম (খালি)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -793,15 +801,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "না"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "সক্রিয় অন্তর্জাল সংযোগ নেই"
 
@@ -873,6 +881,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "ঠিক আছে"
 
@@ -995,7 +1004,7 @@ msgid "Queued"
 msgstr "সারিবদ্ধিত"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "পুনঃ অধঃগ্রহণ"
@@ -1099,8 +1108,8 @@ msgstr "সমযোজনাদি(সেটিংস)"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1185,7 +1194,8 @@ msgstr ""
 msgid "Success"
 msgstr "সফল"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1234,7 +1244,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1248,7 +1258,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1257,7 +1267,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "কুকিসের তথ্যপথ বেছে নিন"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1357,10 +1367,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "হ্যাঁ"

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-03 17:20+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.2-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Soubor „{0}“ byl stažen."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Stahování souboru „{0}“ skončilo s chybou!"
@@ -102,7 +102,7 @@ msgstr "O aplikaci {0}"
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Pro spuštění stahování přidejte adresu URL videa, zvuku nebo playlistu"
@@ -111,9 +111,9 @@ msgstr "Pro spuštění stahování přidejte adresu URL videa, zvuku nebo playl
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,7 +134,7 @@ msgid "Advanced Options"
 msgstr "Rozšířené možnosti"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Všechna stahování byla dokončena."
 
@@ -202,7 +202,7 @@ msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Vymazat dokončená stahování"
@@ -222,7 +222,7 @@ msgstr ""
 "zdroj média"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr "Zavřít"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Zavřít a zastavit stahování?"
 
@@ -243,8 +243,8 @@ msgstr "Zavřít a zastavit stahování?"
 msgid "Comma separated list"
 msgstr "Seznam oddělený čárkami"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Dokončeno"
@@ -254,7 +254,7 @@ msgstr "Dokončeno"
 msgid "Completed Notification Trigger"
 msgstr "Spuštění oznámení o dokončení"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
@@ -306,11 +306,11 @@ msgstr "Oříznutí miniatur zvuku"
 msgid "Crop Thumbnail"
 msgstr "Oříznout miniaturu"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -324,7 +324,7 @@ msgid "Delete"
 msgstr "Odstranit"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
@@ -431,12 +431,12 @@ msgid "Download Again"
 msgstr "Stáhnout znovu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Stahování dokončeno"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Stahování dokončeno s chybou"
 
@@ -445,7 +445,7 @@ msgstr "Stahování dokončeno s chybou"
 msgid "Download log was copied to clipboard."
 msgstr "Protokol stahování byl zkopírován do schránky."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Stáhnout média"
@@ -468,7 +468,7 @@ msgstr "Bylo spuštěno stahování pomocí aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Bylo spuštěno stahování pomocí ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -480,8 +480,8 @@ msgstr "Stahování videa a hudby z webu"
 msgid "Downloader"
 msgstr "Stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Stahování"
@@ -498,7 +498,7 @@ msgid "Downloading..."
 msgstr "Stahování..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Stahování dokončena"
 
@@ -592,7 +592,7 @@ msgid "Error"
 msgstr "Chyba"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Ukončit"
 
@@ -624,7 +624,7 @@ msgstr "Typ souboru"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -687,7 +687,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -720,7 +720,7 @@ msgstr "Informace o kódu jazyka"
 msgid "Leave empty to download from start."
 msgstr "Ponechte prázdné pro stažení od začátku."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Seznam podporovaných webů"
 
@@ -730,8 +730,8 @@ msgstr "Protokol"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Přihlásit se"
 
@@ -745,7 +745,7 @@ msgstr "Oříznout miniaturu na čtverec, užitečné při stahování hudby."
 msgid "Manage previously downloaded media."
 msgstr "Správa dříve stažených médií."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix chat"
 
@@ -800,40 +800,40 @@ msgstr "Minimální velikost rozdělení (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Název"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Název (prázdný)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr "Je dostupná nová aktualizace."
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Žádné aktivní připojení k internetu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr "Žádná dokončená stahování"
 
@@ -846,7 +846,7 @@ msgstr "Žádné údaje"
 msgid "No downloads running"
 msgstr "Nejsou spuštěna žádná stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr "Žádná probíhající stahování"
 
@@ -860,7 +860,7 @@ msgstr "Není vybrán žádný soubor"
 msgid "No Previous Downloads"
 msgstr "Žádná předchozí stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 msgid "No Queued Downloads"
 msgstr "Žádná stahování ve frontě"
 
@@ -937,14 +937,14 @@ msgstr "Otevřít složku"
 msgid "Overwrite Existing Files"
 msgstr "Přepsání existujících souborů"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -955,7 +955,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -963,7 +963,7 @@ msgid "Password"
 msgstr "Heslo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Heslo (prázdné)"
 
@@ -980,10 +980,6 @@ msgstr "Playlist"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-msgid "Preparing required tools..."
-msgstr "Příprava požadovaných nástrojů..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1014,14 +1010,14 @@ msgstr "URL proxy"
 msgid "Quality"
 msgstr "Kvalita"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Ve frontě"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Zbývající stahování: {0}"
@@ -1041,7 +1037,7 @@ msgid "Reset"
 msgstr "Resetovat"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Resetovat klíčenku?"
 
@@ -1067,7 +1063,7 @@ msgid "Retry Download"
 msgstr "Opakovat stahování"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1113,17 +1109,17 @@ msgid "Select Save Folder"
 msgstr "Vybrat složku k uložení"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr "Nastavení"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr "Zobrazit okno"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1170,7 +1166,7 @@ msgid "Start Time (Invalid)"
 msgstr "Čas začátku (neplatný)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1227,7 +1223,7 @@ msgid "Theme"
 msgstr "Motiv"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Tato akce je nevratná. Určitě chcete klíčenku odstranit?"
 
@@ -1240,12 +1236,8 @@ msgstr ""
 "Tento limit (v KiB/s) bude použit pro stahování, u kterých je povoleno "
 "omezení rychlosti. Změna hodnoty nemá vliv na již spuštěná stahování."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr "Toto může chvíli trvat"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1253,36 +1245,30 @@ msgstr ""
 "Tato akce odstraní předchozí klíčenku, což také odstraní všechna hesla "
 "uvnitř klíčenky. Tato akce je nevratná."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Nepodařilo se zakázat klíčenku."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Nepodařilo se resetovat klíčenku."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Nepodařilo se nastavit závislosti. Restartujte prosím aplikaci a zkuste to "
-"znovu."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Vrátit úpravu názvu"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Odemknout klíčenku"
 
@@ -1290,19 +1276,19 @@ msgstr "Odemknout klíčenku"
 msgid "Unset Cookies File"
 msgstr "Nenastaven soubor s cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr "Aktualizovat"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Adresa URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "Adresa URL (neplatná)"
 
@@ -1335,14 +1321,14 @@ msgid "User Interface"
 msgstr "Uživatelské rozhraní"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr "Uživatelské jméno (prázdné)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1394,9 +1380,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ano"
@@ -1543,6 +1529,17 @@ msgstr "— Možnost stahovat několik videí najednou"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Podporuje stahování metadat a titulků videí"
+
+#~ msgid "Preparing required tools..."
+#~ msgstr "Příprava požadovaných nástrojů..."
+
+#~ msgid "This may take a while"
+#~ msgstr "Toto může chvíli trvat"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Nepodařilo se nastavit závislosti. Restartujte prosím aplikaci a zkuste "
+#~ "to znovu."
 
 #~ msgid "Search..."
 #~ msgstr "Hledat..."

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-11-03 17:20+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
-"Language-Team: Czech <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/cs/>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Soubor „{0}“ byl stažen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Stahování souboru „{0}“ skončilo s chybou!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Lze upravit v předvolbách)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -68,8 +68,8 @@ msgstr[2] "{0} stahování — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -91,7 +91,7 @@ msgstr ""
 "Programu yt-dlp lze poskytnout soubor s cookies pro stáhnutí médií, která "
 "vyžadují přihlášení."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "O aplikaci {0}"
@@ -102,18 +102,18 @@ msgstr "O aplikaci {0}"
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Pro spuštění stahování přidejte adresu URL videa, zvuku nebo playlistu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Přidat přihlášení"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Rozšířené možnosti"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Všechna stahování byla dokončena."
 
@@ -153,17 +153,17 @@ msgstr "Použít"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Zvuk"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Jazyk zvuku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Přihlášení"
@@ -172,7 +172,7 @@ msgstr "Přihlášení"
 msgid "Automatically Check for Updates"
 msgstr "Automaticky kontrolovat aktualizace"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Zpět"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Nejlepší"
 
@@ -192,7 +192,7 @@ msgstr "Zrušit"
 msgid "Changelog"
 msgstr "Seznam změn"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr "Zkontrolovat aktualizace"
 
@@ -201,8 +201,8 @@ msgstr "Zkontrolovat aktualizace"
 msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Vymazat dokončená stahování"
@@ -221,21 +221,21 @@ msgstr ""
 "Vymazat pole metadat obsahující adresu URL a další informace identifikující "
 "zdroj média"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Vymazat stahování ve frontě"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Zavřít"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Zavřít a zastavit stahování?"
 
@@ -243,8 +243,8 @@ msgstr "Zavřít a zastavit stahování?"
 msgid "Comma separated list"
 msgstr "Seznam oddělený čárkami"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Dokončeno"
@@ -254,7 +254,7 @@ msgstr "Dokončeno"
 msgid "Completed Notification Trigger"
 msgstr "Spuštění oznámení o dokončení"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
@@ -301,16 +301,16 @@ msgstr "Zásluhy"
 msgid "Crop Audio Thumbnails"
 msgstr "Oříznutí miniatur zvuku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Oříznout miniaturu"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -328,7 +328,7 @@ msgstr "Odstranit"
 msgid "Delete Credential?"
 msgstr "Odstranit údaje?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Zrušit výběr"
@@ -411,15 +411,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Zakázat převody"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskuze"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Dokumentace"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -430,13 +430,13 @@ msgstr "Stáhnout"
 msgid "Download Again"
 msgstr "Stáhnout znovu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Stahování dokončeno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Stahování dokončeno s chybou"
 
@@ -445,17 +445,17 @@ msgstr "Stahování dokončeno s chybou"
 msgid "Download log was copied to clipboard."
 msgstr "Protokol stahování byl zkopírován do schránky."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Stáhnout média"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Stáhnout konkrétní časový úsek"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Stáhnout titulky"
@@ -468,20 +468,20 @@ msgstr "Bylo spuštěno stahování pomocí aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Bylo spuštěno stahování pomocí ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Stahování videa a hudby z webu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Stahování"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Stahování"
@@ -497,12 +497,12 @@ msgstr "Stahování {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Stahování..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Stahování dokončena"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Upravit"
 
@@ -536,27 +536,27 @@ msgstr ""
 "průběh stahování."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Čas konce"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Čas konce (neplatný)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr "Zde zadejte adresu URL média"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Ujistěte se, že jsou údaje správné."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr "Zde zadejte konečný čas"
 
@@ -564,7 +564,7 @@ msgstr "Zde zadejte konečný čas"
 msgid "Enter name here"
 msgstr "Zde zadejte název"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr "Zde zadejte heslo"
@@ -573,7 +573,7 @@ msgstr "Zde zadejte heslo"
 msgid "Enter proxy url here"
 msgstr "Zde zadejte adresu URL proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr "Zde zadejte počáteční čas"
 
@@ -581,7 +581,7 @@ msgstr "Zde zadejte počáteční čas"
 msgid "Enter url here"
 msgstr "Zde zadejte adresu URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr "Zde zadejte uživatelské jméno"
@@ -591,8 +591,8 @@ msgstr "Zde zadejte uživatelské jméno"
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Ukončit"
 
@@ -601,7 +601,7 @@ msgstr "Ukončit"
 msgid "Failed to enable keyring."
 msgstr "Nepodařilo se povolit klíčenku."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Soubor"
 
@@ -614,7 +614,7 @@ msgstr "Soubor již existuje a přepisování je zakázáno"
 msgid "File Name"
 msgstr "Název souboru"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Typ souboru"
@@ -624,23 +624,23 @@ msgstr "Typ souboru"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Nápověda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -688,13 +688,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Klíčenka"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Údaj klíčenky"
@@ -714,13 +714,13 @@ msgstr "Klíčenka uzamčena"
 msgid "Language Code Information"
 msgstr "Informace o kódu jazyka"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Ponechte prázdné pro stažení od začátku."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Seznam podporovaných webů"
 
@@ -735,7 +735,7 @@ msgstr "Protokol"
 msgid "Login"
 msgstr "Přihlásit se"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Oříznout miniaturu na čtverec, užitečné při stahování hudby."
@@ -745,7 +745,7 @@ msgstr "Oříznout miniaturu na čtverec, užitečné při stahování hudby."
 msgid "Manage previously downloaded media."
 msgstr "Správa dříve stažených médií."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix chat"
 
@@ -760,11 +760,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Maximální počet aktivních stahování"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Maximální kvalita"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -776,14 +776,13 @@ msgstr ""
 "povolen."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL média"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Adresa URL média (neplatná)"
 
@@ -811,30 +810,30 @@ msgstr "Název"
 msgid "Name (Empty)"
 msgstr "Název (prázdný)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr "Je dostupná nová aktualizace."
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Žádné aktivní připojení k internetu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 msgid "No Completed Downloads"
 msgstr "Žádná dokončená stahování"
 
@@ -847,7 +846,7 @@ msgstr "Žádné údaje"
 msgid "No downloads running"
 msgstr "Nejsou spuštěna žádná stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Downloads Running"
 msgstr "Žádná probíhající stahování"
 
@@ -861,25 +860,25 @@ msgstr "Není vybrán žádný soubor"
 msgid "No Previous Downloads"
 msgstr "Žádná předchozí stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 msgid "No Queued Downloads"
 msgstr "Žádná stahování ve frontě"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Očíslovat názvy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -900,14 +899,14 @@ msgstr "Vypnuto"
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -938,14 +937,14 @@ msgstr "Otevřít složku"
 msgid "Overwrite Existing Files"
 msgstr "Přepsání existujících souborů"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -954,7 +953,7 @@ msgstr ""
 "nápovědy."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -974,11 +973,15 @@ msgid "Play"
 msgstr "Přehrát"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 msgid "Preparing required tools..."
 msgstr "Příprava požadovaných nástrojů..."
 
@@ -992,7 +995,7 @@ msgstr "Příprava..."
 msgid "Prevent Suspend"
 msgstr "Zabránit uspání"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr "NÁHLED"
 
@@ -1006,19 +1009,19 @@ msgstr "Zpracovává se..."
 msgid "Proxy URL"
 msgstr "URL proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kvalita"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Ve frontě"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Zbývající stahování: {0}"
@@ -1028,7 +1031,7 @@ msgstr "Zbývající stahování: {0}"
 msgid "Remove Source Data"
 msgstr "Odebrat zdrojová data"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Nahlásit chybu"
 
@@ -1063,22 +1066,22 @@ msgstr "Restartovat pro použití motivu?"
 msgid "Retry Download"
 msgstr "Opakovat stahování"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Opakovat selhaná stahování"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Složka k uložení"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Složka k uložení (neplatná)"
 
@@ -1087,7 +1090,7 @@ msgstr "Složka k uložení (neplatná)"
 msgid "Search history"
 msgstr "Historie vyhledávání"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Vybrat vše"
@@ -1098,29 +1101,29 @@ msgstr "Vybrat vše"
 msgid "Select Cookies File"
 msgstr "Vybrat soubor s cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Vyberte položky ke stažení nebo změňte názvy souborů."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Vybrat složku k uložení"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr "Nastavení"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr "Zobrazit okno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1132,19 +1135,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Některá stahování skončila s chybami!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Omezení rychlosti"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Rozdělit kapitoly"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Rozdělí video do několika menších podle jeho kapitol."
@@ -1155,19 +1158,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informace o službě SponsorBlock (otevře se v prohlížeči)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Čas začátku"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Čas začátku (neplatný)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1203,7 +1206,7 @@ msgstr "Jazyky titulků (neplatné)"
 msgid "Success"
 msgstr "Úspěch"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1237,7 +1240,7 @@ msgstr ""
 "Tento limit (v KiB/s) bude použit pro stahování, u kterých je povoleno "
 "omezení rychlosti. Změna hodnoty nemá vliv na již spuštěná stahování."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr "Toto může chvíli trvat"
 
@@ -1250,7 +1253,7 @@ msgstr ""
 "Tato akce odstraní předchozí klíčenku, což také odstraní všechna hesla "
 "uvnitř klíčenky. Tato akce je nevratná."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
@@ -1259,7 +1262,7 @@ msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 msgid "Unable to disable keyring."
 msgstr "Nepodařilo se zakázat klíčenku."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1268,7 +1271,7 @@ msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 msgid "Unable to reset keyring."
 msgstr "Nepodařilo se resetovat klíčenku."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Nepodařilo se nastavit závislosti. Restartujte prosím aplikaci a zkuste to "
@@ -1279,7 +1282,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Vrátit úpravu názvu"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Odemknout klíčenku"
 
@@ -1287,7 +1290,7 @@ msgstr "Odemknout klíčenku"
 msgid "Unset Cookies File"
 msgstr "Nenastaven soubor s cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr "Aktualizovat"
 
@@ -1337,7 +1340,7 @@ msgid "User Name (Empty)"
 msgstr "Uživatelské jméno (prázdné)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1346,13 +1349,18 @@ msgid "Username"
 msgstr "Uživatelské jméno"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Ověřit"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Ověřit"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1370,7 +1378,7 @@ msgid "Waiting..."
 msgstr "Čekání..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Nejhorší"
 
@@ -1385,10 +1393,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ano"

--- a/NickvisionTubeConverter.Shared/Resources/po/cs.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-03 17:20+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Soubor „{0}“ byl stažen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Stahování souboru „{0}“ skončilo s chybou!"
@@ -133,8 +133,8 @@ msgstr "Přidat přihlášení"
 msgid "Advanced Options"
 msgstr "Rozšířené možnosti"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Všechna stahování byla dokončena."
 
@@ -234,8 +234,8 @@ msgstr "Vymazat stahování ve frontě"
 msgid "Close"
 msgstr "Zavřít"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Zavřít a zastavit stahování?"
 
@@ -411,6 +411,10 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Zakázat převody"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskuze"
@@ -418,6 +422,10 @@ msgstr "Diskuze"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Dokumentace"
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
@@ -430,13 +438,13 @@ msgstr "Stáhnout"
 msgid "Download Again"
 msgstr "Stáhnout znovu"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Stahování dokončeno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Stahování dokončeno s chybou"
 
@@ -497,8 +505,8 @@ msgstr "Stahování {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Stahování..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Stahování dokončena"
 
@@ -628,7 +636,7 @@ msgstr "Firefox"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
@@ -810,7 +818,7 @@ msgstr "Název"
 msgid "Name (Empty)"
 msgstr "Název (prázdný)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr "Je dostupná nová aktualizace."
 
@@ -821,15 +829,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Žádné aktivní připojení k internetu"
 
@@ -896,6 +904,7 @@ msgstr "Vypnuto"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1017,7 +1026,7 @@ msgid "Queued"
 msgstr "Ve frontě"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Zbývající stahování: {0}"
@@ -1118,8 +1127,8 @@ msgstr "Nastavení"
 msgid "Show Window"
 msgstr "Zobrazit okno"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1202,7 +1211,8 @@ msgstr "Jazyky titulků (neplatné)"
 msgid "Success"
 msgstr "Úspěch"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1254,7 +1264,7 @@ msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 msgid "Unable to disable keyring."
 msgstr "Nepodařilo se zakázat klíčenku."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1268,7 +1278,7 @@ msgstr "Nepodařilo se resetovat klíčenku."
 msgid "Undo Title Editing"
 msgstr "Vrátit úpravu názvu"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Odemknout klíčenku"
 
@@ -1276,7 +1286,7 @@ msgstr "Odemknout klíčenku"
 msgid "Unset Cookies File"
 msgstr "Nenastaven soubor s cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr "Aktualizovat"
 
@@ -1379,10 +1389,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ano"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" wurde heruntergeladen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Bei \"{0}\" ist beim Herunterladen ein Fehler aufgetreten!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(In Einstellungen konfigurierbar)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} Downloads — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Eine Cookie-Datei kann yt-dlp bereitgestellt werden um Medien "
 "herunterzuladen die einen Login benötigen."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Über {0}"
@@ -100,7 +100,7 @@ msgstr "Über {0}"
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,12 +108,12 @@ msgstr ""
 "starten"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Anmeldedaten hinzufügen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Alle Downloads abgeschlossen."
 
@@ -153,17 +153,17 @@ msgstr "Anwenden"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Audiosprache"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Anmelden"
@@ -172,7 +172,7 @@ msgstr "Anmelden"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Zurück"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Am besten"
 
@@ -192,7 +192,7 @@ msgstr "Abbrechen"
 msgid "Changelog"
 msgstr "Änderungsliste"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -201,8 +201,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Abgeschlossene Downloads leeren"
@@ -221,21 +221,21 @@ msgstr ""
 "Metadatenfelder, die die URL oder andere identifizierende Informationen zur "
 "Medienquelle enthalten, löschen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Warteschlange löschen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Schließen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Downloads abbrechen und beenden?"
 
@@ -243,8 +243,8 @@ msgstr "Downloads abbrechen und beenden?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -254,7 +254,7 @@ msgstr "Abgeschlossen"
 msgid "Completed Notification Trigger"
 msgstr "Benachrichtigungsauslöser abgeschlossen"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
@@ -303,16 +303,16 @@ msgstr "Anmeldedaten"
 msgid "Crop Audio Thumbnails"
 msgstr "Audio-Vorschau Zuschneiden"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Vorschau zuschneiden"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -330,7 +330,7 @@ msgstr "Löschen"
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Auswahl aufheben"
@@ -406,15 +406,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Umwandlungen nicht zulassen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskussionen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -425,13 +425,13 @@ msgstr "Herunterladen"
 msgid "Download Again"
 msgstr "Erneut herunterladen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Download Beendet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Download mit Fehler Beendet"
 
@@ -440,17 +440,17 @@ msgstr "Download mit Fehler Beendet"
 msgid "Download log was copied to clipboard."
 msgstr "Download-Protokoll wurde in die Zwischenablage kopiert."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Medien Herunterladen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Bestimmten Zeitraum herunterladen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Untertitel herunterladen"
@@ -463,20 +463,20 @@ msgstr "Download mit aria2 angefangen"
 msgid "Download using ffmpeg has started"
 msgstr "Download mit FFmpeg angefangen"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Download Web-Video und Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Downloader"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Wird heruntergeladen"
@@ -493,12 +493,12 @@ msgstr "Herunterladen: {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Wird heruntergeladen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Downloads Beendet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -532,28 +532,28 @@ msgstr ""
 "Download-Fortschritt nicht sehen."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Endzeit"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Endzeit (Ungültig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Video-URL hier eingeben"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Stelle sicher das Anmeldedaten korrekt sind."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Video-URL hier eingeben"
@@ -563,7 +563,7 @@ msgstr "Video-URL hier eingeben"
 msgid "Enter name here"
 msgstr "Video-URL hier eingeben"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -574,7 +574,7 @@ msgstr "Video-URL hier eingeben"
 msgid "Enter proxy url here"
 msgstr "Video-URL hier eingeben"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Video-URL hier eingeben"
@@ -584,7 +584,7 @@ msgstr "Video-URL hier eingeben"
 msgid "Enter url here"
 msgstr "Video-URL hier eingeben"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -595,8 +595,8 @@ msgstr "Video-URL hier eingeben"
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Schlüsselring konnte nicht aktiviert werden."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Dateiname"
@@ -619,7 +619,7 @@ msgstr "Datei existiert bereits, und Überschreiben ist nicht erlaubt"
 msgid "File Name"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Dateityp"
@@ -629,23 +629,23 @@ msgstr "Dateityp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-Repository"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Hilfe"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -693,13 +693,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Schlüsselring"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Schlüsselring-Anmeldedaten"
@@ -719,13 +719,13 @@ msgstr "Schlüsselring gesperrt"
 msgid "Language Code Information"
 msgstr "Informationen zum Sprachcode"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Leer lassen um von Anfang an herunterzuladen."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Liste der unterstützten Seiten"
 
@@ -741,7 +741,7 @@ msgstr "Anmeldung"
 msgid "Login"
 msgstr "Anmeldung"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Vorschau quadratisch machen, nützlich bei Musik."
@@ -751,7 +751,7 @@ msgstr "Vorschau quadratisch machen, nützlich bei Musik."
 msgid "Manage previously downloaded media."
 msgstr "Verwalte zuvor heruntergeladene Medien."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -766,11 +766,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Maximale Anzahl aktiver Downloads"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Höchste Qualität"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -782,14 +782,13 @@ msgstr ""
 "aktiviert ist."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Medien-URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Video Url (ungültig)"
 
@@ -816,30 +815,30 @@ msgstr "Name"
 msgid "Name (Empty)"
 msgstr "Name (Leer)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Keine aktive Internetverbindung"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Abgeschlossene Downloads leeren"
@@ -853,7 +852,7 @@ msgstr "Keine Anmeldedaten"
 msgid "No downloads running"
 msgstr "Keine laufenden Downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Keine laufenden Downloads"
@@ -868,26 +867,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Keine bisherigen Downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Warteschlange löschen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Titelnummern"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -908,14 +907,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -947,21 +946,21 @@ msgstr "Ordner öffnen"
 msgid "Overwrite Existing Files"
 msgstr "Vorhandene Dateien überschreiben"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -981,11 +980,15 @@ msgid "Play"
 msgstr "Abspielen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Vorbereiten..."
@@ -1000,7 +1003,7 @@ msgstr "Vorbereiten..."
 msgid "Prevent Suspend"
 msgstr "Ruhezustand verhindern"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1014,19 +1017,19 @@ msgstr "Verarbeitung..."
 msgid "Proxy URL"
 msgstr "Proxy-URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Qualität"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Warteschlange"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Fehlgeschlagene Downloads wiederholen"
@@ -1036,7 +1039,7 @@ msgstr "Fehlgeschlagene Downloads wiederholen"
 msgid "Remove Source Data"
 msgstr "Daten zur Quelle entfernen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Einen Fehler melden"
 
@@ -1071,22 +1074,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Download wiederholen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Fehlgeschlagene Downloads wiederholen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Speicherordner"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Ordner speichern (ungültig)"
 
@@ -1096,7 +1099,7 @@ msgstr "Ordner speichern (ungültig)"
 msgid "Search history"
 msgstr "Verlauf löschen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Alle auswählen"
@@ -1107,30 +1110,30 @@ msgstr "Alle auswählen"
 msgid "Select Cookies File"
 msgstr "Cookie-Datei auswählen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Wähle Elemente zum heruntergeladen oder Dateinamen ändern."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Speicherordner wählen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1143,19 +1146,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Einige Downloads wurden mit Fehlern beendet!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Geschwindigkeitsbegrenzung"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "In Kapitel unterteilen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Teilt das Video in mehrere kürzere basierend auf den Kapiteln."
@@ -1166,19 +1169,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "SponsorBlock-Information (öffnet im Web-Browser)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Startzeit"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Startzeit (Ungültig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1215,7 +1218,7 @@ msgstr "Untertitel-Sprachen (Ungültig)"
 msgid "Success"
 msgstr "Erfolg"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1253,7 +1256,7 @@ msgstr ""
 "Geschwindigkeitsbegrenzung aktiviert ist. Änderung des Wertes hat keine "
 "Auswirkungen auf bereits laufende Downloads."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1266,7 +1269,7 @@ msgstr ""
 "Hierdurch wird der Schlüsselring und alle darin gespeicherten Passwörter "
 "gelöscht. Die Aktion kann nicht rückgängig gemacht werden."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "Feliks Weber <feliks@notabit.eu>\n"
@@ -1277,7 +1280,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Schlüsselring kann nicht deaktiviert werden."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1286,7 +1289,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Schlüsselring kann nicht zurückgesetzt werden."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Die Abhängigkeiten können nicht heruntergeladen werden. Bitte starte die "
@@ -1297,7 +1300,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Titelbearbeitung rückgängig machen"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Schlüsselring entsperren"
 
@@ -1306,7 +1309,7 @@ msgstr "Schlüsselring entsperren"
 msgid "Unset Cookies File"
 msgstr "Cookie-Datei auswählen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1358,7 +1361,7 @@ msgid "User Name (Empty)"
 msgstr "Nutzername (Leer)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1367,13 +1370,18 @@ msgid "Username"
 msgstr "Nutzername"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validieren"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validieren"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1391,7 +1399,7 @@ msgid "Waiting..."
 msgstr "Warten..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Am schlechtesten"
 
@@ -1404,10 +1412,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" wurde heruntergeladen."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Bei \"{0}\" ist beim Herunterladen ein Fehler aufgetreten!"
@@ -100,7 +100,7 @@ msgstr "Über {0}"
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -111,9 +111,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,7 +134,7 @@ msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Alle Downloads abgeschlossen."
 
@@ -202,7 +202,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Abgeschlossene Downloads leeren"
@@ -222,7 +222,7 @@ msgstr ""
 "Medienquelle enthalten, löschen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr "Schließen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Downloads abbrechen und beenden?"
 
@@ -243,8 +243,8 @@ msgstr "Downloads abbrechen und beenden?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -254,7 +254,7 @@ msgstr "Abgeschlossen"
 msgid "Completed Notification Trigger"
 msgstr "Benachrichtigungsauslöser abgeschlossen"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
@@ -308,11 +308,11 @@ msgstr "Audio-Vorschau Zuschneiden"
 msgid "Crop Thumbnail"
 msgstr "Vorschau zuschneiden"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -326,7 +326,7 @@ msgid "Delete"
 msgstr "Löschen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Anmeldedaten löschen?"
 
@@ -426,12 +426,12 @@ msgid "Download Again"
 msgstr "Erneut herunterladen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Download Beendet"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Download mit Fehler Beendet"
 
@@ -440,7 +440,7 @@ msgstr "Download mit Fehler Beendet"
 msgid "Download log was copied to clipboard."
 msgstr "Download-Protokoll wurde in die Zwischenablage kopiert."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Medien Herunterladen"
@@ -463,7 +463,7 @@ msgstr "Download mit aria2 angefangen"
 msgid "Download using ffmpeg has started"
 msgstr "Download mit FFmpeg angefangen"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -475,8 +475,8 @@ msgstr "Download Web-Video und Audio"
 msgid "Downloader"
 msgstr "Downloader"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Wird heruntergeladen"
@@ -494,7 +494,7 @@ msgid "Downloading..."
 msgstr "Wird heruntergeladen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Downloads Beendet"
 
@@ -596,7 +596,7 @@ msgid "Error"
 msgstr "Fehler"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr "Dateityp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -692,7 +692,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -725,7 +725,7 @@ msgstr "Informationen zum Sprachcode"
 msgid "Leave empty to download from start."
 msgstr "Leer lassen um von Anfang an herunterzuladen."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Liste der unterstützten Seiten"
 
@@ -736,8 +736,8 @@ msgstr "Anmeldung"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Anmeldung"
 
@@ -751,7 +751,7 @@ msgstr "Vorschau quadratisch machen, nützlich bei Musik."
 msgid "Manage previously downloaded media."
 msgstr "Verwalte zuvor heruntergeladene Medien."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -805,40 +805,40 @@ msgstr "Minimale Teilungsgröße (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Name"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Name (Leer)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Keine aktive Internetverbindung"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Abgeschlossene Downloads leeren"
@@ -852,7 +852,7 @@ msgstr "Keine Anmeldedaten"
 msgid "No downloads running"
 msgstr "Keine laufenden Downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Keine laufenden Downloads"
@@ -867,7 +867,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Keine bisherigen Downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Warteschlange löschen"
@@ -946,14 +946,14 @@ msgstr "Ordner öffnen"
 msgid "Overwrite Existing Files"
 msgstr "Vorhandene Dateien überschreiben"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -962,7 +962,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -970,7 +970,7 @@ msgid "Password"
 msgstr "Passwort"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Passwort (Leer)"
 
@@ -987,11 +987,6 @@ msgstr "Wiedergabeliste"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Vorbereiten..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1022,14 +1017,14 @@ msgstr "Proxy-URL"
 msgid "Quality"
 msgstr "Qualität"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Warteschlange"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Fehlgeschlagene Downloads wiederholen"
@@ -1049,7 +1044,7 @@ msgid "Reset"
 msgstr "Zurücksetzen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Schlüsselring zurücksetzen?"
 
@@ -1075,7 +1070,7 @@ msgid "Retry Download"
 msgstr "Download wiederholen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1122,18 +1117,18 @@ msgid "Select Save Folder"
 msgstr "Speicherordner wählen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1181,7 +1176,7 @@ msgid "Start Time (Invalid)"
 msgstr "Startzeit (Ungültig)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1240,7 +1235,7 @@ msgid "Theme"
 msgstr "Farbschema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Diese Aktion kann nicht rückgängig gemacht werden. Bist du sicher dass du es "
@@ -1256,12 +1251,8 @@ msgstr ""
 "Geschwindigkeitsbegrenzung aktiviert ist. Änderung des Wertes hat keine "
 "Auswirkungen auf bereits laufende Downloads."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1269,38 +1260,32 @@ msgstr ""
 "Hierdurch wird der Schlüsselring und alle darin gespeicherten Passwörter "
 "gelöscht. Die Aktion kann nicht rückgängig gemacht werden."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "Feliks Weber <feliks@notabit.eu>\n"
 "Simon Hahne <simon@nicewaffel.dev>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Schlüsselring kann nicht deaktiviert werden."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Schlüsselring kann nicht zurückgesetzt werden."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Die Abhängigkeiten können nicht heruntergeladen werden. Bitte starte die "
-"Anwendung neu und versuche es erneut."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Titelbearbeitung rückgängig machen"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Schlüsselring entsperren"
 
@@ -1309,19 +1294,19 @@ msgstr "Schlüsselring entsperren"
 msgid "Unset Cookies File"
 msgstr "Cookie-Datei auswählen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (Ungültig)"
 
@@ -1355,7 +1340,7 @@ msgid "User Interface"
 msgstr "Benutzeroberfläche"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nutzername (Leer)"
@@ -1363,7 +1348,7 @@ msgstr "Nutzername (Leer)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1413,9 +1398,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"
@@ -1563,6 +1548,15 @@ msgstr "— Lade mehrere Medien gleichzeitig herunter"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Unterstützt herunterladen von Metadaten und Videountertiteln"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Vorbereiten..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Die Abhängigkeiten können nicht heruntergeladen werden. Bitte starte die "
+#~ "Anwendung neu und versuche es erneut."
 
 #~ msgid "Search..."
 #~ msgstr "Suchen..."

--- a/NickvisionTubeConverter.Shared/Resources/po/de.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" wurde heruntergeladen."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Bei \"{0}\" ist beim Herunterladen ein Fehler aufgetreten!"
@@ -133,8 +133,8 @@ msgstr "Anmeldedaten hinzufügen"
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Alle Downloads abgeschlossen."
 
@@ -234,8 +234,8 @@ msgstr "Warteschlange löschen"
 msgid "Close"
 msgstr "Schließen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Downloads abbrechen und beenden?"
 
@@ -406,12 +406,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Umwandlungen nicht zulassen"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskussionen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -425,13 +433,13 @@ msgstr "Herunterladen"
 msgid "Download Again"
 msgstr "Erneut herunterladen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Download Beendet"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Download mit Fehler Beendet"
 
@@ -493,8 +501,8 @@ msgstr "Herunterladen: {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Wird heruntergeladen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Downloads Beendet"
 
@@ -633,7 +641,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-Repository"
@@ -815,7 +823,7 @@ msgstr "Name"
 msgid "Name (Empty)"
 msgstr "Name (Leer)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -826,15 +834,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Keine aktive Internetverbindung"
 
@@ -904,6 +912,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1024,7 +1033,7 @@ msgid "Queued"
 msgstr "Warteschlange"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Fehlgeschlagene Downloads wiederholen"
@@ -1127,8 +1136,8 @@ msgstr "Einstellungen"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1213,7 +1222,8 @@ msgstr "Untertitel-Sprachen (Ungültig)"
 msgid "Success"
 msgstr "Erfolg"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1271,7 +1281,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Schlüsselring kann nicht deaktiviert werden."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1285,7 +1295,7 @@ msgstr "Schlüsselring kann nicht zurückgesetzt werden."
 msgid "Undo Title Editing"
 msgstr "Titelbearbeitung rückgängig machen"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Schlüsselring entsperren"
 
@@ -1294,7 +1304,7 @@ msgstr "Schlüsselring entsperren"
 msgid "Unset Cookies File"
 msgstr "Cookie-Datei auswählen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1397,10 +1407,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/el.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-23 16:26+0000\n"
 "Last-Translator: MOUSTAFA ALIOGLOU <moystafaa@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "ολοκληρώθηκε η λήψη του \"{0}\"."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Το \"{0}\" τελείωσε με σφάλμα!"
@@ -129,8 +129,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "Επιλογές για προχωρημένους"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Όλες οι λήψεις έχουν ολοκληρωθεί."
 
@@ -228,8 +228,8 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Κλείσιμο και διακοπή λήψεων;"
 
@@ -382,12 +382,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -401,13 +409,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Η λήψη ολοκληρώθηκε"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 
@@ -470,8 +478,8 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Η λήψη ολοκληρώθηκε"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr ""
 
@@ -600,7 +608,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
@@ -769,7 +777,7 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -780,15 +788,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -856,6 +864,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -975,7 +984,7 @@ msgid "Queued"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -1076,8 +1085,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1158,7 +1167,8 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1203,7 +1213,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1217,7 +1227,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1225,7 +1235,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1323,10 +1333,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/el.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-23 16:26+0000\n"
 "Last-Translator: MOUSTAFA ALIOGLOU <moystafaa@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "ολοκληρώθηκε η λήψη του \"{0}\"."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Το \"{0}\" τελείωσε με σφάλμα!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Δυνατότητα διαμόρφωσης στις προτιμήσεις)"
 
@@ -48,7 +48,7 @@ msgstr ""
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr ""
@@ -67,8 +67,8 @@ msgstr[1] "{0} λήψεις — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -98,18 +98,18 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -123,14 +123,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Επιλογές για προχωρημένους"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Όλες οι λήψεις έχουν ολοκληρωθεί."
 
@@ -149,17 +149,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Ήχος"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr ""
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -176,7 +176,7 @@ msgid "Back"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Καλύτερη"
 
@@ -188,7 +188,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -215,21 +215,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Κλείσιμο και διακοπή λήψεων;"
 
@@ -237,8 +237,8 @@ msgstr "Κλείσιμο και διακοπή λήψεων;"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Συνεισφέροντες στο GitHub ❤️"
 
@@ -292,16 +292,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -382,15 +382,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -401,13 +401,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Η λήψη ολοκληρώθηκε"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 
@@ -416,17 +416,17 @@ msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -440,20 +440,20 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -470,12 +470,12 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Η λήψη ολοκληρώθηκε"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -508,27 +508,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -563,8 +563,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr ""
@@ -596,23 +596,23 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -651,13 +651,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -677,13 +677,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr ""
 
@@ -723,11 +723,11 @@ msgid "Max Number of Active Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -736,14 +736,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr ""
 
@@ -770,30 +769,30 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -806,7 +805,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Downloads Running"
 msgstr ""
 
@@ -820,26 +819,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Προσθήκη λήψης"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -860,14 +859,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -898,21 +897,21 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -932,11 +931,15 @@ msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 msgid "Preparing required tools..."
 msgstr ""
 
@@ -950,7 +953,7 @@ msgstr ""
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -964,19 +967,19 @@ msgstr ""
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -986,7 +989,7 @@ msgstr ""
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1021,22 +1024,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr ""
 
@@ -1045,7 +1048,7 @@ msgstr ""
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
@@ -1056,29 +1059,29 @@ msgstr ""
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1088,19 +1091,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1111,19 +1114,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1159,7 +1162,7 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1188,7 +1191,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1199,7 +1202,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1208,7 +1211,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1217,7 +1220,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
@@ -1226,7 +1229,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1234,7 +1237,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1282,7 +1285,7 @@ msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1291,13 +1294,17 @@ msgid "Username"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+msgid "Validating"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr ""
 
@@ -1315,7 +1322,7 @@ msgid "Waiting..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr ""
 
@@ -1328,10 +1335,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/el.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-23 16:26+0000\n"
 "Last-Translator: MOUSTAFA ALIOGLOU <moystafaa@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "ολοκληρώθηκε η λήψη του \"{0}\"."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Το \"{0}\" τελείωσε με σφάλμα!"
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -107,9 +107,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,7 +130,7 @@ msgid "Advanced Options"
 msgstr "Επιλογές για προχωρημένους"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Όλες οι λήψεις έχουν ολοκληρωθεί."
 
@@ -198,7 +198,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -216,7 +216,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -229,7 +229,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Κλείσιμο και διακοπή λήψεων;"
 
@@ -237,8 +237,8 @@ msgstr "Κλείσιμο και διακοπή λήψεων;"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Συνεισφέροντες στο GitHub ❤️"
 
@@ -297,11 +297,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -315,7 +315,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -402,12 +402,12 @@ msgid "Download Again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Η λήψη ολοκληρώθηκε"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 
@@ -416,7 +416,7 @@ msgstr "Η λήψη ολοκληρώθηκε με σφάλμα"
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -452,8 +452,8 @@ msgstr ""
 msgid "Downloader"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -471,7 +471,7 @@ msgid "Downloading..."
 msgstr "Η λήψη ολοκληρώθηκε"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgid "Error"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr ""
 
@@ -693,8 +693,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr ""
 
@@ -759,40 +759,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Προσθήκη λήψης"
@@ -897,14 +897,14 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -913,7 +913,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -921,7 +921,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -937,10 +937,6 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
-msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-msgid "Preparing required tools..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
@@ -972,14 +968,14 @@ msgstr ""
 msgid "Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -999,7 +995,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1025,7 +1021,7 @@ msgid "Retry Download"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1071,17 +1067,17 @@ msgid "Select Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1126,7 +1122,7 @@ msgid "Start Time (Invalid)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1180,7 +1176,7 @@ msgid "Theme"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1191,37 +1187,29 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
@@ -1229,7 +1217,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1237,19 +1225,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -1280,14 +1268,14 @@ msgid "User Interface"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1336,9 +1324,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-11-03 17:20+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" ha terminado de descargarse."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "¡\"{0}\" se completó con un error!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Configurable en las preferencias)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} descargas — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Se puede proporcionar un archivo de cookies a yt-dlp para permitir la "
 "descarga de medios que requieren un inicio de sesión."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Acerca de {0}"
@@ -100,7 +100,7 @@ msgstr "Acerca de {0}"
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,12 +108,12 @@ msgstr ""
 "descarga"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Añadir inicio de sesión"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opciones avanzadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Todas las descargas han finalizado."
 
@@ -153,17 +153,17 @@ msgstr "Aplicar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Idioma del audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autenticar"
@@ -172,7 +172,7 @@ msgstr "Autenticar"
 msgid "Automatically Check for Updates"
 msgstr "Comprobar automáticamente las actualizaciones"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Atrás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Mejor"
 
@@ -192,7 +192,7 @@ msgstr "Cancelar"
 msgid "Changelog"
 msgstr "Registro de cambios"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
@@ -201,8 +201,8 @@ msgstr "Buscar actualizaciones"
 msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Borrar descargas completadas"
@@ -221,21 +221,21 @@ msgstr ""
 "Borrar los campos de los metadatos que contienen la dirección URL y otros "
 "datos identificativos de la fuente multimedia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Borrar descargas en cola"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "¿Cerrar y detener descargas?"
 
@@ -243,8 +243,8 @@ msgstr "¿Cerrar y detener descargas?"
 msgid "Comma separated list"
 msgstr "Lista separada por comas"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Completado"
@@ -254,7 +254,7 @@ msgstr "Completado"
 msgid "Completed Notification Trigger"
 msgstr "Disparador de las notificaciones de completado"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
@@ -301,16 +301,16 @@ msgstr "Créditos"
 msgid "Crop Audio Thumbnails"
 msgstr "Recortar miniaturas de audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -328,7 +328,7 @@ msgstr "Eliminar"
 msgid "Delete Credential?"
 msgstr "¿Borrar credencial?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleccionar todo"
@@ -414,15 +414,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "No permitir conversiones"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Debates"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Documentación"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -433,13 +433,13 @@ msgstr "Descargar"
 msgid "Download Again"
 msgstr "Descargar de nuevo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Descarga finalizada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Descarga finalizada con error"
 
@@ -448,17 +448,17 @@ msgstr "Descarga finalizada con error"
 msgid "Download log was copied to clipboard."
 msgstr "El registro de descargas se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Descargar medios"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Descargar plazos específicos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Descargar subtítulo"
@@ -471,20 +471,20 @@ msgstr "La descarga usando aria2 ha comenzado"
 msgid "Download using ffmpeg has started"
 msgstr "La descarga usando ffmpeg ha comenzado"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Descargar vídeo y audio de la web"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Descargador"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Descargando"
@@ -500,12 +500,12 @@ msgstr "Descargando {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Descargas terminadas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Editar"
 
@@ -539,28 +539,28 @@ msgstr ""
 "el progreso de la descarga."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Hora de finalización"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Hora de finalización (no válida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Introduzca aquí la URL de los medios"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Asegúrese de que las credenciales son correctas."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr "Indique aquí el plazo final"
 
@@ -568,7 +568,7 @@ msgstr "Indique aquí el plazo final"
 msgid "Enter name here"
 msgstr "Escriba aquí el nombre"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr "Escriba aquí la contraseña"
@@ -577,7 +577,7 @@ msgstr "Escriba aquí la contraseña"
 msgid "Enter proxy url here"
 msgstr "Introduzca aquí la dirección url del proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr "Ingrese el plazo de inicio aquí"
 
@@ -585,7 +585,7 @@ msgstr "Ingrese el plazo de inicio aquí"
 msgid "Enter url here"
 msgstr "Introduzca aquí la dirección url"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr "Introduzca aquí el nombre de usuario"
@@ -595,8 +595,8 @@ msgstr "Introduzca aquí el nombre de usuario"
 msgid "Error"
 msgstr "Error"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Salir"
 
@@ -605,7 +605,7 @@ msgstr "Salir"
 msgid "Failed to enable keyring."
 msgstr "Fallo al activar el llavero."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Archivo"
 
@@ -618,7 +618,7 @@ msgstr "El archivo ya existe y no está permitido sobreescribirlo"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo de archivo"
@@ -628,23 +628,23 @@ msgstr "Tipo de archivo"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Ayuda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -692,13 +692,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Llavero"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Credencial del llavero"
@@ -718,13 +718,13 @@ msgstr "Llavero bloqueado"
 msgid "Language Code Information"
 msgstr "Información del código del idioma"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Dejar en blanco para descargar desde el inicio."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lista de sitios compatibles"
 
@@ -739,7 +739,7 @@ msgstr "Registro"
 msgid "Login"
 msgstr "Inicio de sesión"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Hacer miniaturas cuadradas, útil al descargar música."
@@ -749,7 +749,7 @@ msgstr "Hacer miniaturas cuadradas, útil al descargar música."
 msgid "Manage previously downloaded media."
 msgstr "Gestionar medios descargados previamente."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
@@ -764,11 +764,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Número máximo de descargas activas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Máxima calidad"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -780,14 +780,13 @@ msgstr ""
 "está activado."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL de los medios"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL a los medios (no válido)"
 
@@ -816,30 +815,30 @@ msgstr "Nombre"
 msgid "Name (Empty)"
 msgstr "Nombre (vacío)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Sin conexión a Internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 msgid "No Completed Downloads"
 msgstr "Sin descargas completadas"
 
@@ -852,7 +851,7 @@ msgstr "No hay credenciales"
 msgid "No downloads running"
 msgstr "No hay descargas en curso"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "No hay descargas en curso"
@@ -867,26 +866,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "No hay descargas previas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Borrar descargas en cola"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Número de los títulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -907,14 +906,14 @@ msgstr ""
 msgid "OK"
 msgstr "Vale"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -946,21 +945,21 @@ msgstr "Abrir carpeta"
 msgid "Overwrite Existing Files"
 msgstr "Sobreescribir archivos existentes"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -980,11 +979,15 @@ msgid "Play"
 msgstr "Reproducir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Preparando…"
@@ -999,7 +1002,7 @@ msgstr "Preparando…"
 msgid "Prevent Suspend"
 msgstr "Prevenir la suspensión"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1013,19 +1016,19 @@ msgstr "Procesando…"
 msgid "Proxy URL"
 msgstr "URL del proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Calidad"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "En cola"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Descargas restantes: {0}"
@@ -1035,7 +1038,7 @@ msgstr "Descargas restantes: {0}"
 msgid "Remove Source Data"
 msgstr "Eliminar los datos de origen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Informar de un error"
 
@@ -1070,22 +1073,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Reintentar descarga"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Reintentar descargas fallidas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Guardar carpeta"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Guardar carpeta (no válida)"
 
@@ -1095,7 +1098,7 @@ msgstr "Guardar carpeta (no válida)"
 msgid "Search history"
 msgstr "Borrar historial"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleccionar todo"
@@ -1106,7 +1109,7 @@ msgstr "Seleccionar todo"
 msgid "Select Cookies File"
 msgstr "Selecciona archivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
@@ -1114,24 +1117,24 @@ msgstr ""
 "archivos."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleccione la carpeta de guardado"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Configuración"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1143,19 +1146,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "¡Algunas descargas terminaron con errores!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Límite de velocidad"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Separar los capítulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divida el vídeo en varios más pequeños en función de sus capítulos."
@@ -1166,19 +1169,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Información sobre SponsorBlock (se abre en un navegador web)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Hora de inicio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Hora de inicio (no válida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1215,7 +1218,7 @@ msgstr "Idiomas de los subtítulos (no válido)"
 msgid "Success"
 msgstr "Éxito"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1250,7 +1253,7 @@ msgstr ""
 "límite de velocidad. Cambiar el valor no afecta a las descargas que ya se "
 "están ejecutando."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1263,7 +1266,7 @@ msgstr ""
 "Esto borrará el llavero anterior eliminando todas las contraseñas con él. "
 "Esta acción es irreversible."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "gallegonovato https://github.com/gallegonovato\n"
@@ -1274,7 +1277,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "No se puede desactivar el llavero."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1283,7 +1286,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "No se puede restablecer el llavero."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "No se han podido configurar las dependencias. Reinicie la aplicación e "
@@ -1294,7 +1297,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Deshacer la edición de los títulos"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Desbloquear llavero"
 
@@ -1303,7 +1306,7 @@ msgstr "Desbloquear llavero"
 msgid "Unset Cookies File"
 msgstr "Selecciona archivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1355,7 +1358,7 @@ msgid "User Name (Empty)"
 msgstr "Nombre de usuario (vacío)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1364,13 +1367,18 @@ msgid "Username"
 msgstr "Nombre de usuario"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validar"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Vídeo"
 
@@ -1388,7 +1396,7 @@ msgid "Waiting..."
 msgstr "Esperando..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Peor"
 
@@ -1401,10 +1409,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sí"

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-05 16:25+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" ha terminado de descargarse."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "¡\"{0}\" se completó con un error!"
@@ -133,8 +133,8 @@ msgstr "Añadir inicio de sesión"
 msgid "Advanced Options"
 msgstr "Opciones avanzadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Todas las descargas han finalizado."
 
@@ -234,8 +234,8 @@ msgstr "Borrar descargas en cola"
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "¿Cerrar y detener descargas?"
 
@@ -414,6 +414,10 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "No permitir conversiones"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Debates"
@@ -421,6 +425,10 @@ msgstr "Debates"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Documentación"
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
@@ -433,13 +441,13 @@ msgstr "Descargar"
 msgid "Download Again"
 msgstr "Descargar de nuevo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Descarga finalizada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Descarga finalizada con error"
 
@@ -500,8 +508,8 @@ msgstr "Descargando {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Descargas terminadas"
 
@@ -631,7 +639,7 @@ msgstr "Firefox"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
@@ -814,7 +822,7 @@ msgstr "Nombre"
 msgid "Name (Empty)"
 msgstr "Nombre (vacío)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
@@ -825,15 +833,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Sin conexión a Internet"
 
@@ -900,6 +908,7 @@ msgstr "Apagar"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "DE ACUERDO"
 
@@ -1021,7 +1030,7 @@ msgid "Queued"
 msgstr "En cola"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Descargas restantes: {0}"
@@ -1124,8 +1133,8 @@ msgstr "Ajustes"
 msgid "Show Window"
 msgstr "Mostrar la ventana"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1208,7 +1217,8 @@ msgstr "Idiomas de los subtítulos (no válido)"
 msgid "Success"
 msgstr "Éxito"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1263,7 +1273,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "No se puede desactivar el llavero."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
@@ -1277,7 +1287,7 @@ msgstr "No se puede restablecer el llavero."
 msgid "Undo Title Editing"
 msgstr "Deshacer la edición de los títulos"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Desbloquear llavero"
 
@@ -1285,7 +1295,7 @@ msgstr "Desbloquear llavero"
 msgid "Unset Cookies File"
 msgstr "Desactivar el archivo de las cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr "Actualización"
 
@@ -1389,10 +1399,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sí"

--- a/NickvisionTubeConverter.Shared/Resources/po/es.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-05 16:25+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" ha terminado de descargarse."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "¡\"{0}\" se completó con un error!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Configurable en las preferencias)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} descargas — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Se puede proporcionar un archivo de cookies a yt-dlp para permitir la "
 "descarga de medios que requieren un inicio de sesión."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Acerca de {0}"
@@ -100,7 +100,7 @@ msgstr "Acerca de {0}"
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,12 +108,12 @@ msgstr ""
 "descarga"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Añadir inicio de sesión"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opciones avanzadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Todas las descargas han finalizado."
 
@@ -153,17 +153,17 @@ msgstr "Aplicar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Idioma del audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autenticar"
@@ -172,7 +172,7 @@ msgstr "Autenticar"
 msgid "Automatically Check for Updates"
 msgstr "Comprobar automáticamente las actualizaciones"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Atrás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Mejor"
 
@@ -192,7 +192,7 @@ msgstr "Cancelar"
 msgid "Changelog"
 msgstr "Registro de cambios"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
@@ -201,8 +201,8 @@ msgstr "Buscar actualizaciones"
 msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Borrar descargas completadas"
@@ -221,21 +221,21 @@ msgstr ""
 "Borrar los campos de los metadatos que contienen la dirección URL y otros "
 "datos identificativos de la fuente multimedia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Borrar descargas en cola"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "¿Cerrar y detener descargas?"
 
@@ -243,8 +243,8 @@ msgstr "¿Cerrar y detener descargas?"
 msgid "Comma separated list"
 msgstr "Lista separada por comas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Completado"
@@ -254,7 +254,7 @@ msgstr "Completado"
 msgid "Completed Notification Trigger"
 msgstr "Disparador de las notificaciones de completado"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
@@ -301,16 +301,16 @@ msgstr "Créditos"
 msgid "Crop Audio Thumbnails"
 msgstr "Recortar miniaturas de audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -324,11 +324,11 @@ msgid "Delete"
 msgstr "Eliminar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "¿Borrar credencial?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleccionar todo"
@@ -414,15 +414,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "No permitir conversiones"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Debates"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Documentación"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -433,13 +433,13 @@ msgstr "Descargar"
 msgid "Download Again"
 msgstr "Descargar de nuevo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Descarga finalizada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Descarga finalizada con error"
 
@@ -448,17 +448,17 @@ msgstr "Descarga finalizada con error"
 msgid "Download log was copied to clipboard."
 msgstr "El registro de descargas se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Descargar medios"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Descargar plazos específicos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Descargar subtítulo"
@@ -471,20 +471,20 @@ msgstr "La descarga usando aria2 ha comenzado"
 msgid "Download using ffmpeg has started"
 msgstr "La descarga usando ffmpeg ha comenzado"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Descargar vídeo y audio de la web"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Descargador"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Descargando"
@@ -500,12 +500,12 @@ msgstr "Descargando {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Descargas terminadas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Editar"
 
@@ -539,27 +539,27 @@ msgstr ""
 "el progreso de la descarga."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Hora de finalización"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Hora de finalización (no válida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr "Introducir la dirección URL de los medios aquí"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Asegúrese de que las credenciales son correctas."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr "Indique aquí el plazo final"
 
@@ -567,7 +567,7 @@ msgstr "Indique aquí el plazo final"
 msgid "Enter name here"
 msgstr "Escriba aquí el nombre"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr "Escriba aquí la contraseña"
@@ -576,7 +576,7 @@ msgstr "Escriba aquí la contraseña"
 msgid "Enter proxy url here"
 msgstr "Introduzca aquí la dirección url del proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr "Ingrese el plazo de inicio aquí"
 
@@ -584,7 +584,7 @@ msgstr "Ingrese el plazo de inicio aquí"
 msgid "Enter url here"
 msgstr "Introduzca aquí la dirección url"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr "Introduzca aquí el nombre de usuario"
@@ -594,8 +594,8 @@ msgstr "Introduzca aquí el nombre de usuario"
 msgid "Error"
 msgstr "Error"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Salir"
 
@@ -604,7 +604,7 @@ msgstr "Salir"
 msgid "Failed to enable keyring."
 msgstr "Fallo al activar el llavero."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Archivo"
 
@@ -617,7 +617,7 @@ msgstr "El archivo ya existe y no está permitido sobreescribirlo"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo de archivo"
@@ -627,23 +627,23 @@ msgstr "Tipo de archivo"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Ayuda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -690,14 +690,14 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Llavero"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Credencial del llavero"
@@ -717,13 +717,13 @@ msgstr "Llavero bloqueado"
 msgid "Language Code Information"
 msgstr "Información del código del idioma"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Dejar en blanco para descargar desde el inicio."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista de sitios compatibles"
 
@@ -733,12 +733,12 @@ msgstr "Registro"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Inicio de sesión"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Hacer miniaturas cuadradas, útil al descargar música."
@@ -748,7 +748,7 @@ msgstr "Hacer miniaturas cuadradas, útil al descargar música."
 msgid "Manage previously downloaded media."
 msgstr "Gestionar medios descargados previamente."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
@@ -763,11 +763,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Número máximo de descargas activas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Máxima calidad"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -779,14 +779,13 @@ msgstr ""
 "está activado."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL de los medios"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL a los medios (no válido)"
 
@@ -805,40 +804,40 @@ msgstr "Tamaño mínimo de la división (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nombre"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nombre (vacío)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Sin conexión a Internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr "Sin descargas completadas"
 
@@ -851,7 +850,7 @@ msgstr "No hay credenciales"
 msgid "No downloads running"
 msgstr "No hay descargas en curso"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr "Sin descargas en ejecución"
 
@@ -865,25 +864,25 @@ msgstr "Ningún archivo seleccionado"
 msgid "No Previous Downloads"
 msgstr "No hay descargas previas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 msgid "No Queued Downloads"
 msgstr "La cola de las descargas esta vacía"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Número de los títulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -904,14 +903,14 @@ msgstr "Apagar"
 msgid "OK"
 msgstr "DE ACUERDO"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -942,14 +941,14 @@ msgstr "Abrir carpeta"
 msgid "Overwrite Existing Files"
 msgstr "Sobreescribir archivos existentes"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -958,9 +957,9 @@ msgstr ""
 "del menú Ayuda."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -968,7 +967,7 @@ msgid "Password"
 msgstr "Contraseña"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Contraseña (vacía)"
 
@@ -978,13 +977,13 @@ msgid "Play"
 msgstr "Reproducir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "Preparing required tools..."
-msgstr "Preparando las herramientas necesarias..."
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -996,7 +995,7 @@ msgstr "Preparando…"
 msgid "Prevent Suspend"
 msgstr "Prevenir la suspensión"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr "VISTA PREVIA"
 
@@ -1010,19 +1009,19 @@ msgstr "Procesando…"
 msgid "Proxy URL"
 msgstr "URL del proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Calidad"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "En cola"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Descargas restantes: {0}"
@@ -1032,7 +1031,7 @@ msgstr "Descargas restantes: {0}"
 msgid "Remove Source Data"
 msgstr "Eliminar los datos de origen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Informar de un error"
 
@@ -1042,7 +1041,7 @@ msgid "Reset"
 msgstr "Restablecer"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "¿Restablecer el llavero?"
 
@@ -1067,22 +1066,22 @@ msgstr "¿Reiniciar para aplicar el tema?"
 msgid "Retry Download"
 msgstr "Reintentar descarga"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Reintentar descargas fallidas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Guardar carpeta"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Guardar carpeta (no válida)"
 
@@ -1091,7 +1090,7 @@ msgstr "Guardar carpeta (no válida)"
 msgid "Search history"
 msgstr "Historial de la búsqueda"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleccionar todo"
@@ -1102,7 +1101,7 @@ msgstr "Seleccionar todo"
 msgid "Select Cookies File"
 msgstr "Selecciona archivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
@@ -1110,23 +1109,23 @@ msgstr ""
 "archivos."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleccione la carpeta de guardado"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr "Mostrar la ventana"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1138,19 +1137,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "¡Algunas descargas terminaron con errores!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Límite de velocidad"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Separar los capítulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divida el vídeo en varios más pequeños en función de sus capítulos."
@@ -1161,19 +1160,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Información sobre SponsorBlock (se abre en un navegador web)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Hora de inicio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Hora de inicio (no válida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1209,7 +1208,7 @@ msgstr "Idiomas de los subtítulos (no válido)"
 msgid "Success"
 msgstr "Éxito"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1230,7 +1229,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Esta acción es irreversible. ¿Está seguro de que quiere borrarlo?"
 
@@ -1244,12 +1243,8 @@ msgstr ""
 "límite de velocidad. Cambiar el valor no afecta a las descargas que ya se "
 "están ejecutando."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
-msgid "This may take a while"
-msgstr "Esto puede llevar un tiempo"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1257,38 +1252,32 @@ msgstr ""
 "Esto borrará el llavero anterior eliminando todas las contraseñas con él. "
 "Esta acción es irreversible."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "gallegonovato https://github.com/gallegonovato\n"
 "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "No se puede desactivar el llavero."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "No se puede restablecer el llavero."
-
-#: ../../../Controllers/MainWindowController.cs:274
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"No se han podido configurar las dependencias. Reinicie la aplicación e "
-"inténtelo de nuevo."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Deshacer la edición de los títulos"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Desbloquear llavero"
 
@@ -1296,19 +1285,19 @@ msgstr "Desbloquear llavero"
 msgid "Unset Cookies File"
 msgstr "Desactivar el archivo de las cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr "Actualización"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (no válida)"
 
@@ -1342,27 +1331,32 @@ msgid "User Interface"
 msgstr "Interfaz de usuario"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr "Nombre de usuario (vacío)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nombre de usuario"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validar"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Vídeo"
 
@@ -1380,7 +1374,7 @@ msgid "Waiting..."
 msgstr "Esperando..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Peor"
 
@@ -1395,10 +1389,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sí"
@@ -1547,6 +1541,17 @@ msgstr "— Ejecutar múltiples descargas a la vez"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Admite la descarga de los metadatos y subtítulos del video"
+
+#~ msgid "Preparing required tools..."
+#~ msgstr "Preparando las herramientas necesarias..."
+
+#~ msgid "This may take a while"
+#~ msgstr "Esto puede llevar un tiempo"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "No se han podido configurar las dependencias. Reinicie la aplicación e "
+#~ "inténtelo de nuevo."
 
 #~ msgid "Search..."
 #~ msgstr "Buscar..."

--- a/NickvisionTubeConverter.Shared/Resources/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" on ladattu."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" on valmistunut virheen kera!"
@@ -129,8 +129,8 @@ msgstr "Lisää kirjautumistieto"
 msgid "Advanced Options"
 msgstr "Lisävalinnat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Kaikki lataukset ovat valmistuneet."
 
@@ -228,8 +228,8 @@ msgstr "Tyhjennä jonoon asetetut lataukset"
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Haluatko lopettaa ja pysäyttää lataukset?"
 
@@ -383,12 +383,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Älä salli muunnosta"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -402,13 +410,13 @@ msgstr "Lataa"
 msgid "Download Again"
 msgstr "Lataa uudelleen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Lataus valmistui"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -470,8 +478,8 @@ msgstr "Ladataan {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Ladataan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Lataukset valmistuivat"
 
@@ -600,7 +608,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
@@ -772,7 +780,7 @@ msgstr "Nimi"
 msgid "Name (Empty)"
 msgstr "Nimi (tyhjä)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -783,15 +791,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ei"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Ei aktiivista internetyhteyttä"
 
@@ -861,6 +869,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -980,7 +989,7 @@ msgid "Queued"
 msgstr "Jonossa"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Yritä ladata uudelleen epäonnistuneet lataukset"
@@ -1082,8 +1091,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1166,7 +1175,8 @@ msgstr "Tekstityksen kielet (virheellinen)"
 msgid "Success"
 msgstr "Onnistui"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1211,7 +1221,7 @@ msgstr "Jiri Grönroos"
 msgid "Unable to disable keyring."
 msgstr "Avainnippua ei voitu poistaa käytöstä."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1225,7 +1235,7 @@ msgstr "Avainnippua ei voitu nollata."
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Avaa avainnippu"
 
@@ -1234,7 +1244,7 @@ msgstr "Avaa avainnippu"
 msgid "Unset Cookies File"
 msgstr "Valitse evästetiedosto"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1334,10 +1344,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Kyllä"

--- a/NickvisionTubeConverter.Shared/Resources/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" on ladattu."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" on valmistunut virheen kera!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Muokattavissa asetuksissa)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} latausta — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -98,18 +98,18 @@ msgstr ""
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Lisää videon, äänen tai soittolistan URL-osoite aloittaaksesi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -123,14 +123,14 @@ msgid "Add Login"
 msgstr "Lisää kirjautumistieto"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Lisävalinnat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Kaikki lataukset ovat valmistuneet."
 
@@ -149,17 +149,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Ääni"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Äänen kieli"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Tunnistaudu"
@@ -168,7 +168,7 @@ msgstr "Tunnistaudu"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -176,7 +176,7 @@ msgid "Back"
 msgstr "Takaisin"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Paras"
 
@@ -188,7 +188,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Tyhjennä valmistuneet lataukset"
@@ -215,21 +215,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Tyhjennä jonoon asetetut lataukset"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Haluatko lopettaa ja pysäyttää lataukset?"
 
@@ -237,8 +237,8 @@ msgstr "Haluatko lopettaa ja pysäyttää lataukset?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Valmistunut"
@@ -248,7 +248,7 @@ msgstr "Valmistunut"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
@@ -293,16 +293,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Rajaa pikkukuva"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -320,7 +320,7 @@ msgstr "Poista"
 msgid "Delete Credential?"
 msgstr "Poistetaanko kirjautumistieto?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Älä valitse mitään"
@@ -383,15 +383,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Älä salli muunnosta"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -402,13 +402,13 @@ msgstr "Lataa"
 msgid "Download Again"
 msgstr "Lataa uudelleen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Lataus valmistui"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -417,17 +417,17 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr "Latausloki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Lataa mediaa"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Lataa tekstitys"
@@ -440,20 +440,20 @@ msgstr "Lataus aria2:ta käyttäen alkoi"
 msgid "Download using ffmpeg has started"
 msgstr "Lataus ffmpeg:tä käyttäen alkoi"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Lataa videoita ja ääntä verkosta"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Lataaja"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Ladataan"
@@ -470,12 +470,12 @@ msgstr "Ladataan {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Ladataan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Lataukset valmistuivat"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -507,27 +507,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Loppuaika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Loppuaika (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Varmista, että kirjautumistiedot ovat oikein."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -562,8 +562,8 @@ msgstr ""
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Avainnipun käyttöönotto epäonnistui."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Tiedoston nimi"
@@ -586,7 +586,7 @@ msgstr "Tiedosto on jo olemassa, ja korvaaminen ei ole sallittua"
 msgid "File Name"
 msgstr "Tiedoston nimi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tiedoston tyyppi"
@@ -596,23 +596,23 @@ msgstr "Tiedoston tyyppi"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Ohje"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -653,13 +653,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Avainnippu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -679,13 +679,13 @@ msgstr "Avainnippu lukittu"
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Jätä tyhjäksi ladataksesi alusta lähtien."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Luettelo tuetuista sivustoista"
 
@@ -701,7 +701,7 @@ msgstr "Kirjaudu"
 msgid "Login"
 msgstr "Kirjaudu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Tee pikkukuvasta neliö, hyödyllinen musiikkia ladatessa."
@@ -711,7 +711,7 @@ msgstr "Tee pikkukuvasta neliö, hyödyllinen musiikkia ladatessa."
 msgid "Manage previously downloaded media."
 msgstr "Hallitse aiemmin ladattuja mediatiedostoja."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
@@ -726,11 +726,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Aktiivisten latausten enimmäismäärä"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Paras laatu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -739,14 +739,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Median URL-osoite"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Median URL-osoite (virheellinen)"
 
@@ -773,30 +772,30 @@ msgstr "Nimi"
 msgid "Name (Empty)"
 msgstr "Nimi (tyhjä)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ei"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Ei aktiivista internetyhteyttä"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tyhjennä valmistuneet lataukset"
@@ -810,7 +809,7 @@ msgstr "Ei kirjautumistietoja"
 msgid "No downloads running"
 msgstr "Ei käynnissä olevia latauksia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Ei käynnissä olevia latauksia"
@@ -825,26 +824,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Ei aiempia latauksia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tyhjennä jonoon asetetut lataukset"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -865,14 +864,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -903,21 +902,21 @@ msgstr "Avaa kansio"
 msgid "Overwrite Existing Files"
 msgstr "Korvaa olemassa olevat tiedostot"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -937,11 +936,15 @@ msgid "Play"
 msgstr "Toista"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Soittolista"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Valmistellaan..."
@@ -956,7 +959,7 @@ msgstr "Valmistellaan..."
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -970,19 +973,19 @@ msgstr "Käsitellään..."
 msgid "Proxy URL"
 msgstr "Välityspalvelimen URL-osoite"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Laatu"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Jonossa"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Yritä ladata uudelleen epäonnistuneet lataukset"
@@ -992,7 +995,7 @@ msgstr "Yritä ladata uudelleen epäonnistuneet lataukset"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1027,22 +1030,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Yritä latausta uudelleen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Yritä ladata uudelleen epäonnistuneet lataukset"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Tallennuskansio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Tallennuskansio (virheellinen)"
 
@@ -1052,7 +1055,7 @@ msgstr "Tallennuskansio (virheellinen)"
 msgid "Search history"
 msgstr "Tyhjennä historia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Valitse kaikki"
@@ -1063,29 +1066,29 @@ msgstr "Valitse kaikki"
 msgid "Select Cookies File"
 msgstr "Valitse evästetiedosto"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Valitse tallennuskansio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1095,19 +1098,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Nopeusrajoitus"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Jaa kappaleisiin"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Jakaa videon useisiin pienempiin videoihin kappaleisiin perustuen."
@@ -1119,19 +1122,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Evästetiedoston tiedot"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Alkuaika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Alkuaika (virheellinen)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1168,7 +1171,7 @@ msgstr "Tekstityksen kielet (virheellinen)"
 msgid "Success"
 msgstr "Onnistui"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1197,7 +1200,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1208,7 +1211,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
@@ -1217,7 +1220,7 @@ msgstr "Jiri Grönroos"
 msgid "Unable to disable keyring."
 msgstr "Avainnippua ei voitu poistaa käytöstä."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1226,7 +1229,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Avainnippua ei voitu nollata."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
@@ -1235,7 +1238,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Avaa avainnippu"
 
@@ -1244,7 +1247,7 @@ msgstr "Avaa avainnippu"
 msgid "Unset Cookies File"
 msgstr "Valitse evästetiedosto"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1293,7 +1296,7 @@ msgid "User Name (Empty)"
 msgstr "Käyttäjätunnus (tyhjä)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1302,13 +1305,18 @@ msgid "Username"
 msgstr "Käyttäjätunnus"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validoi"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validoi"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1326,7 +1334,7 @@ msgid "Waiting..."
 msgstr "Odotetaan..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Huonoin"
 
@@ -1339,10 +1347,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Kyllä"

--- a/NickvisionTubeConverter.Shared/Resources/po/fi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-27 01:32+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" on ladattu."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" on valmistunut virheen kera!"
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Lisää videon, äänen tai soittolistan URL-osoite aloittaaksesi"
@@ -107,9 +107,9 @@ msgstr "Lisää videon, äänen tai soittolistan URL-osoite aloittaaksesi"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,7 +130,7 @@ msgid "Advanced Options"
 msgstr "Lisävalinnat"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Kaikki lataukset ovat valmistuneet."
 
@@ -198,7 +198,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Tyhjennä valmistuneet lataukset"
@@ -216,7 +216,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -229,7 +229,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Haluatko lopettaa ja pysäyttää lataukset?"
 
@@ -237,8 +237,8 @@ msgstr "Haluatko lopettaa ja pysäyttää lataukset?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Valmistunut"
@@ -248,7 +248,7 @@ msgstr "Valmistunut"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
@@ -298,11 +298,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr "Rajaa pikkukuva"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -316,7 +316,7 @@ msgid "Delete"
 msgstr "Poista"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Poistetaanko kirjautumistieto?"
 
@@ -403,12 +403,12 @@ msgid "Download Again"
 msgstr "Lataa uudelleen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Lataus valmistui"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr "Latausloki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Lataa mediaa"
@@ -440,7 +440,7 @@ msgstr "Lataus aria2:ta käyttäen alkoi"
 msgid "Download using ffmpeg has started"
 msgstr "Lataus ffmpeg:tä käyttäen alkoi"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -452,8 +452,8 @@ msgstr "Lataa videoita ja ääntä verkosta"
 msgid "Downloader"
 msgstr "Lataaja"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Ladataan"
@@ -471,7 +471,7 @@ msgid "Downloading..."
 msgstr "Ladataan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Lataukset valmistuivat"
 
@@ -563,7 +563,7 @@ msgid "Error"
 msgstr "Virhe"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr "Tiedoston tyyppi"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -652,7 +652,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr "Jätä tyhjäksi ladataksesi alusta lähtien."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Luettelo tuetuista sivustoista"
 
@@ -696,8 +696,8 @@ msgstr "Kirjaudu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Kirjaudu"
 
@@ -711,7 +711,7 @@ msgstr "Tee pikkukuvasta neliö, hyödyllinen musiikkia ladatessa."
 msgid "Manage previously downloaded media."
 msgstr "Hallitse aiemmin ladattuja mediatiedostoja."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
@@ -762,40 +762,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nimi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nimi (tyhjä)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ei"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Ei aktiivista internetyhteyttä"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tyhjennä valmistuneet lataukset"
@@ -809,7 +809,7 @@ msgstr "Ei kirjautumistietoja"
 msgid "No downloads running"
 msgstr "Ei käynnissä olevia latauksia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Ei käynnissä olevia latauksia"
@@ -824,7 +824,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Ei aiempia latauksia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tyhjennä jonoon asetetut lataukset"
@@ -902,14 +902,14 @@ msgstr "Avaa kansio"
 msgid "Overwrite Existing Files"
 msgstr "Korvaa olemassa olevat tiedostot"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -918,7 +918,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -926,7 +926,7 @@ msgid "Password"
 msgstr "Salasana"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Salasana (tyhjä)"
 
@@ -943,11 +943,6 @@ msgstr "Soittolista"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Valmistellaan..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -978,14 +973,14 @@ msgstr "Välityspalvelimen URL-osoite"
 msgid "Quality"
 msgstr "Laatu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Jonossa"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Yritä ladata uudelleen epäonnistuneet lataukset"
@@ -1005,7 +1000,7 @@ msgid "Reset"
 msgstr "Nollaa"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Nollataanko avainnippu?"
 
@@ -1031,7 +1026,7 @@ msgid "Retry Download"
 msgstr "Yritä latausta uudelleen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1078,17 +1073,17 @@ msgid "Select Save Folder"
 msgstr "Valitse tallennuskansio"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1134,7 +1129,7 @@ msgid "Start Time (Invalid)"
 msgstr "Alkuaika (virheellinen)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1189,7 +1184,7 @@ msgid "Theme"
 msgstr "Teema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1200,45 +1195,37 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Avainnippua ei voitu poistaa käytöstä."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Avainnippua ei voitu nollata."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Avaa avainnippu"
 
@@ -1247,19 +1234,19 @@ msgstr "Avaa avainnippu"
 msgid "Unset Cookies File"
 msgstr "Valitse evästetiedosto"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL-osoite"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL-osoite (virheellinen)"
 
@@ -1290,7 +1277,7 @@ msgid "User Interface"
 msgstr "Käyttöliittymä"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Käyttäjätunnus (tyhjä)"
@@ -1298,7 +1285,7 @@ msgstr "Käyttäjätunnus (tyhjä)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1348,9 +1335,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Kyllä"
@@ -1495,6 +1482,10 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Valmistellaan..."
 
 #~ msgid "Search..."
 #~ msgstr "Etsi..."

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "« {0} » a été téléchargé."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "« {0} » s’est terminé avec une erreur !"
@@ -100,7 +100,7 @@ msgstr "À propos de {0}"
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -111,9 +111,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,7 +134,7 @@ msgid "Advanced Options"
 msgstr "Options avancées"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Tous les téléchargements sont terminés."
 
@@ -202,7 +202,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Effacer les téléchargements terminés"
@@ -222,7 +222,7 @@ msgstr ""
 "d’identification pouvant mener à la source du média"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr "Fermer"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Fermer et arrêter les téléchargements ?"
 
@@ -243,8 +243,8 @@ msgstr "Fermer et arrêter les téléchargements ?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Terminé"
@@ -254,7 +254,7 @@ msgstr "Terminé"
 msgid "Completed Notification Trigger"
 msgstr "Notifications de fin de téléchargement"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
@@ -308,11 +308,11 @@ msgstr "Rogner les vignettes des fichiers audio"
 msgid "Crop Thumbnail"
 msgstr "Rogner la vignette"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -326,7 +326,7 @@ msgid "Delete"
 msgstr "Supprimer"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Supprimer ces identifiants ?"
 
@@ -424,12 +424,12 @@ msgid "Download Again"
 msgstr "Télécharger à nouveau"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Téléchargement terminé"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Téléchargement terminé avec une erreur"
 
@@ -438,7 +438,7 @@ msgstr "Téléchargement terminé avec une erreur"
 msgid "Download log was copied to clipboard."
 msgstr "Le journal de téléchargement a été copié vers le presse-papiers."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Téléchargez un média"
@@ -461,7 +461,7 @@ msgstr "Le téléchargement via aria2 a débuté"
 msgid "Download using ffmpeg has started"
 msgstr "Le téléchargement via ffmpeg a débuté"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -473,8 +473,8 @@ msgstr "Téléchargez des vidéos et de l’audio en ligne"
 msgid "Downloader"
 msgstr "Téléchargeur"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Téléchargement"
@@ -492,7 +492,7 @@ msgid "Downloading..."
 msgstr "Téléchargement"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Téléchargements terminés"
 
@@ -594,7 +594,7 @@ msgid "Error"
 msgstr "Erreur"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Sortir"
 
@@ -626,7 +626,7 @@ msgstr "Type de fichier"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -690,7 +690,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -723,7 +723,7 @@ msgstr "Informations sur les abréviations de langage"
 msgid "Leave empty to download from start."
 msgstr "Laisser vide pour télécharger à partir du début."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Liste des sites pris en charge"
 
@@ -734,8 +734,8 @@ msgstr "S’identifier"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "S’identifier"
 
@@ -749,7 +749,7 @@ msgstr "Rend les vignettes carrées, utile pour le téléchargement de musiques.
 msgid "Manage previously downloaded media."
 msgstr "Gérer les médias téléchargés précédemment."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
@@ -803,40 +803,40 @@ msgstr "Taille minimale de division (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nom"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Pas de connexion internet active"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Effacer les téléchargements terminés"
@@ -850,7 +850,7 @@ msgstr "Aucun identifiant"
 msgid "No downloads running"
 msgstr "Aucun téléchargement en cours"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Aucun téléchargement en cours"
@@ -865,7 +865,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Aucun téléchargement précédent"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Effacer les téléchargements en attente"
@@ -944,14 +944,14 @@ msgstr "Ouvrir le dossier"
 msgid "Overwrite Existing Files"
 msgstr "Remplacer les fichiers existants"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabole"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -960,7 +960,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -968,7 +968,7 @@ msgid "Password"
 msgstr "Mot de passe"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Mot de passe (vide)"
 
@@ -985,11 +985,6 @@ msgstr "Liste de lecture"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Préparation..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1020,14 +1015,14 @@ msgstr "URL de Proxy"
 msgid "Quality"
 msgstr "Qualité"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "En attente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Téléchargements restants : {0}"
@@ -1047,7 +1042,7 @@ msgid "Reset"
 msgstr "Réinitialiser"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Réinitialiser le trousseau ?"
 
@@ -1073,7 +1068,7 @@ msgid "Retry Download"
 msgstr "Retenter le téléchargement"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1121,18 +1116,18 @@ msgid "Select Save Folder"
 msgstr "Sélectionner un dossier de sauvegarde"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Paramètres"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1180,7 +1175,7 @@ msgid "Start Time (Invalid)"
 msgstr "Point de départ (invalide)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1239,7 +1234,7 @@ msgid "Theme"
 msgstr "Thème"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "Cette action est irréversible. Êtes-vous sûr⋅e de vouloir le supprimer ?"
@@ -1254,12 +1249,8 @@ msgstr ""
 "limitation de vitesse activée. Modifier cette valeur n’affecte pas les "
 "téléchargements déjà en cours."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1267,36 +1258,30 @@ msgstr ""
 "Cette opération supprimera le trousseau précédent et tous les mots de passe "
 "qu’il contenait. Cette action est irréversible."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Impossible de désactiver le trousseau."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Impossible de réinitialiser le trousseau."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Impossible de configurer les dépendances. Veuillez redémarrer l’application "
-"et réessayer."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Annuler la modification du titre"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Déverrouiller le trousseau"
 
@@ -1305,19 +1290,19 @@ msgstr "Déverrouiller le trousseau"
 msgid "Unset Cookies File"
 msgstr "Sélectionner un fichier de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (invalide)"
 
@@ -1352,7 +1337,7 @@ msgid "User Interface"
 msgstr "Interface utilisateur"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nom d’utilisateur (vide)"
@@ -1360,7 +1345,7 @@ msgstr "Nom d’utilisateur (vide)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1410,9 +1395,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Oui"
@@ -1565,6 +1550,15 @@ msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Prend en charge le téléchargement des métadonnées et des sous-titres des "
 "vidéos"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Préparation..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Impossible de configurer les dépendances. Veuillez redémarrer "
+#~ "l’application et réessayer."
 
 #~ msgid "Search..."
 #~ msgstr "Rechercher…"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "« {0} » a été téléchargé."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "« {0} » s’est terminé avec une erreur !"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(modifiable dans les préférences)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} Gb/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} Kb/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} téléchargements — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Un fichier de cookies peut être fourni à yt-dlp pour permettre de "
 "télécharger les médias requérant une identification."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "À propos de {0}"
@@ -100,7 +100,7 @@ msgstr "À propos de {0}"
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,12 +108,12 @@ msgstr ""
 "commencer un téléchargement"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Ajouter un identifiant"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Options avancées"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Tous les téléchargements sont terminés."
 
@@ -153,17 +153,17 @@ msgstr "Appliquer"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Langue de l’audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "S’identifier"
@@ -172,7 +172,7 @@ msgstr "S’identifier"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Retour"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Meilleure"
 
@@ -192,7 +192,7 @@ msgstr "Annuler"
 msgid "Changelog"
 msgstr "Liste des changements"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -201,8 +201,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Effacer les téléchargements terminés"
@@ -221,21 +221,21 @@ msgstr ""
 "Effacer les champs des métadonnées contenant l’URL et d’autres donnée "
 "d’identification pouvant mener à la source du média"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Effacer les téléchargements en attente"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Fermer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Fermer et arrêter les téléchargements ?"
 
@@ -243,8 +243,8 @@ msgstr "Fermer et arrêter les téléchargements ?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Terminé"
@@ -254,7 +254,7 @@ msgstr "Terminé"
 msgid "Completed Notification Trigger"
 msgstr "Notifications de fin de téléchargement"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
@@ -303,16 +303,16 @@ msgstr "Certificats"
 msgid "Crop Audio Thumbnails"
 msgstr "Rogner les vignettes des fichiers audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Rogner la vignette"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -330,7 +330,7 @@ msgstr "Supprimer"
 msgid "Delete Credential?"
 msgstr "Supprimer ces identifiants ?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Désélectionner tout"
@@ -404,15 +404,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Empêcher les conversions"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussions"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +423,13 @@ msgstr "Télécharger"
 msgid "Download Again"
 msgstr "Télécharger à nouveau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Téléchargement terminé"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Téléchargement terminé avec une erreur"
 
@@ -438,17 +438,17 @@ msgstr "Téléchargement terminé avec une erreur"
 msgid "Download log was copied to clipboard."
 msgstr "Le journal de téléchargement a été copié vers le presse-papiers."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Téléchargez un média"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Télécharger une séquence spécifique"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Télécharger les sous-titres"
@@ -461,20 +461,20 @@ msgstr "Le téléchargement via aria2 a débuté"
 msgid "Download using ffmpeg has started"
 msgstr "Le téléchargement via ffmpeg a débuté"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Téléchargez des vidéos et de l’audio en ligne"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Téléchargeur"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Téléchargement"
@@ -491,12 +491,12 @@ msgstr "Téléchargement {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Téléchargement"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Téléchargements terminés"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Modifier"
 
@@ -530,28 +530,28 @@ msgstr ""
 "vous ne verrez pas la progression du téléchargement."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Fin"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Fin (invalide)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Entrez l’URL d’un média ici"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Assurez-vous que les identifiants soient corrects."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Entrez l’URL d’un média ici"
@@ -561,7 +561,7 @@ msgstr "Entrez l’URL d’un média ici"
 msgid "Enter name here"
 msgstr "Entrez l’URL d’un média ici"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -572,7 +572,7 @@ msgstr "Entrez l’URL d’un média ici"
 msgid "Enter proxy url here"
 msgstr "Entrez l’URL d’un média ici"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Entrez l’URL d’un média ici"
@@ -582,7 +582,7 @@ msgstr "Entrez l’URL d’un média ici"
 msgid "Enter url here"
 msgstr "Entrez l’URL d’un média ici"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -593,8 +593,8 @@ msgstr "Entrez l’URL d’un média ici"
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Sortir"
 
@@ -603,7 +603,7 @@ msgstr "Sortir"
 msgid "Failed to enable keyring."
 msgstr "Échec de l’activation du trousseau."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Fichier"
 
@@ -616,7 +616,7 @@ msgstr "Le fichier existe déjà, et le remplacement n’a pas été activé"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Type de fichier"
@@ -626,23 +626,23 @@ msgstr "Type de fichier"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Aide"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -691,13 +691,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Trousseau"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Identifiant du trousseau"
@@ -717,13 +717,13 @@ msgstr "Trousseau verrouillé"
 msgid "Language Code Information"
 msgstr "Informations sur les abréviations de langage"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Laisser vide pour télécharger à partir du début."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Liste des sites pris en charge"
 
@@ -739,7 +739,7 @@ msgstr "S’identifier"
 msgid "Login"
 msgstr "S’identifier"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Rend les vignettes carrées, utile pour le téléchargement de musiques."
@@ -749,7 +749,7 @@ msgstr "Rend les vignettes carrées, utile pour le téléchargement de musiques.
 msgid "Manage previously downloaded media."
 msgstr "Gérer les médias téléchargés précédemment."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
@@ -764,11 +764,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Nombre maximum de téléchargements actifs"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Qualité maximale"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -780,14 +780,13 @@ msgstr ""
 "téléchargeur s’il est activé."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL du média"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL du média (invalide)"
 
@@ -814,30 +813,30 @@ msgstr "Nom"
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Pas de connexion internet active"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Effacer les téléchargements terminés"
@@ -851,7 +850,7 @@ msgstr "Aucun identifiant"
 msgid "No downloads running"
 msgstr "Aucun téléchargement en cours"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Aucun téléchargement en cours"
@@ -866,26 +865,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Aucun téléchargement précédent"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Effacer les téléchargements en attente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numéroter les titres"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -906,14 +905,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -945,21 +944,21 @@ msgstr "Ouvrir le dossier"
 msgid "Overwrite Existing Files"
 msgstr "Remplacer les fichiers existants"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabole"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -979,11 +978,15 @@ msgid "Play"
 msgstr "Lire"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Préparation..."
@@ -998,7 +1001,7 @@ msgstr "Préparation..."
 msgid "Prevent Suspend"
 msgstr "Empêcher la mise en veille"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1012,19 +1015,19 @@ msgstr "Traitement..."
 msgid "Proxy URL"
 msgstr "URL de Proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Qualité"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "En attente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Téléchargements restants : {0}"
@@ -1034,7 +1037,7 @@ msgstr "Téléchargements restants : {0}"
 msgid "Remove Source Data"
 msgstr "Retirer les données sur la source"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Signaler un bogue"
 
@@ -1069,22 +1072,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Retenter le téléchargement"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Relancer les téléchargements échoués"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Dossier d’enregistrement"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Dossier de sauvegarde (invalide)"
 
@@ -1094,7 +1097,7 @@ msgstr "Dossier de sauvegarde (invalide)"
 msgid "Search history"
 msgstr "Effacer l’historique"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Sélectionner tout"
@@ -1105,31 +1108,31 @@ msgstr "Sélectionner tout"
 msgid "Select Cookies File"
 msgstr "Sélectionner un fichier de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 "Sélectionnez les éléments à télécharger ou modifiez le nom des fichiers."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Sélectionner un dossier de sauvegarde"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Paramètres"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1142,19 +1145,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Certains téléchargements se sont terminés avec des erreurs !"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limitation de vitesse"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Diviser en chapitres"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Sépare la vidéo en plusieurs morceaux correspondant à ses chapitres."
@@ -1165,19 +1168,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informations sur SponsorBlock (ouvrira votre navigateur web)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Point de départ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Point de départ (invalide)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1214,7 +1217,7 @@ msgstr "Langages de sous-titres (invalides)"
 msgid "Success"
 msgstr "Succès"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1251,7 +1254,7 @@ msgstr ""
 "limitation de vitesse activée. Modifier cette valeur n’affecte pas les "
 "téléchargements déjà en cours."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1264,7 +1267,7 @@ msgstr ""
 "Cette opération supprimera le trousseau précédent et tous les mots de passe "
 "qu’il contenait. Cette action est irréversible."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
@@ -1273,7 +1276,7 @@ msgstr "Irénée Thirion"
 msgid "Unable to disable keyring."
 msgstr "Impossible de désactiver le trousseau."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1282,7 +1285,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Impossible de réinitialiser le trousseau."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Impossible de configurer les dépendances. Veuillez redémarrer l’application "
@@ -1293,7 +1296,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Annuler la modification du titre"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Déverrouiller le trousseau"
 
@@ -1302,7 +1305,7 @@ msgstr "Déverrouiller le trousseau"
 msgid "Unset Cookies File"
 msgstr "Sélectionner un fichier de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1355,7 +1358,7 @@ msgid "User Name (Empty)"
 msgstr "Nom d’utilisateur (vide)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1364,13 +1367,18 @@ msgid "Username"
 msgstr "Nom d’utilisateur"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valider"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Valider"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Vidéo"
 
@@ -1388,7 +1396,7 @@ msgid "Waiting..."
 msgstr "Attente..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Basse"
 
@@ -1401,10 +1409,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Oui"

--- a/NickvisionTubeConverter.Shared/Resources/po/fr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "« {0} » a été téléchargé."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "« {0} » s’est terminé avec une erreur !"
@@ -133,8 +133,8 @@ msgstr "Ajouter un identifiant"
 msgid "Advanced Options"
 msgstr "Options avancées"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Tous les téléchargements sont terminés."
 
@@ -234,8 +234,8 @@ msgstr "Effacer les téléchargements en attente"
 msgid "Close"
 msgstr "Fermer"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Fermer et arrêter les téléchargements ?"
 
@@ -404,12 +404,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Empêcher les conversions"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussions"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -423,13 +431,13 @@ msgstr "Télécharger"
 msgid "Download Again"
 msgstr "Télécharger à nouveau"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Téléchargement terminé"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Téléchargement terminé avec une erreur"
 
@@ -491,8 +499,8 @@ msgstr "Téléchargement {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Téléchargement"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Téléchargements terminés"
 
@@ -630,7 +638,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
@@ -813,7 +821,7 @@ msgstr "Nom"
 msgid "Name (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -824,15 +832,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Pas de connexion internet active"
 
@@ -902,6 +910,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1022,7 +1031,7 @@ msgid "Queued"
 msgstr "En attente"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Téléchargements restants : {0}"
@@ -1126,8 +1135,8 @@ msgstr "Paramètres"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1212,7 +1221,8 @@ msgstr "Langages de sous-titres (invalides)"
 msgid "Success"
 msgstr "Succès"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1267,7 +1277,7 @@ msgstr "Irénée Thirion"
 msgid "Unable to disable keyring."
 msgstr "Impossible de désactiver le trousseau."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1281,7 +1291,7 @@ msgstr "Impossible de réinitialiser le trousseau."
 msgid "Undo Title Editing"
 msgstr "Annuler la modification du titre"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Déverrouiller le trousseau"
 
@@ -1290,7 +1300,7 @@ msgstr "Déverrouiller le trousseau"
 msgid "Unset Cookies File"
 msgstr "Sélectionner un fichier de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1394,10 +1404,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Oui"

--- a/NickvisionTubeConverter.Shared/Resources/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Concluíu a descarga de «{0}»."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Concluíu a descarga de «{0}» cun erro!"
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -107,9 +107,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,7 +130,7 @@ msgid "Advanced Options"
 msgstr "Opcións avanzadas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Remataron todas as descargas."
 
@@ -198,7 +198,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -216,7 +216,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -229,7 +229,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Pechar e parar as descargas?"
 
@@ -237,8 +237,8 @@ msgstr "Pechar e parar as descargas?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores/as no GitHub ❤️"
 
@@ -298,11 +298,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -316,7 +316,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Eliminar credencial?"
 
@@ -405,12 +405,12 @@ msgid "Download Again"
 msgstr "Descargar de novo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Descarga rematada"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Descarga rematada con erros"
 
@@ -419,7 +419,7 @@ msgstr "Descarga rematada con erros"
 msgid "Download log was copied to clipboard."
 msgstr "O rexistro de descarga foi copiado ao portapapeis."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
@@ -443,7 +443,7 @@ msgstr "Comezou a descarga empregando aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Comezou a descarga empregando ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -455,8 +455,8 @@ msgstr "Descargar vídeo e son da web"
 msgid "Downloader"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "A descargar"
@@ -474,7 +474,7 @@ msgid "Downloading..."
 msgstr "A descargar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Descargas rematadas"
 
@@ -567,7 +567,7 @@ msgid "Error"
 msgstr "Erro"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr "Tipo de ficheiro"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -655,7 +655,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -688,7 +688,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr "Deixe en branco para descargar desde o inicio."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Listaxe de sitios admitidos"
 
@@ -699,8 +699,8 @@ msgstr "Rexistro"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Rexistro"
 
@@ -714,7 +714,7 @@ msgstr "Crear miniatura cadrada, útil ao descargar música."
 msgid "Manage previously downloaded media."
 msgstr "Xestionar recursos descargados anteriormente."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Conversa en Matrix"
 
@@ -768,40 +768,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nome (Baleiro)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Sen conexión activa coa Internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Non hai descargas anteriores"
@@ -815,7 +815,7 @@ msgstr "Sen credenciais"
 msgid "No downloads running"
 msgstr "Non hai descargas en execución"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Non hai descargas en execución"
@@ -830,7 +830,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Non hai descargas anteriores"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Non hai descargas anteriores"
@@ -908,14 +908,14 @@ msgstr "Abrir cartafol"
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -924,7 +924,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -932,7 +932,7 @@ msgid "Password"
 msgstr "Contrasinal"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Contrasinal (Baleiro)"
 
@@ -949,11 +949,6 @@ msgstr "Lista de reprodución"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "A preparar..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -984,14 +979,14 @@ msgstr ""
 msgid "Quality"
 msgstr "Calidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -1011,7 +1006,7 @@ msgid "Reset"
 msgstr "Restaurar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Restaurar chaveiro?"
 
@@ -1037,7 +1032,7 @@ msgid "Retry Download"
 msgstr "Tentar descarga de novo"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1084,17 +1079,17 @@ msgid "Select Save Folder"
 msgstr "Seleccionar cartafol de destino"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1141,7 +1136,7 @@ msgid "Start Time (Invalid)"
 msgstr "Inicio (Incorrecto)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1199,7 +1194,7 @@ msgid "Theme"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Esta acción é irreversíbel. Confirma que desexa eliminalo?"
 
@@ -1210,12 +1205,8 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1223,36 +1214,30 @@ msgstr ""
 "Isto eliminará o chaveiro anterior e retirará todos os contrasinais que "
 "conteña. Esta acción é irreversíbel."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Xosé <xosecalvo@gmail.com; proxecto@trasno.gal>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Non foi posíbel restaurar o chaveiro."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Non foi posíbel configurar as dependencias. Reinicie a aplicación e ténteo "
-"de novo."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1261,19 +1246,19 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Seleccionar ficheiro de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (Incorrecto)"
 
@@ -1307,7 +1292,7 @@ msgid "User Interface"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nome de usuario (Baleiro)"
@@ -1315,7 +1300,7 @@ msgstr "Nome de usuario (Baleiro)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1365,9 +1350,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Si"
@@ -1512,6 +1497,15 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "A preparar..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Non foi posíbel configurar as dependencias. Reinicie a aplicación e "
+#~ "ténteo de novo."
 
 #~ msgid "Search..."
 #~ msgstr "Procurar..."

--- a/NickvisionTubeConverter.Shared/Resources/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Concluíu a descarga de «{0}»."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Concluíu a descarga de «{0}» cun erro!"
@@ -129,8 +129,8 @@ msgstr "Engadir acceso"
 msgid "Advanced Options"
 msgstr "Opcións avanzadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Remataron todas as descargas."
 
@@ -228,8 +228,8 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Pechar e parar as descargas?"
 
@@ -385,12 +385,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -404,13 +412,13 @@ msgstr "Descargar"
 msgid "Download Again"
 msgstr "Descargar de novo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Descarga rematada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Descarga rematada con erros"
 
@@ -473,8 +481,8 @@ msgstr "A descargar {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "A descargar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Descargas rematadas"
 
@@ -605,7 +613,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repositorio do GitHub"
@@ -778,7 +786,7 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (Baleiro)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -789,15 +797,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Sen conexión activa coa Internet"
 
@@ -867,6 +875,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -986,7 +995,7 @@ msgid "Queued"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -1088,8 +1097,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1173,7 +1182,8 @@ msgstr "Idiomas dos subtítulos (Incorrecto)"
 msgid "Success"
 msgstr "Éxito"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1223,7 +1233,7 @@ msgstr "Xosé <xosecalvo@gmail.com; proxecto@trasno.gal>"
 msgid "Unable to disable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1237,7 +1247,7 @@ msgstr "Non foi posíbel restaurar o chaveiro."
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1246,7 +1256,7 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Seleccionar ficheiro de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1349,10 +1359,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Si"

--- a/NickvisionTubeConverter.Shared/Resources/po/gl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Xosé Calvo <xosecalvo@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Concluíu a descarga de «{0}»."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Concluíu a descarga de «{0}» cun erro!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Configurábel nas preferencias)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} descargas — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -98,18 +98,18 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -123,14 +123,14 @@ msgid "Add Login"
 msgstr "Engadir acceso"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opcións avanzadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Remataron todas as descargas."
 
@@ -149,17 +149,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Son"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Idioma do son"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autenticar"
@@ -168,7 +168,7 @@ msgstr "Autenticar"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -176,7 +176,7 @@ msgid "Back"
 msgstr "Atrás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Mellor"
 
@@ -188,7 +188,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -215,21 +215,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Pechar e parar as descargas?"
 
@@ -237,8 +237,8 @@ msgstr "Pechar e parar as descargas?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores/as no GitHub ❤️"
 
@@ -293,16 +293,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Recortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr "Eliminar credencial?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleccionar todo"
@@ -385,15 +385,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -404,13 +404,13 @@ msgstr "Descargar"
 msgid "Download Again"
 msgstr "Descargar de novo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Descarga rematada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Descarga rematada con erros"
 
@@ -419,17 +419,17 @@ msgstr "Descarga rematada con erros"
 msgid "Download log was copied to clipboard."
 msgstr "O rexistro de descarga foi copiado ao portapapeis."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Descargar fragmento específico"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -443,20 +443,20 @@ msgstr "Comezou a descarga empregando aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Comezou a descarga empregando ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Descargar vídeo e son da web"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "A descargar"
@@ -473,12 +473,12 @@ msgstr "A descargar {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "A descargar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Descargas rematadas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -511,27 +511,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Hora de remate"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Hora de remate (incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Comprobe que as credenciais son correctas."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -566,8 +566,8 @@ msgstr ""
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -577,7 +577,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nome do ficheiro"
@@ -591,7 +591,7 @@ msgstr "O ficheiro xa existo e a substitución non está permitida"
 msgid "File Name"
 msgstr "Nome do ficheiro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo de ficheiro"
@@ -601,23 +601,23 @@ msgstr "Tipo de ficheiro"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repositorio do GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -656,13 +656,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Chaviero"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Credencial do chaveiro"
@@ -682,13 +682,13 @@ msgstr "Chaveiro bloqueado"
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Deixe en branco para descargar desde o inicio."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Listaxe de sitios admitidos"
 
@@ -704,7 +704,7 @@ msgstr "Rexistro"
 msgid "Login"
 msgstr "Rexistro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Crear miniatura cadrada, útil ao descargar música."
@@ -714,7 +714,7 @@ msgstr "Crear miniatura cadrada, útil ao descargar música."
 msgid "Manage previously downloaded media."
 msgstr "Xestionar recursos descargados anteriormente."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Conversa en Matrix"
 
@@ -729,11 +729,11 @@ msgid "Max Number of Active Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Calidade máxima"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -745,14 +745,13 @@ msgstr ""
 "estiver activado."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL do recurso"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL do recurso (incorrecto)"
 
@@ -779,30 +778,30 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (Baleiro)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Sen conexión activa coa Internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Non hai descargas anteriores"
@@ -816,7 +815,7 @@ msgstr "Sen credenciais"
 msgid "No downloads running"
 msgstr "Non hai descargas en execución"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Non hai descargas en execución"
@@ -831,26 +830,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Non hai descargas anteriores"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Non hai descargas anteriores"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numerar títulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -871,14 +870,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -909,21 +908,21 @@ msgstr "Abrir cartafol"
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -943,11 +942,15 @@ msgid "Play"
 msgstr "Reproducir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Lista de reprodución"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "A preparar..."
@@ -962,7 +965,7 @@ msgstr "A preparar..."
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -976,19 +979,19 @@ msgstr "A procesar..."
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Calidade"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -998,7 +1001,7 @@ msgstr ""
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1033,22 +1036,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Tentar descarga de novo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Cartafol de destino"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Cartafol de destino (Incorrecto)"
 
@@ -1058,7 +1061,7 @@ msgstr "Cartafol de destino (Incorrecto)"
 msgid "Search history"
 msgstr "Limpar historial"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleccionar todo"
@@ -1069,29 +1072,29 @@ msgstr "Seleccionar todo"
 msgid "Select Cookies File"
 msgstr "Seleccionar ficheiro de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Seleccione elementos para descargar ou cambie os nomes dos ficheiros."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleccionar cartafol de destino"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1103,19 +1106,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Algunhas descargas remataron con erros!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Límite de velocidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividir capítulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divide o vídeo en varios menores en función dos seus capítulos."
@@ -1126,19 +1129,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Inicio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Inicio (Incorrecto)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1175,7 +1178,7 @@ msgstr "Idiomas dos subtítulos (Incorrecto)"
 msgid "Success"
 msgstr "Éxito"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1207,7 +1210,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1220,7 +1223,7 @@ msgstr ""
 "Isto eliminará o chaveiro anterior e retirará todos os contrasinais que "
 "conteña. Esta acción é irreversíbel."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Xosé <xosecalvo@gmail.com; proxecto@trasno.gal>"
 
@@ -1229,7 +1232,7 @@ msgstr "Xosé <xosecalvo@gmail.com; proxecto@trasno.gal>"
 msgid "Unable to disable keyring."
 msgstr "Non foi posíbel desactivar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1238,7 +1241,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Non foi posíbel restaurar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Non foi posíbel configurar as dependencias. Reinicie a aplicación e ténteo "
@@ -1249,7 +1252,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1258,7 +1261,7 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Seleccionar ficheiro de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1310,7 +1313,7 @@ msgid "User Name (Empty)"
 msgstr "Nome de usuario (Baleiro)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1319,13 +1322,18 @@ msgid "Username"
 msgstr "Nome de usuario"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validar"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Vídeo"
 
@@ -1343,7 +1351,7 @@ msgid "Waiting..."
 msgstr "Á espera..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Peor"
 
@@ -1356,10 +1364,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Si"

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,14 +20,14 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "הסתיימה הורדת „{0}”."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "הורדת „{0}” הסתיימה עם שגיאה!"
@@ -135,8 +135,8 @@ msgstr "הוספת התחברות"
 msgid "Advanced Options"
 msgstr "אפשרויות מתקדמות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "הסתיימו כל ההורדות."
 
@@ -234,8 +234,8 @@ msgstr "ניקוי תור ההורדות"
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "לסגור ולעצור את ההורדות?"
 
@@ -400,12 +400,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "מניעת המרות"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -419,13 +427,13 @@ msgstr "הורדה"
 msgid "Download Again"
 msgstr "להוריד שוב"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "הורדה הסתיימה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "הורדה הסתיימה עם שגיאה"
 
@@ -488,8 +496,8 @@ msgstr "מוריד ‏‏{0:f2}%‎ ‏({1})‎"
 msgid "Downloading..."
 msgstr "בהורדה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "הסתיימות הורדות"
 
@@ -622,7 +630,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
@@ -799,7 +807,7 @@ msgstr "שם"
 msgid "Name (Empty)"
 msgstr "שם (ריק)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -810,15 +818,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "לא"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "אין חיבור פעיל לרשת האינטרנט"
 
@@ -888,6 +896,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -1008,7 +1017,7 @@ msgid "Queued"
 msgstr "בתור"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "לנסות שוב להוריד הורדות שכשלו"
@@ -1110,8 +1119,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1196,7 +1205,8 @@ msgstr "שפות לכתוביות (לא תקין)"
 msgid "Success"
 msgstr "הצליחה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1250,7 +1260,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1264,7 +1274,7 @@ msgstr "לא ניתן לאפס את קבוצת המפתחות."
 msgid "Undo Title Editing"
 msgstr "ביטול עריכת הכותרת"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "שחרור קבוצת מפתחות"
 
@@ -1273,7 +1283,7 @@ msgstr "שחרור קבוצת מפתחות"
 msgid "Unset Cookies File"
 msgstr "בחירת קובץ עוגיות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1376,10 +1386,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "כן"

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,20 +20,20 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "הסתיימה הורדת „{0}”."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "הורדת „{0}” הסתיימה עם שגיאה!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(ניתן להתאמה בהעדפות)"
 
@@ -49,7 +49,7 @@ msgstr "‏{0:f1} גיב״ב/שנ׳"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "‏{0:f1} קי״ב/שנ׳"
@@ -70,8 +70,8 @@ msgstr[3] "‏{0} יורד — ‏‎{1:f1}% ‏‎‏({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -93,7 +93,7 @@ msgid ""
 msgstr ""
 "ניתן לספק קובץ עוגיות ל־yt-dlp, על מנת לאפשר הורדת מדיה הדורשת התחברות."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -104,18 +104,18 @@ msgstr ""
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "על מנת להתחיל הורדה יש להוסיף כתובת של סרט, שמע, או רשימת השמעה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -129,14 +129,14 @@ msgid "Add Login"
 msgstr "הוספת התחברות"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "אפשרויות מתקדמות"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "הסתיימו כל ההורדות."
 
@@ -155,17 +155,17 @@ msgstr "החלה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "שמע"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "שפת שמע"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "אימות"
@@ -174,7 +174,7 @@ msgstr "אימות"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -182,7 +182,7 @@ msgid "Back"
 msgstr "חזרה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "הטוב ביותר"
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "ניקוי הורדות שהושלמו"
@@ -221,21 +221,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "ניקוי תור ההורדות"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "לסגור ולעצור את ההורדות?"
 
@@ -243,8 +243,8 @@ msgstr "לסגור ולעצור את ההורדות?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "הושלמו"
@@ -254,7 +254,7 @@ msgstr "הושלמו"
 msgid "Completed Notification Trigger"
 msgstr "גורם להתרעות על השלמת הורדות"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub‏ ❤️ {0}"
 
@@ -302,16 +302,16 @@ msgstr "אישורים"
 msgid "Crop Audio Thumbnails"
 msgstr "חיתוך תמונה ממוזערה לשמע"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "חיתוך תמונה ממוזערת"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -329,7 +329,7 @@ msgstr "מחיקה"
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "ביטול בחירת הכול"
@@ -400,15 +400,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "מניעת המרות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -419,13 +419,13 @@ msgstr "הורדה"
 msgid "Download Again"
 msgstr "להוריד שוב"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "הורדה הסתיימה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "הורדה הסתיימה עם שגיאה"
 
@@ -434,17 +434,17 @@ msgstr "הורדה הסתיימה עם שגיאה"
 msgid "Download log was copied to clipboard."
 msgstr "יומן ההורדה הועתק ללוח הגזירים."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "הורדת מדיה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "הורדת פרק זמן מוגדר"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -458,20 +458,20 @@ msgstr "התחילה הורדה באמצעות aria2"
 msgid "Download using ffmpeg has started"
 msgstr "התחילה הורדה באמצעות ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "הורדת סרטי רשת וקובצי שמע"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "מוריד"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "בהורדה"
@@ -488,12 +488,12 @@ msgstr "מוריד ‏‏{0:f2}%‎ ‏({1})‎"
 msgid "Downloading..."
 msgstr "בהורדה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "הסתיימות הורדות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -528,27 +528,27 @@ msgstr ""
 "אפשרות לראות את התקדמות ההורדה."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "זמן סיום"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "זמן סיום (לא תקין)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "יש לוודא שפרטי הזיהוי תקינים."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -583,8 +583,8 @@ msgstr ""
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "שם קובץ"
@@ -608,7 +608,7 @@ msgstr "הקובץ כבר קיים, והדריסה שלו לא מתאפשרת"
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "סוג קובץ"
@@ -618,23 +618,23 @@ msgstr "סוג קובץ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "עזרה"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -678,13 +678,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "קבוצת מפתחות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "אישור קבוצת מפתחות"
@@ -704,13 +704,13 @@ msgstr "קבוצת המפתחות ננעלה"
 msgid "Language Code Information"
 msgstr "קוד שפה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "יש להשאיר ריק על מנת להוריד מההתחלה."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "רשימה של קבצים נתמכים"
 
@@ -726,7 +726,7 @@ msgstr "התחברות"
 msgid "Login"
 msgstr "התחברות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "להפוך את התמונה הממוזערת לריבוע. שימושי בהורדת מוזיקה."
@@ -736,7 +736,7 @@ msgstr "להפוך את התמונה הממוזערת לריבוע. שימושי
 msgid "Manage previously downloaded media."
 msgstr "ניהול הורדות מדיה קודמות."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -751,11 +751,11 @@ msgid "Max Number of Active Downloads"
 msgstr "מספר מרבי של הורדות פעילות"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "איכות מרבית"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -766,14 +766,13 @@ msgstr ""
 "אפשור אפשרות זאת תשבית את השימוש ב־aria2 בתור המוריד."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "כתובת מדיה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "כתובת מדיה (לא תקינה)"
 
@@ -800,30 +799,30 @@ msgstr "שם"
 msgid "Name (Empty)"
 msgstr "שם (ריק)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "לא"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "אין חיבור פעיל לרשת האינטרנט"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "ניקוי הורדות שהושלמו"
@@ -837,7 +836,7 @@ msgstr "אין אישורים"
 msgid "No downloads running"
 msgstr "אין הורדות פעילות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "אין הורדות פעילות"
@@ -852,26 +851,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "אין הורדות קודמות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "ניקוי תור ההורדות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "מספר בכותרות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -892,14 +891,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -931,21 +930,21 @@ msgstr "פתיחת תיקייה"
 msgid "Overwrite Existing Files"
 msgstr "דריסת קבצים קיימים"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -965,11 +964,15 @@ msgid "Play"
 msgstr "ניגון"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "רשימת השמעה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "בהכנה…"
@@ -984,7 +987,7 @@ msgstr "בהכנה…"
 msgid "Prevent Suspend"
 msgstr "למנוע השהיה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -998,19 +1001,19 @@ msgstr "בתהליך…"
 msgid "Proxy URL"
 msgstr "כתובת מתווך"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "איכות"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "בתור"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "לנסות שוב להוריד הורדות שכשלו"
@@ -1020,7 +1023,7 @@ msgstr "לנסות שוב להוריד הורדות שכשלו"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1055,22 +1058,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "לנסות להוריד שוב"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "לנסות שוב להוריד הורדות שכשלו"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "תיקייה שמירה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "תיקיית שמירה (לא תקין)"
 
@@ -1080,7 +1083,7 @@ msgstr "תיקיית שמירה (לא תקין)"
 msgid "Search history"
 msgstr "ניקוי היסטוריה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "בחירת הכול"
@@ -1091,29 +1094,29 @@ msgstr "בחירת הכול"
 msgid "Select Cookies File"
 msgstr "בחירת קובץ עוגיות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "בחירת פריטים להורדה או שינוי שמות הקבצים."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "בחירת תיקיית שמירה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1125,19 +1128,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "כמה הורדות הסתיימו עם שגיאות!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "הגבלת מהירות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "פיצול פרקים"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "פיצול הסרט למספר חלקים קטנים המבוססים על הפרקים שבו."
@@ -1149,19 +1152,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "מידע SponsorBlock"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "זמן התחלה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "זמן התחלה (לא תקין)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1198,7 +1201,7 @@ msgstr "שפות לכתוביות (לא תקין)"
 msgid "Success"
 msgstr "הצליחה"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1232,7 +1235,7 @@ msgstr ""
 "מגבלה זו (קי״ב/שנ׳) מוחלת להורדות שהוחלו עליהן הגבלת מהירות. שינוי הערך לא "
 "ישפיע על הורדות שכבר פעילות."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1245,7 +1248,7 @@ msgstr ""
 "זה יוביל למחיקת כל קבוצות המפתחות הקודמות על כל הססמאות שבהן. פעולה זו בלתי "
 "הפיכה."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
@@ -1256,7 +1259,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1265,7 +1268,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "לא ניתן לאפס את קבוצת המפתחות."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr "לא ניתן להגדיר תלויות. יש להפעיל מחדש את היישום ולנסות שוב."
 
@@ -1274,7 +1277,7 @@ msgstr "לא ניתן להגדיר תלויות. יש להפעיל מחדש את
 msgid "Undo Title Editing"
 msgstr "ביטול עריכת הכותרת"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "שחרור קבוצת מפתחות"
 
@@ -1283,7 +1286,7 @@ msgstr "שחרור קבוצת מפתחות"
 msgid "Unset Cookies File"
 msgstr "בחירת קובץ עוגיות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1335,7 +1338,7 @@ msgid "User Name (Empty)"
 msgstr "שם משתמש (ריק)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1344,13 +1347,18 @@ msgid "Username"
 msgstr "שם משתמש"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "תיקוף"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "תיקוף"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "סרט"
 
@@ -1368,7 +1376,7 @@ msgid "Waiting..."
 msgstr "בהמתנה…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "גרוע ביותר"
 
@@ -1381,10 +1389,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "כן"

--- a/NickvisionTubeConverter.Shared/Resources/po/he.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-25 10:01+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -21,13 +21,13 @@ msgstr ""
 "X-Generator: Weblate 5.0.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "הסתיימה הורדת „{0}”."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "הורדת „{0}” הסתיימה עם שגיאה!"
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "על מנת להתחיל הורדה יש להוסיף כתובת של סרט, שמע, או רשימת השמעה"
@@ -113,9 +113,9 @@ msgstr "על מנת להתחיל הורדה יש להוסיף כתובת של ס
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -136,7 +136,7 @@ msgid "Advanced Options"
 msgstr "אפשרויות מתקדמות"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "הסתיימו כל ההורדות."
 
@@ -204,7 +204,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "ניקוי הורדות שהושלמו"
@@ -222,7 +222,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "לסגור ולעצור את ההורדות?"
 
@@ -243,8 +243,8 @@ msgstr "לסגור ולעצור את ההורדות?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "הושלמו"
@@ -254,7 +254,7 @@ msgstr "הושלמו"
 msgid "Completed Notification Trigger"
 msgstr "גורם להתרעות על השלמת הורדות"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub‏ ❤️ {0}"
 
@@ -307,11 +307,11 @@ msgstr "חיתוך תמונה ממוזערה לשמע"
 msgid "Crop Thumbnail"
 msgstr "חיתוך תמונה ממוזערת"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -325,7 +325,7 @@ msgid "Delete"
 msgstr "מחיקה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "למחוק אישורים?"
 
@@ -420,12 +420,12 @@ msgid "Download Again"
 msgstr "להוריד שוב"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "הורדה הסתיימה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "הורדה הסתיימה עם שגיאה"
 
@@ -434,7 +434,7 @@ msgstr "הורדה הסתיימה עם שגיאה"
 msgid "Download log was copied to clipboard."
 msgstr "יומן ההורדה הועתק ללוח הגזירים."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "הורדת מדיה"
@@ -458,7 +458,7 @@ msgstr "התחילה הורדה באמצעות aria2"
 msgid "Download using ffmpeg has started"
 msgstr "התחילה הורדה באמצעות ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -470,8 +470,8 @@ msgstr "הורדת סרטי רשת וקובצי שמע"
 msgid "Downloader"
 msgstr "מוריד"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "בהורדה"
@@ -489,7 +489,7 @@ msgid "Downloading..."
 msgstr "בהורדה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "הסתיימות הורדות"
 
@@ -584,7 +584,7 @@ msgid "Error"
 msgstr "שגיאה"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -618,7 +618,7 @@ msgstr "סוג קובץ"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -677,7 +677,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -710,7 +710,7 @@ msgstr "קוד שפה"
 msgid "Leave empty to download from start."
 msgstr "יש להשאיר ריק על מנת להוריד מההתחלה."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "רשימה של קבצים נתמכים"
 
@@ -721,8 +721,8 @@ msgstr "התחברות"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "התחברות"
 
@@ -736,7 +736,7 @@ msgstr "להפוך את התמונה הממוזערת לריבוע. שימושי
 msgid "Manage previously downloaded media."
 msgstr "ניהול הורדות מדיה קודמות."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -789,40 +789,40 @@ msgstr "גודל פיצול מזערי (‎-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "שם"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "שם (ריק)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "לא"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "אין חיבור פעיל לרשת האינטרנט"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "ניקוי הורדות שהושלמו"
@@ -836,7 +836,7 @@ msgstr "אין אישורים"
 msgid "No downloads running"
 msgstr "אין הורדות פעילות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "אין הורדות פעילות"
@@ -851,7 +851,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "אין הורדות קודמות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "ניקוי תור ההורדות"
@@ -930,14 +930,14 @@ msgstr "פתיחת תיקייה"
 msgid "Overwrite Existing Files"
 msgstr "דריסת קבצים קיימים"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -946,7 +946,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -954,7 +954,7 @@ msgid "Password"
 msgstr "ססמה"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "ססמה (ריק)"
 
@@ -971,11 +971,6 @@ msgstr "רשימת השמעה"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "בהכנה…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1006,14 +1001,14 @@ msgstr "כתובת מתווך"
 msgid "Quality"
 msgstr "איכות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "בתור"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "לנסות שוב להוריד הורדות שכשלו"
@@ -1033,7 +1028,7 @@ msgid "Reset"
 msgstr "איפוס"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "איפוס קבוצת המפתחות?"
 
@@ -1059,7 +1054,7 @@ msgid "Retry Download"
 msgstr "לנסות להוריד שוב"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1106,17 +1101,17 @@ msgid "Select Save Folder"
 msgstr "בחירת תיקיית שמירה"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1164,7 +1159,7 @@ msgid "Start Time (Invalid)"
 msgstr "זמן התחלה (לא תקין)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1222,7 +1217,7 @@ msgid "Theme"
 msgstr "ערכת עיצוב"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "פעולה זו בלתי הפיכה. האם אכן ברצונך לבצע את המחיקה?"
 
@@ -1235,12 +1230,8 @@ msgstr ""
 "מגבלה זו (קי״ב/שנ׳) מוחלת להורדות שהוחלו עליהן הגבלת מהירות. שינוי הערך לא "
 "ישפיע על הורדות שכבר פעילות."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1248,36 +1239,32 @@ msgstr ""
 "זה יוביל למחיקת כל קבוצות המפתחות הקודמות על כל הססמאות שבהן. פעולה זו בלתי "
 "הפיכה."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "לא ניתן למחוק את קבוצת המפתחות."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "לא ניתן לאפס את קבוצת המפתחות."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr "לא ניתן להגדיר תלויות. יש להפעיל מחדש את היישום ולנסות שוב."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "ביטול עריכת הכותרת"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "שחרור קבוצת מפתחות"
 
@@ -1286,19 +1273,19 @@ msgstr "שחרור קבוצת מפתחות"
 msgid "Unset Cookies File"
 msgstr "בחירת קובץ עוגיות"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "כתובת"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "כתובת (לא תקינה)"
 
@@ -1332,7 +1319,7 @@ msgid "User Interface"
 msgstr "ממשק משתמש"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "שם משתמש (ריק)"
@@ -1340,7 +1327,7 @@ msgstr "שם משתמש (ריק)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1390,9 +1377,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "כן"
@@ -1541,6 +1528,13 @@ msgstr "- הפעלת מספר הורדות במקביל"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- תמיכה בהורדת נתוני מידע וכתוביות לסרטים"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "בהכנה…"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr "לא ניתן להגדיר תלויות. יש להפעיל מחדש את היישום ולנסות שוב."
 
 #~ msgid "Search..."
 #~ msgstr "חיפוש…"

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,14 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -126,8 +126,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr ""
 
@@ -225,8 +225,8 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -379,12 +379,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -398,13 +406,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -465,8 +473,8 @@ msgstr ""
 msgid "Downloading..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr ""
 
@@ -594,7 +602,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
@@ -763,7 +771,7 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -774,15 +782,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -849,6 +857,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -968,7 +977,7 @@ msgid "Queued"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -1069,8 +1078,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1151,7 +1160,8 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1196,7 +1206,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1210,7 +1220,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1218,7 +1228,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1316,10 +1326,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,20 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr ""
@@ -64,8 +64,8 @@ msgstr[1] ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -84,7 +84,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -95,18 +95,18 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -120,14 +120,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr ""
 
@@ -146,17 +146,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -173,7 +173,7 @@ msgid "Back"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr ""
 
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -194,8 +194,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -212,21 +212,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -234,8 +234,8 @@ msgstr ""
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -289,16 +289,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -379,15 +379,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -398,13 +398,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -413,17 +413,17 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr ""
@@ -436,20 +436,20 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -465,12 +465,12 @@ msgstr ""
 msgid "Downloading..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -502,27 +502,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -539,7 +539,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -557,8 +557,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr ""
 
@@ -580,7 +580,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr ""
@@ -590,23 +590,23 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -645,13 +645,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -671,13 +671,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr ""
 
@@ -717,11 +717,11 @@ msgid "Max Number of Active Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -730,14 +730,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr ""
 
@@ -764,30 +763,30 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -800,7 +799,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Downloads Running"
 msgstr ""
 
@@ -814,25 +813,25 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 msgid "No Queued Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -853,14 +852,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -891,21 +890,21 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -925,11 +924,15 @@ msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 msgid "Preparing required tools..."
 msgstr ""
 
@@ -943,7 +946,7 @@ msgstr ""
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -957,19 +960,19 @@ msgstr ""
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -979,7 +982,7 @@ msgstr ""
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1014,22 +1017,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr ""
 
@@ -1038,7 +1041,7 @@ msgstr ""
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
@@ -1049,29 +1052,29 @@ msgstr ""
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1081,19 +1084,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1104,19 +1107,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1152,7 +1155,7 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1181,7 +1184,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1192,7 +1195,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1201,7 +1204,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1210,7 +1213,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
@@ -1219,7 +1222,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1227,7 +1230,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1275,7 +1278,7 @@ msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1284,13 +1287,17 @@ msgid "Username"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+msgid "Validating"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr ""
 
@@ -1308,7 +1315,7 @@ msgid "Waiting..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr ""
 
@@ -1321,10 +1328,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/hi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,13 +17,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -95,7 +95,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -104,9 +104,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,7 +127,7 @@ msgid "Advanced Options"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr ""
 
@@ -195,7 +195,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -213,7 +213,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -226,7 +226,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -234,8 +234,8 @@ msgstr ""
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -294,11 +294,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -312,7 +312,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -399,12 +399,12 @@ msgid "Download Again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -413,7 +413,7 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
@@ -436,7 +436,7 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -448,8 +448,8 @@ msgstr ""
 msgid "Downloader"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -466,7 +466,7 @@ msgid "Downloading..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgid "Error"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -590,7 +590,7 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr ""
 
@@ -687,8 +687,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr ""
 
@@ -753,40 +753,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 msgid "No Queued Downloads"
 msgstr ""
 
@@ -890,14 +890,14 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -906,7 +906,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -914,7 +914,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -930,10 +930,6 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
-msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-msgid "Preparing required tools..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
@@ -965,14 +961,14 @@ msgstr ""
 msgid "Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -992,7 +988,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1018,7 +1014,7 @@ msgid "Retry Download"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1064,17 +1060,17 @@ msgid "Select Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1119,7 +1115,7 @@ msgid "Start Time (Invalid)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1173,7 +1169,7 @@ msgid "Theme"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1184,37 +1180,29 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
@@ -1222,7 +1210,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1230,19 +1218,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -1273,14 +1261,14 @@ msgid "User Interface"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1329,9 +1317,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" letöltése befejeződött."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" letöltése közben hiba történt."
@@ -131,8 +131,8 @@ msgstr "Bejelentkezés hozzáadása"
 msgid "Advanced Options"
 msgstr "Haladó beállítások"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Minden letöltés befejeződött."
 
@@ -230,8 +230,8 @@ msgstr "Sorban álló letöltések törlése"
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Megszakítás és kilépés"
 
@@ -398,12 +398,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Átkódolás tiltása"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -417,13 +425,13 @@ msgstr "Letöltés"
 msgid "Download Again"
 msgstr "Letöltés ismét"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Hiba történt letöltés közben"
 
@@ -486,8 +494,8 @@ msgstr "Letöltés folyamatban {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Letöltés folyamatban"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Letöltés befejeződött"
 
@@ -619,7 +627,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub tároló"
@@ -796,7 +804,7 @@ msgstr "Megnevezés"
 msgid "Name (Empty)"
 msgstr "Megnevezés (üres)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -807,15 +815,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nem"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Nincs internetkapcsolat"
 
@@ -885,6 +893,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -1005,7 +1014,7 @@ msgid "Queued"
 msgstr "Ütemezve"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Sikertelen letöltések újrakezdése"
@@ -1107,8 +1116,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1194,7 +1203,8 @@ msgstr "Feliratok (hibás)"
 msgid "Success"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1247,7 +1257,7 @@ msgstr "ViBE"
 msgid "Unable to disable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1261,7 +1271,7 @@ msgstr "Jelszókezelő visszaállítása nem lehetséges."
 msgid "Undo Title Editing"
 msgstr "Módosítás visszavonása"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Jelszókezelő feloldása"
 
@@ -1270,7 +1280,7 @@ msgstr "Jelszókezelő feloldása"
 msgid "Unset Cookies File"
 msgstr "Süti fájl betöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1373,10 +1383,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Igen"

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" letöltése befejeződött."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" letöltése közben hiba történt."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Beállításokban módosítható)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/mp"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/mp"
@@ -67,8 +67,8 @@ msgstr[1] "{0} letöltés folyamatban — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "A yt-dlp képes külső fájlban tárolt bejelentkezési adatok betöltésére az azt "
 "igénylő oldalakhoz."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -100,18 +100,18 @@ msgstr ""
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Kezdéshez adja hozzá a letölteni kívánt tartalom hivatkozását"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr "Bejelentkezés hozzáadása"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Haladó beállítások"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Minden letöltés befejeződött."
 
@@ -151,17 +151,17 @@ msgstr "Mentés"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Hang"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Hangsáv"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Bejelentkezés"
@@ -170,7 +170,7 @@ msgstr "Bejelentkezés"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr "Vissza"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Jó"
 
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Befejezett letöltések törlése"
@@ -217,21 +217,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Sorban álló letöltések törlése"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Megszakítás és kilépés"
 
@@ -239,8 +239,8 @@ msgstr "Megszakítás és kilépés"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Befejezett letöltések"
@@ -250,7 +250,7 @@ msgstr "Befejezett letöltések"
 msgid "Completed Notification Trigger"
 msgstr "Értesítések"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Közreműködők GitHub-bon ❤️"
 
@@ -299,16 +299,16 @@ msgstr "Bejelentkezések"
 msgid "Crop Audio Thumbnails"
 msgstr "Borítókép javítása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Borítókép javítása"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -326,7 +326,7 @@ msgstr "Törlés"
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Kijelölés törlése"
@@ -398,15 +398,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Átkódolás tiltása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -417,13 +417,13 @@ msgstr "Letöltés"
 msgid "Download Again"
 msgstr "Letöltés ismét"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Hiba történt letöltés közben"
 
@@ -432,17 +432,17 @@ msgstr "Hiba történt letöltés közben"
 msgid "Download log was copied to clipboard."
 msgstr "Letöltés napló vágólapra másolva."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Tartalom letöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Részlet letöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -456,20 +456,20 @@ msgstr "Letöltés aria2 kódoló használatával megkezdődött"
 msgid "Download using ffmpeg has started"
 msgstr "Letöltés ffmpeg kódoló használatával megkezdődött"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Internetes médiatartalmak letöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Letöltő"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Letöltés folyamatban"
@@ -486,12 +486,12 @@ msgstr "Letöltés folyamatban {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Letöltés folyamatban"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -525,27 +525,27 @@ msgstr ""
 "aira2 kódoló engedélyezése. Gyorsabb, de nem jelzi a feldolgozás állapotát."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Részlet vége"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Részlet vége (hibás)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Győződjön meg arról, hogy az adatok helyesek!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -562,7 +562,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -570,7 +570,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -580,8 +580,8 @@ msgstr ""
 msgid "Error"
 msgstr "Hiba"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Fájlnév"
@@ -605,7 +605,7 @@ msgstr "A fájl már létezik, de felülírás nem engedélyezett"
 msgid "File Name"
 msgstr "Fájlnév"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Fájltípus"
@@ -615,23 +615,23 @@ msgstr "Fájltípus"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub tároló"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Súgó"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -674,13 +674,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Jelszókezelő"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Bejelentkezés:"
@@ -700,13 +700,13 @@ msgstr "Jelszókezelő zárolva"
 msgid "Language Code Information"
 msgstr "Információ a nyelvi kódlapokról"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Hagyja üresen, ha az elejétől szeretné letölteni a videót!"
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Támogatott honlapok listája"
 
@@ -722,7 +722,7 @@ msgstr "Bejelentkezés"
 msgid "Login"
 msgstr "Bejelentkezés"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Javítja a zenei tartalmak elnyújtott borítóképeit."
@@ -732,7 +732,7 @@ msgstr "Javítja a zenei tartalmak elnyújtott borítóképeit."
 msgid "Manage previously downloaded media."
 msgstr "Korábbi letöltések kezelése."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix csatorna"
 
@@ -747,11 +747,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Párhuzamos letöltések száma"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Legjobb minőség"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -763,14 +763,13 @@ msgstr ""
 "kerül."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Hivatkozás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
@@ -797,30 +796,30 @@ msgstr "Megnevezés"
 msgid "Name (Empty)"
 msgstr "Megnevezés (üres)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nem"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Nincs internetkapcsolat"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Befejezett letöltések törlése"
@@ -834,7 +833,7 @@ msgstr "Nincs tárolt bejelentkezés"
 msgid "No downloads running"
 msgstr "Nincs folyamatban letöltés"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nincs folyamatban letöltés"
@@ -849,26 +848,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Nincsenek előzmények"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Sorban álló letöltések törlése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -889,14 +888,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -928,21 +927,21 @@ msgstr "Fájl helyének megnyitása"
 msgid "Overwrite Existing Files"
 msgstr "Azonos nevű fájl felülírása"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -962,11 +961,15 @@ msgid "Play"
 msgstr "Lejátszás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Lejátszási lista"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Előkészítés..."
@@ -981,7 +984,7 @@ msgstr "Előkészítés..."
 msgid "Prevent Suspend"
 msgstr "Készenlét/felfüggesztés tiltása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -995,19 +998,19 @@ msgstr "Feldolgozás..."
 msgid "Proxy URL"
 msgstr "Proxy átjáró címe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Felbontás/minőség"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Ütemezve"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Sikertelen letöltések újrakezdése"
@@ -1017,7 +1020,7 @@ msgstr "Sikertelen letöltések újrakezdése"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1052,22 +1055,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Letöltés újra"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Sikertelen letöltések újrakezdése"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Letöltés helye"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Letöltés helye (hibás)"
 
@@ -1077,7 +1080,7 @@ msgstr "Letöltés helye (hibás)"
 msgid "Search history"
 msgstr "Előzmények törlése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Összes kijelölése"
@@ -1088,29 +1091,29 @@ msgstr "Összes kijelölése"
 msgid "Select Cookies File"
 msgstr "Süti fájl betöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Elemek kijelölése letöltéshez vagy átnevezéshez."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Letöltés helyének kiválasztása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1122,20 +1125,20 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Egyes letöltések közben hiba történt."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Sávszélesség korlátozása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Fejezetek beágyazása"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1147,19 +1150,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Információ a süti fájlról"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Részlet kezdete"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Részlet kezdete (hibás)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1196,7 +1199,7 @@ msgstr "Feliratok (hibás)"
 msgid "Success"
 msgstr "Letöltés befejeződött"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1231,7 +1234,7 @@ msgstr ""
 "Ez a beállítás csak a korlátozott letöltésekre van hatással. Valamint a "
 "módosítása a már futó letöltéseket nem érinti. Értéke KiB/mp-ben értendő."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1244,7 +1247,7 @@ msgstr ""
 "Ez a művelet törli az összes tárolt bejelentkezést. A művelet nem "
 "visszafordítható."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "ViBE"
 
@@ -1253,7 +1256,7 @@ msgstr "ViBE"
 msgid "Unable to disable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1262,7 +1265,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Jelszókezelő visszaállítása nem lehetséges."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Nem sikerült a függőségek feloldása. Kérem, indítsa újra a programot és "
@@ -1273,7 +1276,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Módosítás visszavonása"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Jelszókezelő feloldása"
 
@@ -1282,7 +1285,7 @@ msgstr "Jelszókezelő feloldása"
 msgid "Unset Cookies File"
 msgstr "Süti fájl betöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1334,7 +1337,7 @@ msgid "User Name (Empty)"
 msgstr "Felhasználónév (üres)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1343,13 +1346,18 @@ msgid "Username"
 msgstr "Felhasználónév"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Elemzés"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Elemzés"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Videó"
 
@@ -1367,7 +1375,7 @@ msgid "Waiting..."
 msgstr "Várakozik..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Rossz"
 
@@ -1380,10 +1388,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Igen"

--- a/NickvisionTubeConverter.Shared/Resources/po/hu.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: ViBE <vibe@protonmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" letöltése befejeződött."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" letöltése közben hiba történt."
@@ -100,7 +100,7 @@ msgstr ""
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Kezdéshez adja hozzá a letölteni kívánt tartalom hivatkozását"
@@ -109,9 +109,9 @@ msgstr "Kezdéshez adja hozzá a letölteni kívánt tartalom hivatkozását"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "Haladó beállítások"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Minden letöltés befejeződött."
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Befejezett letöltések törlése"
@@ -218,7 +218,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -231,7 +231,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Megszakítás és kilépés"
 
@@ -239,8 +239,8 @@ msgstr "Megszakítás és kilépés"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Befejezett letöltések"
@@ -250,7 +250,7 @@ msgstr "Befejezett letöltések"
 msgid "Completed Notification Trigger"
 msgstr "Értesítések"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Közreműködők GitHub-bon ❤️"
 
@@ -304,11 +304,11 @@ msgstr "Borítókép javítása"
 msgid "Crop Thumbnail"
 msgstr "Borítókép javítása"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -322,7 +322,7 @@ msgid "Delete"
 msgstr "Törlés"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Bejelentkezés törlése"
 
@@ -418,12 +418,12 @@ msgid "Download Again"
 msgstr "Letöltés ismét"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Letöltés befejeződött"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Hiba történt letöltés közben"
 
@@ -432,7 +432,7 @@ msgstr "Hiba történt letöltés közben"
 msgid "Download log was copied to clipboard."
 msgstr "Letöltés napló vágólapra másolva."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Tartalom letöltése"
@@ -456,7 +456,7 @@ msgstr "Letöltés aria2 kódoló használatával megkezdődött"
 msgid "Download using ffmpeg has started"
 msgstr "Letöltés ffmpeg kódoló használatával megkezdődött"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -468,8 +468,8 @@ msgstr "Internetes médiatartalmak letöltése"
 msgid "Downloader"
 msgstr "Letöltő"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Letöltés folyamatban"
@@ -487,7 +487,7 @@ msgid "Downloading..."
 msgstr "Letöltés folyamatban"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Letöltés befejeződött"
 
@@ -581,7 +581,7 @@ msgid "Error"
 msgstr "Hiba"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgstr "Fájltípus"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -673,7 +673,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -706,7 +706,7 @@ msgstr "Információ a nyelvi kódlapokról"
 msgid "Leave empty to download from start."
 msgstr "Hagyja üresen, ha az elejétől szeretné letölteni a videót!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Támogatott honlapok listája"
 
@@ -717,8 +717,8 @@ msgstr "Bejelentkezés"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Bejelentkezés"
 
@@ -732,7 +732,7 @@ msgstr "Javítja a zenei tartalmak elnyújtott borítóképeit."
 msgid "Manage previously downloaded media."
 msgstr "Korábbi letöltések kezelése."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix csatorna"
 
@@ -786,40 +786,40 @@ msgstr "Tartalmak darabolása (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Megnevezés"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Megnevezés (üres)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nem"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Nincs internetkapcsolat"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Befejezett letöltések törlése"
@@ -833,7 +833,7 @@ msgstr "Nincs tárolt bejelentkezés"
 msgid "No downloads running"
 msgstr "Nincs folyamatban letöltés"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nincs folyamatban letöltés"
@@ -848,7 +848,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Nincsenek előzmények"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Sorban álló letöltések törlése"
@@ -927,14 +927,14 @@ msgstr "Fájl helyének megnyitása"
 msgid "Overwrite Existing Files"
 msgstr "Azonos nevű fájl felülírása"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -943,7 +943,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -951,7 +951,7 @@ msgid "Password"
 msgstr "Jelszó"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Jelszó (üres)"
 
@@ -968,11 +968,6 @@ msgstr "Lejátszási lista"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Előkészítés..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1003,14 +998,14 @@ msgstr "Proxy átjáró címe"
 msgid "Quality"
 msgstr "Felbontás/minőség"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Ütemezve"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Sikertelen letöltések újrakezdése"
@@ -1030,7 +1025,7 @@ msgid "Reset"
 msgstr "Visszaállítás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Jelszókezelő visszaállítása"
 
@@ -1056,7 +1051,7 @@ msgid "Retry Download"
 msgstr "Letöltés újra"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1103,17 +1098,17 @@ msgid "Select Save Folder"
 msgstr "Letöltés helyének kiválasztása"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1162,7 +1157,7 @@ msgid "Start Time (Invalid)"
 msgstr "Részlet kezdete (hibás)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1220,7 +1215,7 @@ msgid "Theme"
 msgstr "Téma"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "A művelet nem visszafordítható. Valóban törli a bejelentkezési adatokat?"
@@ -1234,12 +1229,8 @@ msgstr ""
 "Ez a beállítás csak a korlátozott letöltésekre van hatással. Valamint a "
 "módosítása a már futó letöltéseket nem érinti. Értéke KiB/mp-ben értendő."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1247,36 +1238,30 @@ msgstr ""
 "Ez a művelet törli az összes tárolt bejelentkezést. A művelet nem "
 "visszafordítható."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "ViBE"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Jelszókezelő letiltása nem lehetséges."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Jelszókezelő visszaállítása nem lehetséges."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Nem sikerült a függőségek feloldása. Kérem, indítsa újra a programot és "
-"próbálja újra!"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Módosítás visszavonása"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Jelszókezelő feloldása"
 
@@ -1285,19 +1270,19 @@ msgstr "Jelszókezelő feloldása"
 msgid "Unset Cookies File"
 msgstr "Süti fájl betöltése"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Hivatkozás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "Hivatkozás (hibás)"
 
@@ -1331,7 +1316,7 @@ msgid "User Interface"
 msgstr "Kezelőfelület"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Felhasználónév (üres)"
@@ -1339,7 +1324,7 @@ msgstr "Felhasználónév (üres)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1389,9 +1374,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Igen"
@@ -1543,6 +1528,15 @@ msgstr "— Párhuzamos letöltési lehetőség"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Támogatott a feliratok és egyebek beágyazása"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Előkészítés..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Nem sikerült a függőségek feloldása. Kérem, indítsa újra a programot és "
+#~ "próbálja újra!"
 
 #~ msgid "Search..."
 #~ msgstr "Keresés..."

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" telah selesai diunduh."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" telah selesai dengan kesalahan!"
@@ -96,7 +96,7 @@ msgstr "Tentang {0}"
 msgid "Add"
 msgstr "Tambah"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -105,9 +105,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -128,7 +128,7 @@ msgid "Advanced Options"
 msgstr "Opsi Lanjutan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Semua unduhan selesai."
 
@@ -196,7 +196,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -215,7 +215,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -229,7 +229,7 @@ msgid "Close"
 msgstr "Tutup"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Tutup dan Hentikan Unduhan?"
 
@@ -237,8 +237,8 @@ msgstr "Tutup dan Hentikan Unduhan?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Selesai"
@@ -248,7 +248,7 @@ msgstr "Selesai"
 msgid "Completed Notification Trigger"
 msgstr "Pemicu Pemberitahuan Selesai"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -303,11 +303,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr "Potong Keluku (Thumbnail)"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgid "Delete"
 msgstr "Hapus"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
@@ -413,12 +413,12 @@ msgid "Download Again"
 msgstr "Mengunduh"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Unduhan Selesai"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Unduh Selesai Dengan Error"
 
@@ -427,7 +427,7 @@ msgstr "Unduh Selesai Dengan Error"
 msgid "Download log was copied to clipboard."
 msgstr "Log unduhan disalin ke papan klip."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
@@ -453,7 +453,7 @@ msgstr "Pengunduhan menggunakan aria2 telah dimulai"
 msgid "Download using ffmpeg has started"
 msgstr "Pengunduhan menggunakan aria2 telah dimulai"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -465,8 +465,8 @@ msgstr "Unduh video web dan audio"
 msgid "Downloader"
 msgstr "Pengunduh"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Mengunduh"
@@ -484,7 +484,7 @@ msgid "Downloading..."
 msgstr "Mengunduh"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Unduhan Selesai"
 
@@ -589,7 +589,7 @@ msgid "Error"
 msgstr "Kesalahan"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr "Tipe Berkas"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -714,7 +714,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Daftar situs yang didukung"
 
@@ -724,8 +724,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr "Jadikan keluku berbentuk persegi, berguna ketika mengunduh musik."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Obrolan Matriks"
 
@@ -790,40 +790,40 @@ msgstr "Ukuran pemisahan minimum (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nama"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nama (Kosong)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Tidak"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tutup dan Hentikan Unduhan?"
@@ -837,7 +837,7 @@ msgstr "Tidak ada kredensial"
 msgid "No downloads running"
 msgstr "Tidak ada unduhan yang berjalan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Tidak ada unduhan yang berjalan"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Hentikan Unduhan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tutup dan Hentikan Unduhan?"
@@ -932,14 +932,14 @@ msgstr "Buka Folder"
 msgid "Overwrite Existing Files"
 msgstr "Timpa Berkas yang Ada"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -948,7 +948,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -956,7 +956,7 @@ msgid "Password"
 msgstr "Kata sandi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Kata sandi (Kosong)"
 
@@ -974,11 +974,6 @@ msgstr "Daftar Putar"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Menyiapkan..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1009,14 +1004,14 @@ msgstr ""
 msgid "Quality"
 msgstr "Kualitas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Antrian"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Ulangi Unduhan"
@@ -1036,7 +1031,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Atur Keyring"
@@ -1063,7 +1058,7 @@ msgid "Retry Download"
 msgstr "Ulangi Unduhan"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 #, fuzzy
@@ -1111,18 +1106,18 @@ msgid "Select Save Folder"
 msgstr "Pilih Folder Simpan"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Pengaturan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1173,7 +1168,7 @@ msgid "Start Time (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 #, fuzzy
@@ -1234,7 +1229,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Aksi ini tidak dapat diurungkan. Apakah anda yakin untuk menghapusnya?"
 
@@ -1247,48 +1242,38 @@ msgstr ""
 "Batas ini (dalam KiB/d) diterapkan untuk unduhan yang mengaktifkan batas "
 "kecepatan. Mengubah nilai ini tidak memengaruhi unduhan yang sudah berjalan."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "kredit penerjemah"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Tidak dapat mengunduh dependensi. Silahkan mulai ulang aplikasi dan coba "
-"lagi."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Urungkan menyunting judul"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Buka Keyring"
 
@@ -1297,19 +1282,19 @@ msgstr "Buka Keyring"
 msgid "Unset Cookies File"
 msgstr "Pilih File Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (tidak sah)"
 
@@ -1340,7 +1325,7 @@ msgid "User Interface"
 msgstr "Tampilan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nama pengguna (Kosong)"
@@ -1348,7 +1333,7 @@ msgstr "Nama pengguna (Kosong)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1398,9 +1383,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Iya"
@@ -1548,6 +1533,15 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Menyiapkan..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Tidak dapat mengunduh dependensi. Silahkan mulai ulang aplikasi dan coba "
+#~ "lagi."
 
 #~ msgctxt "Subtitle"
 #~ msgid "None"

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" telah selesai diunduh."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" telah selesai dengan kesalahan!"
@@ -127,8 +127,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "Opsi Lanjutan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Semua unduhan selesai."
 
@@ -228,8 +228,8 @@ msgstr "Tutup dan Hentikan Unduhan?"
 msgid "Close"
 msgstr "Tutup"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Tutup dan Hentikan Unduhan?"
 
@@ -392,12 +392,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskusi"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -412,13 +420,13 @@ msgstr "Unduh"
 msgid "Download Again"
 msgstr "Mengunduh"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Unduhan Selesai"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Unduh Selesai Dengan Error"
 
@@ -483,8 +491,8 @@ msgstr "Mengunduh {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Mengunduh"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Unduhan Selesai"
 
@@ -627,7 +635,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repo GitHub"
@@ -800,7 +808,7 @@ msgstr "Nama"
 msgid "Name (Empty)"
 msgstr "Nama (Kosong)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -811,15 +819,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Tidak"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -890,6 +898,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1011,7 +1020,7 @@ msgid "Queued"
 msgstr "Antrian"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Ulangi Unduhan"
@@ -1116,8 +1125,8 @@ msgstr "Pengaturan"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1207,7 +1216,8 @@ msgstr "Folder Penyimpanan (tidak sah)"
 msgid "Success"
 msgstr "Sukses"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1259,7 +1269,7 @@ msgstr "kredit penerjemah"
 msgid "Unable to disable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1273,7 +1283,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Urungkan menyunting judul"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Buka Keyring"
 
@@ -1282,7 +1292,7 @@ msgstr "Buka Keyring"
 msgid "Unset Cookies File"
 msgstr "Pilih File Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1382,10 +1392,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Iya"

--- a/NickvisionTubeConverter.Shared/Resources/po/id.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-06-12 02:55+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" telah selesai diunduh."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" telah selesai dengan kesalahan!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Dapat dikonfigurasi di preferensi)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/dtk"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/dtk"
@@ -66,8 +66,8 @@ msgstr[0] "{0} unduhan - {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -85,7 +85,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Tentang {0}"
@@ -96,18 +96,18 @@ msgstr "Tentang {0}"
 msgid "Add"
 msgstr "Tambah"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -121,14 +121,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opsi Lanjutan"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Semua unduhan selesai."
 
@@ -147,17 +147,17 @@ msgstr "Terapkan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Suara"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Otentikasi"
@@ -166,7 +166,7 @@ msgstr "Otentikasi"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -174,7 +174,7 @@ msgid "Back"
 msgstr "Kembali"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Terbaik"
 
@@ -186,7 +186,7 @@ msgstr "Batalkan"
 msgid "Changelog"
 msgstr "Perubahan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -195,8 +195,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -214,8 +214,8 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -223,13 +223,13 @@ msgid "Clear Queued Downloads"
 msgstr "Tutup dan Hentikan Unduhan?"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Tutup"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Tutup dan Hentikan Unduhan?"
 
@@ -237,8 +237,8 @@ msgstr "Tutup dan Hentikan Unduhan?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Selesai"
@@ -248,7 +248,7 @@ msgstr "Selesai"
 msgid "Completed Notification Trigger"
 msgstr "Pemicu Pemberitahuan Selesai"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -298,16 +298,16 @@ msgstr "Kredensial"
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Potong Keluku (Thumbnail)"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgstr "Hapus"
 msgid "Delete Credential?"
 msgstr "Hapus Kredensial?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -392,15 +392,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskusi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -412,13 +412,13 @@ msgstr "Unduh"
 msgid "Download Again"
 msgstr "Mengunduh"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Unduhan Selesai"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Unduh Selesai Dengan Error"
 
@@ -427,18 +427,18 @@ msgstr "Unduh Selesai Dengan Error"
 msgid "Download log was copied to clipboard."
 msgstr "Log unduhan disalin ke papan klip."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
 msgstr "Unduh"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -453,20 +453,20 @@ msgstr "Pengunduhan menggunakan aria2 telah dimulai"
 msgid "Download using ffmpeg has started"
 msgstr "Pengunduhan menggunakan aria2 telah dimulai"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Unduh video web dan audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Pengunduh"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Mengunduh"
@@ -483,12 +483,12 @@ msgstr "Mengunduh {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Mengunduh"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Unduhan Selesai"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -523,30 +523,30 @@ msgstr ""
 "namun anda tidak akan melihat proses unduhan."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "URL Media (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Masukkan URL media disini"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 #, fuzzy
 msgid "Ensure credentials are correct."
 msgstr "Atur Kredensial di keyring anda."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Masukkan URL media disini"
@@ -556,7 +556,7 @@ msgstr "Masukkan URL media disini"
 msgid "Enter name here"
 msgstr "Masukkan URL media disini"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -567,7 +567,7 @@ msgstr "Masukkan URL media disini"
 msgid "Enter proxy url here"
 msgstr "Masukkan URL media disini"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Masukkan URL media disini"
@@ -577,7 +577,7 @@ msgstr "Masukkan URL media disini"
 msgid "Enter url here"
 msgstr "Masukkan URL media disini"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -588,8 +588,8 @@ msgstr "Masukkan URL media disini"
 msgid "Error"
 msgstr "Kesalahan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nama File"
@@ -613,7 +613,7 @@ msgstr "File sudah ada, dan penimpaan tidak diperbolehkan"
 msgid "File Name"
 msgstr "Nama File"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipe Berkas"
@@ -623,23 +623,23 @@ msgstr "Tipe Berkas"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repo GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -680,13 +680,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Kredensial Keyring"
@@ -708,13 +708,13 @@ msgstr "Kredensial Keyring"
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Daftar situs yang didukung"
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Jadikan keluku berbentuk persegi, berguna ketika mengunduh musik."
@@ -739,7 +739,7 @@ msgstr "Jadikan keluku berbentuk persegi, berguna ketika mengunduh musik."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Obrolan Matriks"
 
@@ -754,11 +754,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Jumlah Maksimal Unduhan Aktif"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Kualitas Maksimum"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -767,14 +767,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL Media"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL Media (tidak sah)"
 
@@ -801,30 +800,30 @@ msgstr "Nama"
 msgid "Name (Empty)"
 msgstr "Nama (Kosong)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Tidak"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tutup dan Hentikan Unduhan?"
@@ -838,7 +837,7 @@ msgstr "Tidak ada kredensial"
 msgid "No downloads running"
 msgstr "Tidak ada unduhan yang berjalan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Tidak ada unduhan yang berjalan"
@@ -854,26 +853,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Hentikan Unduhan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tutup dan Hentikan Unduhan?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Hitung Video"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -894,14 +893,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -933,21 +932,21 @@ msgstr "Buka Folder"
 msgid "Overwrite Existing Files"
 msgstr "Timpa Berkas yang Ada"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -968,11 +967,15 @@ msgid "Play"
 msgstr "Daftar Putar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Daftar Putar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Menyiapkan..."
@@ -987,7 +990,7 @@ msgstr "Menyiapkan..."
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1001,19 +1004,19 @@ msgstr "Memproses..."
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kualitas"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Antrian"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Ulangi Unduhan"
@@ -1023,7 +1026,7 @@ msgstr "Ulangi Unduhan"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Laporkan Masalah"
 
@@ -1059,8 +1062,8 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Ulangi Unduhan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 #, fuzzy
@@ -1068,14 +1071,14 @@ msgid "Retry Failed Downloads"
 msgstr "Ulangi Unduhan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Folder Penyimpanan"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
 
@@ -1084,7 +1087,7 @@ msgstr "Folder Penyimpanan (tidak sah)"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1096,30 +1099,30 @@ msgstr "Hentikan Unduhan"
 msgid "Select Cookies File"
 msgstr "Pilih File Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Pilih item untuk diunduh atau ubah nama file."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Pilih Folder Simpan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Pengaturan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1133,19 +1136,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Beberapa unduhan selesai dengan error!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Batas Kecepatan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1157,20 +1160,20 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "File Kuki"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "Folder Penyimpanan (tidak sah)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 #, fuzzy
@@ -1209,7 +1212,7 @@ msgstr "Folder Penyimpanan (tidak sah)"
 msgid "Success"
 msgstr "Sukses"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1244,7 +1247,7 @@ msgstr ""
 "Batas ini (dalam KiB/d) diterapkan untuk unduhan yang mengaktifkan batas "
 "kecepatan. Mengubah nilai ini tidak memengaruhi unduhan yang sudah berjalan."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1255,7 +1258,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "kredit penerjemah"
 
@@ -1265,7 +1268,7 @@ msgstr "kredit penerjemah"
 msgid "Unable to disable keyring."
 msgstr "Nonaktifkan Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1274,7 +1277,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Tidak dapat mengunduh dependensi. Silahkan mulai ulang aplikasi dan coba "
@@ -1285,7 +1288,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Urungkan menyunting judul"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Buka Keyring"
 
@@ -1294,7 +1297,7 @@ msgstr "Buka Keyring"
 msgid "Unset Cookies File"
 msgstr "Pilih File Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1343,7 +1346,7 @@ msgid "User Name (Empty)"
 msgstr "Nama pengguna (Kosong)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1352,13 +1355,18 @@ msgid "Username"
 msgstr "Nama pengguna"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Memvalidasi"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Memvalidasi"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1376,7 +1384,7 @@ msgid "Waiting..."
 msgstr "Menunggu..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Terburuk"
 
@@ -1389,10 +1397,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Iya"

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-04 02:45+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Lo scaricamento di \"{0}\" è terminato."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" è terminato con un errore."
@@ -133,8 +133,8 @@ msgstr "Aggiungi login"
 msgid "Advanced Options"
 msgstr "Opzioni avanzate"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Tutti gli scaricamenti sono terminati."
 
@@ -234,8 +234,8 @@ msgstr "Elimina gli scaricamenti in coda"
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Chiudere e interrompere gli scaricamenti?"
 
@@ -414,6 +414,10 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Non consentire conversioni"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussioni"
@@ -421,6 +425,10 @@ msgstr "Discussioni"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Documentazione"
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
@@ -433,13 +441,13 @@ msgstr "Scarica"
 msgid "Download Again"
 msgstr "Scarica di nuovo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Scaricamento terminato"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Scaricamento terminato con errori"
 
@@ -500,8 +508,8 @@ msgstr "In scaricamento {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Download in corso..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Scaricamenti terminati"
 
@@ -636,7 +644,7 @@ msgstr "Firefox"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
@@ -820,7 +828,7 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr "Nuovo aggiornamento disponibile."
 
@@ -831,15 +839,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Nessuna connessione Internet attiva"
 
@@ -909,6 +917,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1031,7 +1040,7 @@ msgid "Queued"
 msgstr "In coda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Download rimanenti: {0}"
@@ -1134,8 +1143,8 @@ msgstr "Impostazioni"
 msgid "Show Window"
 msgstr "Mostra finestra"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1219,7 +1228,8 @@ msgstr "Lingue sottotitoli (non valide)"
 msgid "Success"
 msgstr "Completato"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1274,7 +1284,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Disattivazione del portachiavi non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr "Impossibile scaricare e installare l'aggiornamento."
 
@@ -1288,7 +1298,7 @@ msgstr "Azzeramento del portachiavi non riuscito."
 msgid "Undo Title Editing"
 msgstr "Annulla la modifica del titolo"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Sblocca portachiavi"
 
@@ -1297,7 +1307,7 @@ msgstr "Sblocca portachiavi"
 msgid "Unset Cookies File"
 msgstr "Seleziona file cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr "Aggiornamento"
 
@@ -1402,10 +1412,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sì"

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-04 02:45+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.2-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Lo scaricamento di \"{0}\" è terminato."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" è terminato con un errore."
@@ -100,7 +100,7 @@ msgstr "Informazioni su {0}"
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -111,9 +111,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,7 +134,7 @@ msgid "Advanced Options"
 msgstr "Opzioni avanzate"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Tutti gli scaricamenti sono terminati."
 
@@ -202,7 +202,7 @@ msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Cancella gli scaricamenti completati"
@@ -222,7 +222,7 @@ msgstr ""
 "alla sorgente dei media"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr "Chiudi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Chiudere e interrompere gli scaricamenti?"
 
@@ -243,8 +243,8 @@ msgstr "Chiudere e interrompere gli scaricamenti?"
 msgid "Comma separated list"
 msgstr "Elenco separato da virgole"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Completati"
@@ -254,7 +254,7 @@ msgstr "Completati"
 msgid "Completed Notification Trigger"
 msgstr "Notifica di completamento"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributori su GitHub ❤️"
 
@@ -306,11 +306,11 @@ msgstr "Ritaglia miniature audio"
 msgid "Crop Thumbnail"
 msgstr "Ritaglia miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -324,7 +324,7 @@ msgid "Delete"
 msgstr "Elimina"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
@@ -434,12 +434,12 @@ msgid "Download Again"
 msgstr "Scarica di nuovo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Scaricamento terminato"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Scaricamento terminato con errori"
 
@@ -448,7 +448,7 @@ msgstr "Scaricamento terminato con errori"
 msgid "Download log was copied to clipboard."
 msgstr "Registro dello scaricamento copiato negli appunti."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Scarica audio e video"
@@ -471,7 +471,7 @@ msgstr "Lo scaricamento con aria2 è iniziato"
 msgid "Download using ffmpeg has started"
 msgstr "Lo scaricamento con ffmpeg è iniziato"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -483,8 +483,8 @@ msgstr "Scaricare video e audio dalla rete"
 msgid "Downloader"
 msgstr "Scaricatore"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "In corso"
@@ -501,7 +501,7 @@ msgid "Downloading..."
 msgstr "Download in corso..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Scaricamenti terminati"
 
@@ -600,7 +600,7 @@ msgid "Error"
 msgstr "Errore"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Esci"
 
@@ -632,7 +632,7 @@ msgstr "Tipo di file"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -695,7 +695,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -728,7 +728,7 @@ msgstr "Informazioni sul codice della lingua"
 msgid "Leave empty to download from start."
 msgstr "Lascia vuoto per scaricare dall'inizio."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Elenco dei siti supportati"
 
@@ -739,8 +739,8 @@ msgstr "Login"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Login"
 
@@ -754,7 +754,7 @@ msgstr "Rende la miniatura quadrata, utile quando si scarica musica."
 msgid "Manage previously downloaded media."
 msgstr "Gestisci i media precedentemente scaricati."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Chat di Matrix"
 
@@ -810,40 +810,40 @@ msgstr "Dimensione minima suddivisioni (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr "Nuovo aggiornamento disponibile."
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Nessuna connessione Internet attiva"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Cancella gli scaricamenti completati"
@@ -857,7 +857,7 @@ msgstr "Nessun certificato"
 msgid "No downloads running"
 msgstr "Nessuno scaricamento in corso"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nessuno scaricamento in corso"
@@ -872,7 +872,7 @@ msgstr "Nessun file selezionato"
 msgid "No Previous Downloads"
 msgstr "Nessun download precedente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Elimina gli scaricamenti in coda"
@@ -951,14 +951,14 @@ msgstr "Apri cartella"
 msgid "Overwrite Existing Files"
 msgstr "Sovrascrivi file esistenti"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -969,7 +969,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -977,7 +977,7 @@ msgid "Password"
 msgstr "Password"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Password (vuota)"
 
@@ -994,11 +994,6 @@ msgstr "Playlist"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "In preparazione…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1029,14 +1024,14 @@ msgstr "URL proxy"
 msgid "Quality"
 msgstr "Qualità"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "In coda"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Download rimanenti: {0}"
@@ -1056,7 +1051,7 @@ msgid "Reset"
 msgstr "Azzera"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Azzera il portachiavi?"
 
@@ -1082,7 +1077,7 @@ msgid "Retry Download"
 msgstr "Riprova scaricamento"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1129,18 +1124,18 @@ msgid "Select Save Folder"
 msgstr "Seleziona cartella di salvataggio"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr "Mostra finestra"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1187,7 +1182,7 @@ msgid "Start Time (Invalid)"
 msgstr "Ora di inizio (non valida)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1245,7 +1240,7 @@ msgid "Theme"
 msgstr "Stile"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Questa azione è irreversibile. Confermare l'eliminazione?"
 
@@ -1259,12 +1254,8 @@ msgstr ""
 "abilitato. Modificarne il valore non ha effetto sugli scaricamenti già in "
 "corso."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr "L'operazione potrebbe richiedere del tempo"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1272,38 +1263,32 @@ msgstr ""
 "Questo eliminerà il portachiavi precedente rimuovendo tutte le password. "
 "Questa azione è irreversibile."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "Albano Battistella\n"
 "Davide Ferracin <davide.ferracin@protonmail.com>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Disattivazione del portachiavi non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr "Impossibile scaricare e installare l'aggiornamento."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Azzeramento del portachiavi non riuscito."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Installazione delle dipendenze non riuscita. Riavviare l'applicazione e "
-"riprovare."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Annulla la modifica del titolo"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Sblocca portachiavi"
 
@@ -1312,19 +1297,19 @@ msgstr "Sblocca portachiavi"
 msgid "Unset Cookies File"
 msgstr "Seleziona file cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr "Aggiornamento"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (non valido)"
 
@@ -1358,7 +1343,7 @@ msgid "User Interface"
 msgstr "Interfaccia utente"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nome utente (vuoto)"
@@ -1366,7 +1351,7 @@ msgstr "Nome utente (vuoto)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1418,9 +1403,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sì"
@@ -1568,6 +1553,18 @@ msgstr "— Scarica più di un file alla volta"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Supporta lo scaricamento di metadati e sottotitoli dei video"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "In preparazione…"
+
+#~ msgid "This may take a while"
+#~ msgstr "L'operazione potrebbe richiedere del tempo"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Installazione delle dipendenze non riuscita. Riavviare l'applicazione e "
+#~ "riprovare."
 
 #~ msgid "Search..."
 #~ msgstr "Cerca..."

--- a/NickvisionTubeConverter.Shared/Resources/po/it.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/it.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-11-04 02:45+0000\n"
 "Last-Translator: albanobattistella <albano_battistella@hotmail.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Lo scaricamento di \"{0}\" è terminato."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" è terminato con un errore."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(configurabile nelle preferenze)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} scaricamenti — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "È possibile fornire un file cookie a yt-dlp per consentire lo scaricamento "
 "di contenuti multimediali che richiedono un accesso."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Informazioni su {0}"
@@ -100,7 +100,7 @@ msgstr "Informazioni su {0}"
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,12 +108,12 @@ msgstr ""
 "scaricare"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Aggiungi login"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opzioni avanzate"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Tutti gli scaricamenti sono terminati."
 
@@ -153,17 +153,17 @@ msgstr "Applica"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Lingua dell'audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autenticazione"
@@ -172,7 +172,7 @@ msgstr "Autenticazione"
 msgid "Automatically Check for Updates"
 msgstr "Controlla automaticamente gli aggiornamenti"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Indietro"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Migliore"
 
@@ -192,7 +192,7 @@ msgstr "Annulla"
 msgid "Changelog"
 msgstr "Novità"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr "Verifica aggiornamenti"
 
@@ -201,8 +201,8 @@ msgstr "Verifica aggiornamenti"
 msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Cancella gli scaricamenti completati"
@@ -221,21 +221,21 @@ msgstr ""
 "Azzera i campi dei metadati che contengono URL e altri dati riconducibili "
 "alla sorgente dei media"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Elimina gli scaricamenti in coda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Chiudere e interrompere gli scaricamenti?"
 
@@ -243,8 +243,8 @@ msgstr "Chiudere e interrompere gli scaricamenti?"
 msgid "Comma separated list"
 msgstr "Elenco separato da virgole"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Completati"
@@ -254,7 +254,7 @@ msgstr "Completati"
 msgid "Completed Notification Trigger"
 msgstr "Notifica di completamento"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributori su GitHub ❤️"
 
@@ -301,16 +301,16 @@ msgstr "Crediti"
 msgid "Crop Audio Thumbnails"
 msgstr "Ritaglia miniature audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Ritaglia miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -328,7 +328,7 @@ msgstr "Elimina"
 msgid "Delete Credential?"
 msgstr "Eliminare il certificato?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Deseleziona tutto"
@@ -414,15 +414,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Non consentire conversioni"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussioni"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Documentazione"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -433,13 +433,13 @@ msgstr "Scarica"
 msgid "Download Again"
 msgstr "Scarica di nuovo"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Scaricamento terminato"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Scaricamento terminato con errori"
 
@@ -448,17 +448,17 @@ msgstr "Scaricamento terminato con errori"
 msgid "Download log was copied to clipboard."
 msgstr "Registro dello scaricamento copiato negli appunti."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Scarica audio e video"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Scarica intervallo specifico"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Scarica i sottotitoli"
@@ -471,20 +471,20 @@ msgstr "Lo scaricamento con aria2 è iniziato"
 msgid "Download using ffmpeg has started"
 msgstr "Lo scaricamento con ffmpeg è iniziato"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Scaricare video e audio dalla rete"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Scaricatore"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "In corso"
@@ -500,12 +500,12 @@ msgstr "In scaricamento {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Download in corso..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Scaricamenti terminati"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Modifica"
 
@@ -539,27 +539,27 @@ msgstr ""
 "fornisce il progresso dello scaricamento."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Ora di fine"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Ora di fine (non valida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr "Invia l'URL del media qui"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Assicurati che le credenziali siano corrette."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Inserisci qui l'URL multimediale"
@@ -568,7 +568,7 @@ msgstr "Inserisci qui l'URL multimediale"
 msgid "Enter name here"
 msgstr "Inserisci il nome qui"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr "Inserisci la password qui"
@@ -578,7 +578,7 @@ msgstr "Inserisci la password qui"
 msgid "Enter proxy url here"
 msgstr "Inserisci qui l'URL multimediale"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Inserisci qui l'URL multimediale"
@@ -588,7 +588,7 @@ msgstr "Inserisci qui l'URL multimediale"
 msgid "Enter url here"
 msgstr "Inserisci qui l'URL multimediale"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -599,8 +599,8 @@ msgstr "Inserisci qui l'URL multimediale"
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Esci"
 
@@ -609,7 +609,7 @@ msgstr "Esci"
 msgid "Failed to enable keyring."
 msgstr "Attivazione del portachiavi non riuscita."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "File"
 
@@ -622,7 +622,7 @@ msgstr "Il file esiste già, e la sovrascrittura è disabilitata"
 msgid "File Name"
 msgstr "Nome file"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo di file"
@@ -632,23 +632,23 @@ msgstr "Tipo di file"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Aiuto"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -696,13 +696,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Portachiavi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Certificato del portachiavi"
@@ -722,13 +722,13 @@ msgstr "Portachiavi chiuso"
 msgid "Language Code Information"
 msgstr "Informazioni sul codice della lingua"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Lascia vuoto per scaricare dall'inizio."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Elenco dei siti supportati"
 
@@ -744,7 +744,7 @@ msgstr "Login"
 msgid "Login"
 msgstr "Login"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Rende la miniatura quadrata, utile quando si scarica musica."
@@ -754,7 +754,7 @@ msgstr "Rende la miniatura quadrata, utile quando si scarica musica."
 msgid "Manage previously downloaded media."
 msgstr "Gestisci i media precedentemente scaricati."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Chat di Matrix"
 
@@ -769,11 +769,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Numero massimo di scaricamenti attivi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Massima qualità"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -785,14 +785,13 @@ msgstr ""
 "abilitato."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL del media"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL del media (non valido)"
 
@@ -821,30 +820,30 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr "Nuovo aggiornamento disponibile."
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Nessuna connessione Internet attiva"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Cancella gli scaricamenti completati"
@@ -858,7 +857,7 @@ msgstr "Nessun certificato"
 msgid "No downloads running"
 msgstr "Nessuno scaricamento in corso"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nessuno scaricamento in corso"
@@ -873,26 +872,26 @@ msgstr "Nessun file selezionato"
 msgid "No Previous Downloads"
 msgstr "Nessun download precedente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Elimina gli scaricamenti in coda"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numera i video"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -913,14 +912,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -952,14 +951,14 @@ msgstr "Apri cartella"
 msgid "Overwrite Existing Files"
 msgstr "Sovrascrivi file esistenti"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -968,7 +967,7 @@ msgstr ""
 "tramite il menu Aiuto."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -988,11 +987,15 @@ msgid "Play"
 msgstr "Avvia"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "In preparazione…"
@@ -1007,7 +1010,7 @@ msgstr "In preparazione…"
 msgid "Prevent Suspend"
 msgstr "Impedisci sospensione"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr "ANTEPRIMA"
 
@@ -1021,19 +1024,19 @@ msgstr "In lavorazione…"
 msgid "Proxy URL"
 msgstr "URL proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Qualità"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "In coda"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Download rimanenti: {0}"
@@ -1043,7 +1046,7 @@ msgstr "Download rimanenti: {0}"
 msgid "Remove Source Data"
 msgstr "Rimuovi i dati della sorgente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Segnala un problema"
 
@@ -1078,22 +1081,22 @@ msgstr "Riavviare per applicare il tema?"
 msgid "Retry Download"
 msgstr "Riprova scaricamento"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Riprova gli scaricamenti non riusciti"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Cartella di salvataggio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Cartella di salvataggio (non valida)"
 
@@ -1103,7 +1106,7 @@ msgstr "Cartella di salvataggio (non valida)"
 msgid "Search history"
 msgstr "Cancella cronologia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Seleziona tutto"
@@ -1114,30 +1117,30 @@ msgstr "Seleziona tutto"
 msgid "Select Cookies File"
 msgstr "Seleziona file cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selezionare gli elementi da scaricare o modificare i nomi dei file."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Seleziona cartella di salvataggio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr "Mostra finestra"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1149,19 +1152,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Alcuni scaricamenti sono terminati con degli errori."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite di velocità"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividi i capitoli"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Separa il video in più parti, una per ciascun capitolo."
@@ -1172,19 +1175,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informazioni su SponsorBlock (si apre in un browser web)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Ora di inizio"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Ora di inizio (non valida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1221,7 +1224,7 @@ msgstr "Lingue sottotitoli (non valide)"
 msgid "Success"
 msgstr "Completato"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1256,7 +1259,7 @@ msgstr ""
 "abilitato. Modificarne il valore non ha effetto sugli scaricamenti già in "
 "corso."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr "L'operazione potrebbe richiedere del tempo"
 
@@ -1269,7 +1272,7 @@ msgstr ""
 "Questo eliminerà il portachiavi precedente rimuovendo tutte le password. "
 "Questa azione è irreversibile."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "Albano Battistella\n"
@@ -1280,7 +1283,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Disattivazione del portachiavi non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr "Impossibile scaricare e installare l'aggiornamento."
 
@@ -1289,7 +1292,7 @@ msgstr "Impossibile scaricare e installare l'aggiornamento."
 msgid "Unable to reset keyring."
 msgstr "Azzeramento del portachiavi non riuscito."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Installazione delle dipendenze non riuscita. Riavviare l'applicazione e "
@@ -1300,7 +1303,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Annulla la modifica del titolo"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Sblocca portachiavi"
 
@@ -1309,7 +1312,7 @@ msgstr "Sblocca portachiavi"
 msgid "Unset Cookies File"
 msgstr "Seleziona file cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr "Aggiornamento"
 
@@ -1361,7 +1364,7 @@ msgid "User Name (Empty)"
 msgstr "Nome utente (vuoto)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1370,13 +1373,18 @@ msgid "Username"
 msgstr "Nome utente"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valida"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Valida"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1394,7 +1402,7 @@ msgid "Waiting..."
 msgstr "In attesa…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Peggiore"
 
@@ -1409,10 +1417,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sì"

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-27 09:41+0000\n"
 "Last-Translator: Turmoil Nailsis <indianrunner@duck.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" はダウンロード完了です。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" のダウンロードはエラーで終了しました！"
@@ -98,7 +98,7 @@ msgstr "{0} について"
 msgid "Add"
 msgstr "追加"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "動画、音声、再生リストの URL を追加してダウンロードを始めます"
@@ -107,9 +107,9 @@ msgstr "動画、音声、再生リストの URL を追加してダウンロー�
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,7 +130,7 @@ msgid "Advanced Options"
 msgstr "詳細オプション"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "すべてのダウンロードが完了しました。"
 
@@ -198,7 +198,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "完了したダウンロードをクリア"
@@ -216,7 +216,7 @@ msgid ""
 msgstr "メディアのソースを特定できるURL などのメタデータを削除する"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -229,7 +229,7 @@ msgid "Close"
 msgstr "閉じる"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "閉じてダウンロードを中止しますか？"
 
@@ -237,8 +237,8 @@ msgstr "閉じてダウンロードを中止しますか？"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "完了済"
@@ -248,7 +248,7 @@ msgstr "完了済"
 msgid "Completed Notification Trigger"
 msgstr "完了の通知のタイミング"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub での貢献者の皆さん❤️"
 
@@ -301,11 +301,11 @@ msgstr "オーディオサムネイルを整形"
 msgid "Crop Thumbnail"
 msgstr "サムネイルを整形"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -319,7 +319,7 @@ msgid "Delete"
 msgstr "削除"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
@@ -416,12 +416,12 @@ msgid "Download Again"
 msgstr "もう一度ダウンロード"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "ダウンロードが完了"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "ダウンロードはエラーで終了"
 
@@ -430,7 +430,7 @@ msgstr "ダウンロードはエラーで終了"
 msgid "Download log was copied to clipboard."
 msgstr "ダウンロードログがクリップボードにコピーされました。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "メディアをダウンロード"
@@ -453,7 +453,7 @@ msgstr "Aria2 を使用したダウンロードが開始"
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg を使用したダウンロードが開始"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -465,8 +465,8 @@ msgstr "ウェブ上のビデオと音声をダウンロード"
 msgid "Downloader"
 msgstr "ダウンローダー"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ダウンロード中"
@@ -484,7 +484,7 @@ msgid "Downloading..."
 msgstr "ダウンロード中"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "ダウンロード完了"
 
@@ -586,7 +586,7 @@ msgid "Error"
 msgstr "エラー"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgstr "ファイルの種類"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -680,7 +680,7 @@ msgstr "完了時、通知はウィンドウがフォーカス状態でないと
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -713,7 +713,7 @@ msgstr "言語コードについて"
 msgid "Leave empty to download from start."
 msgstr "オプションが空のままだと、動画の最初からダウンロードされます。"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "サポートされているサイト"
 
@@ -724,8 +724,8 @@ msgstr "ログイン"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "ログイン"
 
@@ -739,7 +739,7 @@ msgstr "サムネイルを四角に整えます。音楽をダウンロードす
 msgid "Manage previously downloaded media."
 msgstr "前にダウンロードしたメディアを管理します。"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix チャット"
 
@@ -793,40 +793,40 @@ msgstr "最小分割サイズ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "名前"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "名前（空）"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "いいえ"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "有効なインターネット接続がありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "完了したダウンロードをクリア"
@@ -840,7 +840,7 @@ msgstr "資格情報なし"
 msgid "No downloads running"
 msgstr "進行中のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "進行中のダウンロードはありません"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "過去のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "一時停止中のダウンロードをクリア"
@@ -934,14 +934,14 @@ msgstr "フォルダーを開く"
 msgid "Overwrite Existing Files"
 msgstr "存在するファイルを上書きする"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -950,7 +950,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -958,7 +958,7 @@ msgid "Password"
 msgstr "パスワード"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "パスワード（空）"
 
@@ -975,11 +975,6 @@ msgstr "再生リスト"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "準備中..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1010,14 +1005,14 @@ msgstr "プロキシ URL"
 msgid "Quality"
 msgstr "品質"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "停止中"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "失敗したダウンロードを再試行"
@@ -1037,7 +1032,7 @@ msgid "Reset"
 msgstr "リセット"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "キーリングをリセットしますか？"
 
@@ -1063,7 +1058,7 @@ msgid "Retry Download"
 msgstr "ダウンロードを再試行"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1110,18 +1105,18 @@ msgid "Select Save Folder"
 msgstr "保存するフォルダーを選択"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "設定"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1168,7 +1163,7 @@ msgid "Start Time (Invalid)"
 msgstr "開始（無効）"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1226,7 +1221,7 @@ msgid "Theme"
 msgstr "テーマ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "このアクションは取り消せません。本当に削除しますか？"
 
@@ -1239,12 +1234,8 @@ msgstr ""
 "この制限（KIB/毎秒に制限）は、ダウンロードにスピード制限が設定されている時の"
 "み有効になります。すでに進行中のダウンロードには、設定は適用されません。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1252,35 +1243,30 @@ msgstr ""
 "以前のキーリングとすべてのパスワードは削除されます。この動作は元に戻せませ"
 "ん。"
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Gnuey56 <gnuey56@proton.me>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "キーリングを無効化できません。"
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "キーリングをリセットできません。"
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"依存関係をダウンロードできません。アプリを再起動して試してみてください。"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "タイトルの編集を取り消し"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "キーリングをロック解除"
 
@@ -1289,19 +1275,19 @@ msgstr "キーリングをロック解除"
 msgid "Unset Cookies File"
 msgstr "クッキーのファイルを選択"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (無効)"
 
@@ -1335,7 +1321,7 @@ msgid "User Interface"
 msgstr "ユーザーインターフェース"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "ユーザー名（空）"
@@ -1343,7 +1329,7 @@ msgstr "ユーザー名（空）"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1393,9 +1379,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "はい"
@@ -1542,6 +1528,14 @@ msgstr "— 同時に複数のダウンロードが可能"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— メタデータと字幕のダウンロードに対応"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "準備中..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "依存関係をダウンロードできません。アプリを再起動して試してみてください。"
 
 #~ msgid "Search..."
 #~ msgstr "検索..."

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-27 09:41+0000\n"
 "Last-Translator: Turmoil Nailsis <indianrunner@duck.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" はダウンロード完了です。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" のダウンロードはエラーで終了しました！"
@@ -129,8 +129,8 @@ msgstr "ログインを追加"
 msgid "Advanced Options"
 msgstr "詳細オプション"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "すべてのダウンロードが完了しました。"
 
@@ -228,8 +228,8 @@ msgstr "一時停止中のダウンロードをクリア"
 msgid "Close"
 msgstr "閉じる"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "閉じてダウンロードを中止しますか？"
 
@@ -396,12 +396,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "フォーマット変換を無効化"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "ディスカッション"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -415,13 +423,13 @@ msgstr "ダウンロード"
 msgid "Download Again"
 msgstr "もう一度ダウンロード"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "ダウンロードが完了"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "ダウンロードはエラーで終了"
 
@@ -483,8 +491,8 @@ msgstr "ダウンロード中 {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ダウンロード中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "ダウンロード完了"
 
@@ -623,7 +631,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub リポジトリ"
@@ -803,7 +811,7 @@ msgstr "名前"
 msgid "Name (Empty)"
 msgstr "名前（空）"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -814,15 +822,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "いいえ"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "有効なインターネット接続がありません"
 
@@ -892,6 +900,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1012,7 +1021,7 @@ msgid "Queued"
 msgstr "停止中"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "失敗したダウンロードを再試行"
@@ -1115,8 +1124,8 @@ msgstr "設定"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1200,7 +1209,8 @@ msgstr "字幕の言語（無効）"
 msgid "Success"
 msgstr "成功"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1252,7 +1262,7 @@ msgstr "Gnuey56 <gnuey56@proton.me>"
 msgid "Unable to disable keyring."
 msgstr "キーリングを無効化できません。"
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1266,7 +1276,7 @@ msgstr "キーリングをリセットできません。"
 msgid "Undo Title Editing"
 msgstr "タイトルの編集を取り消し"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "キーリングをロック解除"
 
@@ -1275,7 +1285,7 @@ msgstr "キーリングをロック解除"
 msgid "Unset Cookies File"
 msgstr "クッキーのファイルを選択"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1378,10 +1388,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "はい"

--- a/NickvisionTubeConverter.Shared/Resources/po/ja.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-27 09:41+0000\n"
 "Last-Translator: Turmoil Nailsis <indianrunner@duck.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" はダウンロード完了です。"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" のダウンロードはエラーで終了しました！"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "（後で再設定できます）"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB /毎秒"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/毎秒"
@@ -66,8 +66,8 @@ msgstr[0] "{0} ダウンロード— {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgstr ""
 "ログインが必要なメディアをダウンロードするために yt-dlp にクッキーファイルを"
 "渡すことができます。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "{0} について"
@@ -98,18 +98,18 @@ msgstr "{0} について"
 msgid "Add"
 msgstr "追加"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "動画、音声、再生リストの URL を追加してダウンロードを始めます"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -123,14 +123,14 @@ msgid "Add Login"
 msgstr "ログインを追加"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "詳細オプション"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "すべてのダウンロードが完了しました。"
 
@@ -149,17 +149,17 @@ msgstr "適用"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "音声"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "音声の言語"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "認証"
@@ -168,7 +168,7 @@ msgstr "認証"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -176,7 +176,7 @@ msgid "Back"
 msgstr "戻る"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "最高"
 
@@ -188,7 +188,7 @@ msgstr "キャンセル"
 msgid "Changelog"
 msgstr "変更履歴"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -197,8 +197,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "完了したダウンロードをクリア"
@@ -215,21 +215,21 @@ msgid ""
 "of the media source"
 msgstr "メディアのソースを特定できるURL などのメタデータを削除する"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "一時停止中のダウンロードをクリア"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "閉じる"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "閉じてダウンロードを中止しますか？"
 
@@ -237,8 +237,8 @@ msgstr "閉じてダウンロードを中止しますか？"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "完了済"
@@ -248,7 +248,7 @@ msgstr "完了済"
 msgid "Completed Notification Trigger"
 msgstr "完了の通知のタイミング"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub での貢献者の皆さん❤️"
 
@@ -296,16 +296,16 @@ msgstr "資格情報"
 msgid "Crop Audio Thumbnails"
 msgstr "オーディオサムネイルを整形"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "サムネイルを整形"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -323,7 +323,7 @@ msgstr "削除"
 msgid "Delete Credential?"
 msgstr "資格情報を削除しますか？"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "すべて選択解除"
@@ -396,15 +396,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "フォーマット変換を無効化"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "ディスカッション"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -415,13 +415,13 @@ msgstr "ダウンロード"
 msgid "Download Again"
 msgstr "もう一度ダウンロード"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "ダウンロードが完了"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "ダウンロードはエラーで終了"
 
@@ -430,17 +430,17 @@ msgstr "ダウンロードはエラーで終了"
 msgid "Download log was copied to clipboard."
 msgstr "ダウンロードログがクリップボードにコピーされました。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "メディアをダウンロード"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "特定の時間枠をダウンロードする"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "字幕をダウンロードする"
@@ -453,20 +453,20 @@ msgstr "Aria2 を使用したダウンロードが開始"
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg を使用したダウンロードが開始"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "ウェブ上のビデオと音声をダウンロード"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "ダウンローダー"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ダウンロード中"
@@ -483,12 +483,12 @@ msgstr "ダウンロード中 {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ダウンロード中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "ダウンロード完了"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -522,28 +522,28 @@ msgstr ""
 "ロードの進捗を見ることはできません。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "終わり"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "終わり (無効)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "メディアの URL をここに入力"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "資格情報が正しいか確認します。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "メディアの URL をここに入力"
@@ -553,7 +553,7 @@ msgstr "メディアの URL をここに入力"
 msgid "Enter name here"
 msgstr "メディアの URL をここに入力"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -564,7 +564,7 @@ msgstr "メディアの URL をここに入力"
 msgid "Enter proxy url here"
 msgstr "メディアの URL をここに入力"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "メディアの URL をここに入力"
@@ -574,7 +574,7 @@ msgstr "メディアの URL をここに入力"
 msgid "Enter url here"
 msgstr "メディアの URL をここに入力"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -585,8 +585,8 @@ msgstr "メディアの URL をここに入力"
 msgid "Error"
 msgstr "エラー"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "キーリングの有効化に失敗しました。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "ファイル名"
@@ -609,7 +609,7 @@ msgstr "すでにファイルが存在しており、ファイルの上書きが
 msgid "File Name"
 msgstr "ファイル名"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "ファイルの種類"
@@ -619,23 +619,23 @@ msgstr "ファイルの種類"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub リポジトリ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "ヘルプ"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -681,13 +681,13 @@ msgstr "完了時、通知はウィンドウがフォーカス状態でないと
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "キーリング"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "キーリング資格情報"
@@ -707,13 +707,13 @@ msgstr "キーリングはロックされています"
 msgid "Language Code Information"
 msgstr "言語コードについて"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "オプションが空のままだと、動画の最初からダウンロードされます。"
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "サポートされているサイト"
 
@@ -729,7 +729,7 @@ msgstr "ログイン"
 msgid "Login"
 msgstr "ログイン"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "サムネイルを四角に整えます。音楽をダウンロードする時に便利です。"
@@ -739,7 +739,7 @@ msgstr "サムネイルを四角に整えます。音楽をダウンロードす
 msgid "Manage previously downloaded media."
 msgstr "前にダウンロードしたメディアを管理します。"
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix チャット"
 
@@ -754,11 +754,11 @@ msgid "Max Number of Active Downloads"
 msgstr "同時にダウンロードできる最大数"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "最高品質"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -770,14 +770,13 @@ msgstr ""
 "は無効になります。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "メディアのURL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "メディアの URL (無効)"
 
@@ -804,30 +803,30 @@ msgstr "名前"
 msgid "Name (Empty)"
 msgstr "名前（空）"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "いいえ"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "有効なインターネット接続がありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "完了したダウンロードをクリア"
@@ -841,7 +840,7 @@ msgstr "資格情報なし"
 msgid "No downloads running"
 msgstr "進行中のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "進行中のダウンロードはありません"
@@ -856,26 +855,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "過去のダウンロードはありません"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "一時停止中のダウンロードをクリア"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "動画の数"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -896,14 +895,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -935,21 +934,21 @@ msgstr "フォルダーを開く"
 msgid "Overwrite Existing Files"
 msgstr "存在するファイルを上書きする"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -969,11 +968,15 @@ msgid "Play"
 msgstr "再生"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "再生リスト"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "準備中..."
@@ -988,7 +991,7 @@ msgstr "準備中..."
 msgid "Prevent Suspend"
 msgstr "サスペンドを防ぐ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1002,19 +1005,19 @@ msgstr "進行中..."
 msgid "Proxy URL"
 msgstr "プロキシ URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "品質"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "停止中"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "失敗したダウンロードを再試行"
@@ -1024,7 +1027,7 @@ msgstr "失敗したダウンロードを再試行"
 msgid "Remove Source Data"
 msgstr "ソースのデータを削除"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "バグを報告"
 
@@ -1059,22 +1062,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "ダウンロードを再試行"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "失敗したダウンロードを再試行"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "保存フォルダー"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "保存フォルダー（不可）"
 
@@ -1084,7 +1087,7 @@ msgstr "保存フォルダー（不可）"
 msgid "Search history"
 msgstr "履歴をクリア"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "すべて選択"
@@ -1095,30 +1098,30 @@ msgstr "すべて選択"
 msgid "Select Cookies File"
 msgstr "クッキーのファイルを選択"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "ダウンロードを選択またはファイル名を変更します。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "保存するフォルダーを選択"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "設定"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1130,19 +1133,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "一部のダウンロードはエラーで失敗しました！"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "スピード制限"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "チャプター（章）で分ける"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "動画を複数の小さなチャプターごとに分割します。"
@@ -1153,19 +1156,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "SponsorBlockの情報"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "開始"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "開始（無効）"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1202,7 +1205,7 @@ msgstr "字幕の言語（無効）"
 msgid "Success"
 msgstr "成功"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1236,7 +1239,7 @@ msgstr ""
 "この制限（KIB/毎秒に制限）は、ダウンロードにスピード制限が設定されている時の"
 "み有効になります。すでに進行中のダウンロードには、設定は適用されません。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1249,7 +1252,7 @@ msgstr ""
 "以前のキーリングとすべてのパスワードは削除されます。この動作は元に戻せませ"
 "ん。"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Gnuey56 <gnuey56@proton.me>"
 
@@ -1258,7 +1261,7 @@ msgstr "Gnuey56 <gnuey56@proton.me>"
 msgid "Unable to disable keyring."
 msgstr "キーリングを無効化できません。"
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1267,7 +1270,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "キーリングをリセットできません。"
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "依存関係をダウンロードできません。アプリを再起動して試してみてください。"
@@ -1277,7 +1280,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "タイトルの編集を取り消し"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "キーリングをロック解除"
 
@@ -1286,7 +1289,7 @@ msgstr "キーリングをロック解除"
 msgid "Unset Cookies File"
 msgstr "クッキーのファイルを選択"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1338,7 +1341,7 @@ msgid "User Name (Empty)"
 msgstr "ユーザー名（空）"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1347,13 +1350,18 @@ msgid "Username"
 msgstr "ユーザー名"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "内容の確認"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "内容の確認"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "動画"
 
@@ -1371,7 +1379,7 @@ msgid "Waiting..."
 msgstr "待機中..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "最低"
 
@@ -1384,10 +1392,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "はい"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} er nedlastet."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} fullført med feil."
@@ -99,7 +99,7 @@ msgstr "Om {0}"
 msgid "Add"
 msgstr "Legg til"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,9 +108,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -131,7 +131,7 @@ msgid "Advanced Options"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 #, fuzzy
 msgid "All downloads have finished."
 msgstr "Nedlasting fullført"
@@ -201,7 +201,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -220,7 +220,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -233,7 +233,7 @@ msgid "Close"
 msgstr "Lukk"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Lukk og stopp nedlastinger?"
 
@@ -241,8 +241,8 @@ msgstr "Lukk og stopp nedlastinger?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Fullført"
@@ -252,7 +252,7 @@ msgstr "Fullført"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -303,11 +303,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -409,12 +409,12 @@ msgid "Download Again"
 msgstr "Laster ned"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Nedlasting fullført"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Nedlasting fullført med feil"
 
@@ -424,7 +424,7 @@ msgstr "Nedlasting fullført med feil"
 msgid "Download log was copied to clipboard."
 msgstr "Nedlastingslogg kopiert til utklippstavlen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
@@ -449,7 +449,7 @@ msgstr "Nedlasting med aria2 har startet"
 msgid "Download using ffmpeg has started"
 msgstr "Nedlasting med FFmpeg har startet"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -461,8 +461,8 @@ msgstr ""
 msgid "Downloader"
 msgstr "Nedlaster"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Laster ned"
@@ -480,7 +480,7 @@ msgid "Downloading..."
 msgstr "Laster ned"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "Nedlasting fullført"
@@ -584,7 +584,7 @@ msgid "Error"
 msgstr "Feil"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Avslutt"
 
@@ -617,7 +617,7 @@ msgstr "Filtype"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -704,7 +704,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Liste over støttede sider"
 
@@ -714,8 +714,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix-sludring"
 
@@ -781,41 +781,41 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "Filtype"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nei"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tøm nedlastinger i kø"
@@ -829,7 +829,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "Ingen nedlastinger kjører"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Ingen nedlastinger kjører"
@@ -845,7 +845,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Stopp alle nedlastinger"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tøm nedlastinger i kø"
@@ -926,14 +926,14 @@ msgstr "Åpne lagringsmappe"
 msgid "Overwrite Existing Files"
 msgstr "Overskriv eksisterende filer"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -942,7 +942,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -950,7 +950,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -967,11 +967,6 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Forbereder …"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1002,14 +997,14 @@ msgstr ""
 msgid "Quality"
 msgstr "Kvalitet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "I kø"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Gjenstående nedlastinger: {0}"
@@ -1029,7 +1024,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1055,7 +1050,7 @@ msgid "Retry Download"
 msgstr "Prøv igjen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1103,18 +1098,18 @@ msgid "Select Save Folder"
 msgstr "Velg lagringsmappe"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1162,7 +1157,7 @@ msgid "Start Time (Invalid)"
 msgstr "Starttid (ugyldig)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1222,7 +1217,7 @@ msgid "Theme"
 msgstr "Drakt"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1236,46 +1231,37 @@ msgstr ""
 "påskrudd. Endring av verdien har ingen innvirkning på igangsatte "
 "nedlastinger."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Kunne ikke laste ned avhengigheter. Start programmet på ny og prøv igjen."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Angre navneendring"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1284,19 +1270,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
@@ -1328,7 +1314,7 @@ msgid "User Interface"
 msgstr "Brukergrensesnitt"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Brukergrensesnitt"
@@ -1336,7 +1322,7 @@ msgstr "Brukergrensesnitt"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
@@ -1387,9 +1373,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"
@@ -1539,6 +1525,14 @@ msgstr ""
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Forbereder …"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Kunne ikke laste ned avhengigheter. Start programmet på ny og prøv igjen."
 
 #, fuzzy
 #~ msgctxt "Subtitle"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} er nedlastet."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} fullført med feil."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, fuzzy
 msgid "(Configurable in preferences)"
 msgstr "Kan tilpasses i egenskapene"
@@ -49,7 +49,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -68,8 +68,8 @@ msgstr[1] "Nedlastinger: {0} — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -88,7 +88,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Om {0}"
@@ -99,18 +99,18 @@ msgstr "Om {0}"
 msgid "Add"
 msgstr "Legg til"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -124,14 +124,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 #, fuzzy
 msgid "All downloads have finished."
 msgstr "Nedlasting fullført"
@@ -151,17 +151,17 @@ msgstr "Bruk"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 #, fuzzy
 msgid "Authenticate"
@@ -171,7 +171,7 @@ msgstr "Program"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -179,7 +179,7 @@ msgid "Back"
 msgstr "Tilbake"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Best"
 
@@ -191,7 +191,7 @@ msgstr "Avbryt"
 msgid "Changelog"
 msgstr "Endringslogg"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -200,8 +200,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 #, fuzzy
 msgid "Clear Completed Downloads"
@@ -219,21 +219,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Tøm nedlastinger i kø"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Lukk"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Lukk og stopp nedlastinger?"
 
@@ -241,8 +241,8 @@ msgstr "Lukk og stopp nedlastinger?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Fullført"
@@ -252,7 +252,7 @@ msgstr "Fullført"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -298,16 +298,16 @@ msgstr "Bidragsytere"
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -388,15 +388,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskusjoner"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -408,13 +408,13 @@ msgstr "Last ned"
 msgid "Download Again"
 msgstr "Laster ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Nedlasting fullført"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Nedlasting fullført med feil"
 
@@ -424,18 +424,18 @@ msgstr "Nedlasting fullført med feil"
 msgid "Download log was copied to clipboard."
 msgstr "Nedlastingslogg kopiert til utklippstavlen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
 msgstr "Nedlaster"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -449,20 +449,20 @@ msgstr "Nedlasting med aria2 har startet"
 msgid "Download using ffmpeg has started"
 msgstr "Nedlasting med FFmpeg har startet"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Nedlaster"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Laster ned"
@@ -479,13 +479,13 @@ msgstr "Laster ned {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Laster ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "Nedlasting fullført"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Rediger"
 
@@ -520,28 +520,28 @@ msgstr ""
 "om nedlatingsframdrift."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Slutt-tid (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Skriv inn medianettadresse her"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Skriv inn medianettadresse her"
@@ -551,7 +551,7 @@ msgstr "Skriv inn medianettadresse her"
 msgid "Enter name here"
 msgstr "Skriv inn medianettadresse her"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -562,7 +562,7 @@ msgstr "Skriv inn medianettadresse her"
 msgid "Enter proxy url here"
 msgstr "Skriv inn medianettadresse her"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Skriv inn medianettadresse her"
@@ -572,7 +572,7 @@ msgstr "Skriv inn medianettadresse her"
 msgid "Enter url here"
 msgstr "Skriv inn medianettadresse her"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -583,8 +583,8 @@ msgstr "Skriv inn medianettadresse her"
 msgid "Error"
 msgstr "Feil"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Avslutt"
 
@@ -593,7 +593,7 @@ msgstr "Avslutt"
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Fil"
 
@@ -607,7 +607,7 @@ msgstr "Filen finnes allerede, og overskriving er ikke tillatt"
 msgid "File Name"
 msgstr "Filtype"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Filtype"
@@ -617,23 +617,23 @@ msgstr "Filtype"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-kodelager"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Hjelp"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -672,13 +672,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -698,13 +698,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Liste over støttede sider"
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix-sludring"
 
@@ -744,12 +744,12 @@ msgid "Max Number of Active Downloads"
 msgstr "Maks. antall aktive nedlastinger"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 #, fuzzy
 msgid "Maximum Quality"
 msgstr "Kvalitet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -758,14 +758,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Videonettadresse"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Videonettadresse (ugyldig)"
 
@@ -793,30 +792,30 @@ msgstr "Filtype"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nei"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tøm nedlastinger i kø"
@@ -830,7 +829,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "Ingen nedlastinger kjører"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Ingen nedlastinger kjører"
@@ -846,27 +845,27 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Stopp alle nedlastinger"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Tøm nedlastinger i kø"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "Videoantall"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -887,14 +886,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -927,21 +926,21 @@ msgstr "Åpne lagringsmappe"
 msgid "Overwrite Existing Files"
 msgstr "Overskriv eksisterende filer"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -961,11 +960,15 @@ msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Forbereder …"
@@ -980,7 +983,7 @@ msgstr "Forbereder …"
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -994,19 +997,19 @@ msgstr "Behandler …"
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kvalitet"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "I kø"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Gjenstående nedlastinger: {0}"
@@ -1016,7 +1019,7 @@ msgstr "Gjenstående nedlastinger: {0}"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Innrapporter en feil"
 
@@ -1051,22 +1054,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Prøv igjen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Prøv å laste ned mislykkede nedlastinger igjen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Lagringsmappe"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Lagre mappe (ugyldig)"
 
@@ -1075,7 +1078,7 @@ msgstr "Lagre mappe (ugyldig)"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1088,30 +1091,30 @@ msgstr "Stopp alle nedlastinger"
 msgid "Select Cookies File"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1124,19 +1127,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Noen nedlastinger ble fullført med feil."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hastighetsgrense"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1147,19 +1150,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Starttid (ugyldig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1197,7 +1200,7 @@ msgstr "Starttid (ugyldig)"
 msgid "Success"
 msgstr "Vellykket"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1233,7 +1236,7 @@ msgstr ""
 "påskrudd. Endring av verdien har ingen innvirkning på igangsatte "
 "nedlastinger."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1244,7 +1247,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1253,7 +1256,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1262,7 +1265,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Kunne ikke laste ned avhengigheter. Start programmet på ny og prøv igjen."
@@ -1272,7 +1275,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Angre navneendring"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1281,7 +1284,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1331,7 +1334,7 @@ msgid "User Name (Empty)"
 msgstr "Brukergrensesnitt"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1341,13 +1344,18 @@ msgid "Username"
 msgstr "Brukergrensesnitt"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Bekreft"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Bekreft"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr ""
 
@@ -1365,7 +1373,7 @@ msgid "Waiting..."
 msgstr "Venter …"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Dårlig"
 
@@ -1378,10 +1386,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-06-14 17:48+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} er nedlastet."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, fuzzy, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} fullført med feil."
@@ -130,8 +130,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 #, fuzzy
 msgid "All downloads have finished."
 msgstr "Nedlasting fullført"
@@ -232,8 +232,8 @@ msgstr "Tøm nedlastinger i kø"
 msgid "Close"
 msgstr "Lukk"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Lukk og stopp nedlastinger?"
 
@@ -388,12 +388,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskusjoner"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -408,13 +416,13 @@ msgstr "Last ned"
 msgid "Download Again"
 msgstr "Laster ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Nedlasting fullført"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Nedlasting fullført med feil"
 
@@ -479,8 +487,8 @@ msgstr "Laster ned {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Laster ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 #, fuzzy
 msgid "Downloads Finished"
 msgstr "Nedlasting fullført"
@@ -621,7 +629,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-kodelager"
@@ -792,7 +800,7 @@ msgstr "Filtype"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -803,15 +811,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nei"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -883,6 +891,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1004,7 +1013,7 @@ msgid "Queued"
 msgstr "I kø"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Gjenstående nedlastinger: {0}"
@@ -1108,8 +1117,8 @@ msgstr "Innstillinger"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1195,7 +1204,8 @@ msgstr "Starttid (ugyldig)"
 msgid "Success"
 msgstr "Vellykket"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1247,7 +1257,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1261,7 +1271,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Angre navneendring"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1270,7 +1280,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Velg lagringsmappe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1372,10 +1382,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "‘{0}’ is klaar met downloaden"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "‘{0}’ is voltooid met een fout!"
@@ -98,7 +98,7 @@ msgstr "Over {0}"
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -108,9 +108,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -131,7 +131,7 @@ msgid "Advanced Options"
 msgstr "Geavanceerde opties"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Alle downloads zijn voltooid."
 
@@ -199,7 +199,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Voltooide downloads wissen"
@@ -217,7 +217,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -230,7 +230,7 @@ msgid "Close"
 msgstr "Sluiten"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Sluiten en downloads stoppen?"
 
@@ -238,8 +238,8 @@ msgstr "Sluiten en downloads stoppen?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Voltooid"
@@ -249,7 +249,7 @@ msgstr "Voltooid"
 msgid "Completed Notification Trigger"
 msgstr "Meldingen bij voltooide downloads"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Bijdragers op GitHub ❤️"
 
@@ -300,11 +300,11 @@ msgstr "Audio-miniaturen bijsnijden"
 msgid "Crop Thumbnail"
 msgstr "Miniatuur bijsnijden"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -318,7 +318,7 @@ msgid "Delete"
 msgstr "Verwijderen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
@@ -405,12 +405,12 @@ msgid "Download Again"
 msgstr "Opnieuw downloaden"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Download voltooid"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Download voltooid met fouten"
 
@@ -419,7 +419,7 @@ msgstr "Download voltooid met fouten"
 msgid "Download log was copied to clipboard."
 msgstr "Downloadlogboek gekopieerd naar klembord"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Media downloaden"
@@ -443,7 +443,7 @@ msgstr "Downloaden met aria2 is gestart"
 msgid "Download using ffmpeg has started"
 msgstr "Downloaden met FFmpeg is gestart"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -455,8 +455,8 @@ msgstr "Download video's en audio van het web"
 msgid "Downloader"
 msgstr "Downloader"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Downloaden"
@@ -474,7 +474,7 @@ msgid "Downloading..."
 msgstr "Downloaden"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Downloads voltooid"
 
@@ -577,7 +577,7 @@ msgid "Error"
 msgstr "Fout"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Verlaten"
 
@@ -610,7 +610,7 @@ msgstr "Bestandstype"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -664,7 +664,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -698,7 +698,7 @@ msgstr "Taalcode­informatie"
 msgid "Leave empty to download from start."
 msgstr "Laat leeg om vanaf het begin te downloaden."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lijst met ondersteunde websites"
 
@@ -709,8 +709,8 @@ msgstr "Inloggen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Inloggen"
 
@@ -724,7 +724,7 @@ msgstr "Maakt het miniatuur vierkant, handig bij het downloaden van muziek"
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix-kamer"
 
@@ -775,40 +775,40 @@ msgstr "Minimale splitsingsgrootte (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Naam"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Naam (leeg)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nee"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Geen actieve internetverbinding"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Voltooide downloads wissen"
@@ -822,7 +822,7 @@ msgstr "Geen inloggegevens"
 msgid "No downloads running"
 msgstr "Geen actieve downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Geen actieve downloads"
@@ -837,7 +837,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Geen vorige downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Download­wachtrij wissen"
@@ -916,14 +916,14 @@ msgstr "Map openen"
 msgid "Overwrite Existing Files"
 msgstr "Bestaande bestanden overschrijven"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -932,7 +932,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -940,7 +940,7 @@ msgid "Password"
 msgstr "Wachtwoord"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Wachtwoord (leeg)"
 
@@ -957,11 +957,6 @@ msgstr "Afspeellijst"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Voorbereiden…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -992,14 +987,14 @@ msgstr "Proxy-URL"
 msgid "Quality"
 msgstr "Kwaliteit"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "In wachtrij"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Resterende downloads: {0}"
@@ -1019,7 +1014,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Sleutelbos instellen"
@@ -1046,7 +1041,7 @@ msgid "Retry Download"
 msgstr "Download opnieuw proberen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1093,18 +1088,18 @@ msgid "Select Save Folder"
 msgstr "Opslagmap selecteren"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Instellingen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1154,7 +1149,7 @@ msgid "Start Time (Invalid)"
 msgstr "Begintijd (ongeldig)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1212,7 +1207,7 @@ msgid "Theme"
 msgstr "Thema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Deze actie is onomkeerbaar. Weet u zeker dat u het wilt verwijderen?"
 
@@ -1226,47 +1221,38 @@ msgstr ""
 "snelheidslimiet is ingeschakeld. Het wijzigen van de waarde heeft geen "
 "invloed op reeds lopende downloads."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Kon afhankelijkheden niet downloaden. Herstart de app en probeer opnieuw."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Titelbewerking ongedaan maken"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Sleutelbos ontgrendelen"
 
@@ -1275,19 +1261,19 @@ msgstr "Sleutelbos ontgrendelen"
 msgid "Unset Cookies File"
 msgstr "Cookies-bestand selecteren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (ongeldig)"
 
@@ -1318,7 +1304,7 @@ msgid "User Interface"
 msgstr "Gebruikersinterface"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Gebruikersnaam (leeg)"
@@ -1326,7 +1312,7 @@ msgstr "Gebruikersnaam (leeg)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1376,9 +1362,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"
@@ -1524,6 +1510,14 @@ msgstr "— Voer meerdere downloads tegelijk uit"
 msgid "— Supports downloading metadata and video subtitles"
 msgstr ""
 "— Ondersteuning voor het downloaden van video-metagegevens en -ondertitels"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Voorbereiden…"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Kon afhankelijkheden niet downloaden. Herstart de app en probeer opnieuw."
 
 #~ msgid "Search..."
 #~ msgstr "Zoeken…"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "‘{0}’ is klaar met downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "‘{0}’ is voltooid met een fout!"
@@ -130,8 +130,8 @@ msgstr "Login toevoegen"
 msgid "Advanced Options"
 msgstr "Geavanceerde opties"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Alle downloads zijn voltooid."
 
@@ -229,8 +229,8 @@ msgstr "Download­wachtrij wissen"
 msgid "Close"
 msgstr "Sluiten"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Sluiten en downloads stoppen?"
 
@@ -385,12 +385,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Conversie uitschakelen"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussies"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -404,13 +412,13 @@ msgstr "Downloaden"
 msgid "Download Again"
 msgstr "Opnieuw downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Download voltooid"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Download voltooid met fouten"
 
@@ -473,8 +481,8 @@ msgstr "Downloaden — {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Downloads voltooid"
 
@@ -614,7 +622,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
@@ -785,7 +793,7 @@ msgstr "Naam"
 msgid "Name (Empty)"
 msgstr "Naam (leeg)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -796,15 +804,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nee"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Geen actieve internetverbinding"
 
@@ -874,6 +882,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "Ok"
 
@@ -994,7 +1003,7 @@ msgid "Queued"
 msgstr "In wachtrij"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Resterende downloads: {0}"
@@ -1098,8 +1107,8 @@ msgstr "Instellingen"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1186,7 +1195,8 @@ msgstr "Ondertitel­talen (ongeldig)"
 msgid "Success"
 msgstr "Voltooid"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1238,7 +1248,7 @@ msgstr "Philip Goto https://philipgoto.nl/"
 msgid "Unable to disable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1252,7 +1262,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Titelbewerking ongedaan maken"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Sleutelbos ontgrendelen"
 
@@ -1261,7 +1271,7 @@ msgstr "Sleutelbos ontgrendelen"
 msgid "Unset Cookies File"
 msgstr "Cookies-bestand selecteren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1361,10 +1371,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/nl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-10 02:45+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "‘{0}’ is klaar met downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "‘{0}’ is voltooid met een fout!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(configureerbaar in voorkeuren)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} downloads — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Over {0}"
@@ -98,19 +98,19 @@ msgstr "Over {0}"
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 "Voeg een URL van een video, audio, of een playlist toe om te downloaden"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -124,14 +124,14 @@ msgid "Add Login"
 msgstr "Login toevoegen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Geavanceerde opties"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Alle downloads zijn voltooid."
 
@@ -150,17 +150,17 @@ msgstr "Toepassen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Audio­taal"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Authenticeren"
@@ -169,7 +169,7 @@ msgstr "Authenticeren"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -177,7 +177,7 @@ msgid "Back"
 msgstr "Terug"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Best"
 
@@ -189,7 +189,7 @@ msgstr "Annuleren"
 msgid "Changelog"
 msgstr "Wijzigingslogboek"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -198,8 +198,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Voltooide downloads wissen"
@@ -216,21 +216,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Download­wachtrij wissen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Sluiten"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Sluiten en downloads stoppen?"
 
@@ -238,8 +238,8 @@ msgstr "Sluiten en downloads stoppen?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Voltooid"
@@ -249,7 +249,7 @@ msgstr "Voltooid"
 msgid "Completed Notification Trigger"
 msgstr "Meldingen bij voltooide downloads"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Bijdragers op GitHub ❤️"
 
@@ -295,16 +295,16 @@ msgstr "Inloggegevens"
 msgid "Crop Audio Thumbnails"
 msgstr "Audio-miniaturen bijsnijden"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Miniatuur bijsnijden"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -322,7 +322,7 @@ msgstr "Verwijderen"
 msgid "Delete Credential?"
 msgstr "Inloggegevens verwijderen?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Alles deselecteren"
@@ -385,15 +385,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Conversie uitschakelen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -404,13 +404,13 @@ msgstr "Downloaden"
 msgid "Download Again"
 msgstr "Opnieuw downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Download voltooid"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Download voltooid met fouten"
 
@@ -419,17 +419,17 @@ msgstr "Download voltooid met fouten"
 msgid "Download log was copied to clipboard."
 msgstr "Downloadlogboek gekopieerd naar klembord"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Media downloaden"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Specifiek tijdsbestek downloaden"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -443,20 +443,20 @@ msgstr "Downloaden met aria2 is gestart"
 msgid "Download using ffmpeg has started"
 msgstr "Downloaden met FFmpeg is gestart"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Download video's en audio van het web"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Downloader"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Downloaden"
@@ -473,12 +473,12 @@ msgstr "Downloaden — {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Downloaden"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Downloads voltooid"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Bewerken"
 
@@ -513,28 +513,28 @@ msgstr ""
 "voortgang van het downloaden niet."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Eindtijd"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Eindtijd (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Voer media-URL hier in"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Zorg ervoor dat de inloggegevens correct zijn."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Voer media-URL hier in"
@@ -544,7 +544,7 @@ msgstr "Voer media-URL hier in"
 msgid "Enter name here"
 msgstr "Voer media-URL hier in"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -555,7 +555,7 @@ msgstr "Voer media-URL hier in"
 msgid "Enter proxy url here"
 msgstr "Voer media-URL hier in"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Voer media-URL hier in"
@@ -565,7 +565,7 @@ msgstr "Voer media-URL hier in"
 msgid "Enter url here"
 msgstr "Voer media-URL hier in"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -576,8 +576,8 @@ msgstr "Voer media-URL hier in"
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Verlaten"
 
@@ -587,7 +587,7 @@ msgstr "Verlaten"
 msgid "Failed to enable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Bestand"
 
@@ -600,7 +600,7 @@ msgstr "Bestand bestaat al en overschrijven is niet toegestaan"
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Bestandstype"
@@ -610,23 +610,23 @@ msgstr "Bestandstype"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Hulp"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -665,13 +665,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Sleutelbos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Inloggegevens van sleutelbos"
@@ -692,13 +692,13 @@ msgstr "Sleutelbos uitgeschakeld"
 msgid "Language Code Information"
 msgstr "Taalcode­informatie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Laat leeg om vanaf het begin te downloaden."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lijst met ondersteunde websites"
 
@@ -714,7 +714,7 @@ msgstr "Inloggen"
 msgid "Login"
 msgstr "Inloggen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Maakt het miniatuur vierkant, handig bij het downloaden van muziek"
@@ -724,7 +724,7 @@ msgstr "Maakt het miniatuur vierkant, handig bij het downloaden van muziek"
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix-kamer"
 
@@ -739,11 +739,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Maximumaantal actieve downloads"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Maximale kwaliteit"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -752,14 +752,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Media-URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Media-URL (ongeldig)"
 
@@ -786,30 +785,30 @@ msgstr "Naam"
 msgid "Name (Empty)"
 msgstr "Naam (leeg)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nee"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Geen actieve internetverbinding"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Voltooide downloads wissen"
@@ -823,7 +822,7 @@ msgstr "Geen inloggegevens"
 msgid "No downloads running"
 msgstr "Geen actieve downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Geen actieve downloads"
@@ -838,26 +837,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Geen vorige downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Download­wachtrij wissen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Titels nummeren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -878,14 +877,14 @@ msgstr ""
 msgid "OK"
 msgstr "Ok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -917,21 +916,21 @@ msgstr "Map openen"
 msgid "Overwrite Existing Files"
 msgstr "Bestaande bestanden overschrijven"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -951,11 +950,15 @@ msgid "Play"
 msgstr "Afspelen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Afspeellijst"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Voorbereiden…"
@@ -970,7 +973,7 @@ msgstr "Voorbereiden…"
 msgid "Prevent Suspend"
 msgstr "Slaapstand voorkomen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -984,19 +987,19 @@ msgstr "Verwerken…"
 msgid "Proxy URL"
 msgstr "Proxy-URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kwaliteit"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "In wachtrij"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Resterende downloads: {0}"
@@ -1006,7 +1009,7 @@ msgstr "Resterende downloads: {0}"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Fout melden"
 
@@ -1042,22 +1045,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Download opnieuw proberen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Mislukte downloads opnieuw proberen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Opslagmap"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Opslagmap (ongeldig)"
 
@@ -1067,7 +1070,7 @@ msgstr "Opslagmap (ongeldig)"
 msgid "Search history"
 msgstr "Geschiedenis wissen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Alles selecteren"
@@ -1078,30 +1081,30 @@ msgstr "Alles selecteren"
 msgid "Select Cookies File"
 msgstr "Cookies-bestand selecteren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selecteer items om te downloaden of de bestandsnaam van aan te passen."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Opslagmap selecteren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Instellingen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1114,20 +1117,20 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Sommige downloads zijn voltooid met fouten!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Snelheidslimiet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Hoofdstukken invoegen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1139,19 +1142,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Cookies-bestand-informatie"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Starttijd"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Begintijd (ongeldig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1188,7 +1191,7 @@ msgstr "Ondertitel­talen (ongeldig)"
 msgid "Success"
 msgstr "Voltooid"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1223,7 +1226,7 @@ msgstr ""
 "snelheidslimiet is ingeschakeld. Het wijzigen van de waarde heeft geen "
 "invloed op reeds lopende downloads."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1234,7 +1237,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
@@ -1244,7 +1247,7 @@ msgstr "Philip Goto https://philipgoto.nl/"
 msgid "Unable to disable keyring."
 msgstr "Sleutelbos uitschakelen"
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1253,7 +1256,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Kon afhankelijkheden niet downloaden. Herstart de app en probeer opnieuw."
@@ -1263,7 +1266,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Titelbewerking ongedaan maken"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Sleutelbos ontgrendelen"
 
@@ -1272,7 +1275,7 @@ msgstr "Sleutelbos ontgrendelen"
 msgid "Unset Cookies File"
 msgstr "Cookies-bestand selecteren"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1321,7 +1324,7 @@ msgid "User Name (Empty)"
 msgstr "Gebruikersnaam (leeg)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1330,13 +1333,18 @@ msgid "Username"
 msgstr "Gebruikersnaam"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Valideren"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Valideren"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1354,7 +1362,7 @@ msgid "Waiting..."
 msgstr "Wachten…"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Slechtst"
 
@@ -1367,10 +1375,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,13 +19,13 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -106,9 +106,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -129,7 +129,7 @@ msgid "Advanced Options"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr ""
 
@@ -197,7 +197,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -215,7 +215,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -228,7 +228,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -236,8 +236,8 @@ msgstr ""
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -247,7 +247,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -296,11 +296,11 @@ msgstr ""
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -314,7 +314,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -401,12 +401,12 @@ msgid "Download Again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
@@ -438,7 +438,7 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -450,8 +450,8 @@ msgstr ""
 msgid "Downloader"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -468,7 +468,7 @@ msgid "Downloading..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgid "Error"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -679,7 +679,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr ""
 
@@ -689,8 +689,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -704,7 +704,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr ""
 
@@ -755,40 +755,40 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 msgid "No Queued Downloads"
 msgstr ""
 
@@ -892,14 +892,14 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -908,7 +908,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -916,7 +916,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -932,10 +932,6 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
-msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-msgid "Preparing required tools..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
@@ -967,14 +963,14 @@ msgstr ""
 msgid "Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -994,7 +990,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1020,7 +1016,7 @@ msgid "Retry Download"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1066,17 +1062,17 @@ msgid "Select Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1121,7 +1117,7 @@ msgid "Start Time (Invalid)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1175,7 +1171,7 @@ msgid "Theme"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1186,37 +1182,29 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
@@ -1224,7 +1212,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1232,19 +1220,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -1275,14 +1263,14 @@ msgid "User Interface"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1331,9 +1319,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,20 +18,20 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -47,7 +47,7 @@ msgstr ""
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr ""
@@ -66,8 +66,8 @@ msgstr[1] ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -86,7 +86,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -97,18 +97,18 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -122,14 +122,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr ""
 
@@ -148,17 +148,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr ""
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -175,7 +175,7 @@ msgid "Back"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr ""
 
@@ -187,7 +187,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -196,8 +196,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -214,21 +214,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -236,8 +236,8 @@ msgstr ""
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -247,7 +247,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -291,16 +291,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -381,15 +381,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -400,13 +400,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -415,17 +415,17 @@ msgstr ""
 msgid "Download log was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr ""
@@ -438,20 +438,20 @@ msgstr ""
 msgid "Download using ffmpeg has started"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr ""
@@ -467,12 +467,12 @@ msgstr ""
 msgid "Downloading..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -504,27 +504,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -559,8 +559,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -569,7 +569,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr ""
 
@@ -582,7 +582,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr ""
@@ -592,23 +592,23 @@ msgstr ""
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -647,13 +647,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -673,13 +673,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr ""
@@ -704,7 +704,7 @@ msgstr ""
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr ""
 
@@ -719,11 +719,11 @@ msgid "Max Number of Active Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -732,14 +732,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr ""
 
@@ -766,30 +765,30 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 msgid "No Completed Downloads"
 msgstr ""
 
@@ -802,7 +801,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Downloads Running"
 msgstr ""
 
@@ -816,25 +815,25 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 msgid "No Queued Downloads"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -855,14 +854,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -893,21 +892,21 @@ msgstr ""
 msgid "Overwrite Existing Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -927,11 +926,15 @@ msgid "Play"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 msgid "Preparing required tools..."
 msgstr ""
 
@@ -945,7 +948,7 @@ msgstr ""
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -959,19 +962,19 @@ msgstr ""
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -981,7 +984,7 @@ msgstr ""
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1016,22 +1019,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr ""
 
@@ -1040,7 +1043,7 @@ msgstr ""
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr ""
@@ -1051,29 +1054,29 @@ msgstr ""
 msgid "Select Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1083,19 +1086,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1106,19 +1109,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1154,7 +1157,7 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1183,7 +1186,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1194,7 +1197,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1203,7 +1206,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1212,7 +1215,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
@@ -1221,7 +1224,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1229,7 +1232,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1277,7 +1280,7 @@ msgid "User Name (Empty)"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1286,13 +1289,17 @@ msgid "Username"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+msgid "Validating"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr ""
 
@@ -1310,7 +1317,7 @@ msgid "Waiting..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr ""
 
@@ -1323,10 +1330,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
+++ b/NickvisionTubeConverter.Shared/Resources/po/parabolic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,14 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -128,8 +128,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr ""
 
@@ -227,8 +227,8 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr ""
 
@@ -381,12 +381,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -400,13 +408,13 @@ msgstr ""
 msgid "Download Again"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr ""
 
@@ -467,8 +475,8 @@ msgstr ""
 msgid "Downloading..."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr ""
 
@@ -596,7 +604,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
@@ -765,7 +773,7 @@ msgstr ""
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -776,15 +784,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -851,6 +859,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -970,7 +979,7 @@ msgid "Queued"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr ""
@@ -1071,8 +1080,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1153,7 +1162,8 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1198,7 +1208,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1212,7 +1222,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1220,7 +1230,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1318,10 +1328,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-08 15:54+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
-"Language-Team: Polish <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/pl/>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,20 +20,20 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Pobieranie \"{0}\" zostało zakończone."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Pobieranie \"{0}\" zakończyło się błędem!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Konfigurowalne w preferencjach)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -69,8 +69,8 @@ msgstr[2] "pobieranie - {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -92,7 +92,7 @@ msgstr ""
 "Ciasteczko może zostać udostępnione yt-dlp, aby umożliwić pobieranie plików "
 "dostępnych po zalogowaniu."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "O {0}"
@@ -103,18 +103,18 @@ msgstr "O {0}"
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Dodaj adres URL wideo, audio lub playlisty, aby rozpocząć pobieranie."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -128,14 +128,14 @@ msgid "Add Login"
 msgstr "Dodaj dane logowania"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opcje zaawansowane"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Pobieranie wszystkich plików zostało zakończone."
 
@@ -154,17 +154,17 @@ msgstr "Zastosuj"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Język dźwięku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Uwierzytelnij"
@@ -173,7 +173,7 @@ msgstr "Uwierzytelnij"
 msgid "Automatically Check for Updates"
 msgstr "Automatycznie sprawdzaj aktualizacje"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -181,7 +181,7 @@ msgid "Back"
 msgstr "Wstecz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Najlepsza"
 
@@ -193,7 +193,7 @@ msgstr "Anuluj"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -222,21 +222,21 @@ msgstr ""
 "Usuń metadane zawierające adres URL i inne dane, które mogą prowadzić do "
 "źródła multimediów"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Wyczyść procesy oczekujące w kolejce"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Zamknąć i zatrzymać pobieranie?"
 
@@ -244,8 +244,8 @@ msgstr "Zamknąć i zatrzymać pobieranie?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Zakończone"
@@ -255,7 +255,7 @@ msgstr "Zakończone"
 msgid "Completed Notification Trigger"
 msgstr "Powiadamiaj o ukończeniu"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Kontrybutorzy GitHub ❤️"
 
@@ -304,16 +304,16 @@ msgstr "Dane logowania"
 msgid "Crop Audio Thumbnails"
 msgstr "Przycinaj miniatury plików audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Przytnij miniaturę"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -327,11 +327,11 @@ msgid "Delete"
 msgstr "Usuń"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Odznacz wszystko"
@@ -404,15 +404,23 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Nie zezwalaj na konwersję"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +431,13 @@ msgstr "Pobierz"
 msgid "Download Again"
 msgstr "Pobierz ponownie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Pobieranie zostało zakończone"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Pobieranie zostało zakończone z błędami"
 
@@ -438,17 +446,17 @@ msgstr "Pobieranie zostało zakończone z błędami"
 msgid "Download log was copied to clipboard."
 msgstr "Dziennik pobierania został skopiowany do schowka."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Pobierz"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Pobierz określony fragment"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Pobierz napisy"
@@ -461,20 +469,20 @@ msgstr "Rozpoczęto pobieranie za pomocą aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Rozpoczęto pobieranie za pomocą ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Pobieraj wideo i audio z Internetu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Pobieranie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Pobierane"
@@ -491,12 +499,12 @@ msgstr "Pobieranie {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Pobierane"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Pobieranie zostało zakończone"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -530,27 +538,27 @@ msgstr ""
 "postępu nie będzie widoczny."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Koniec"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Koniec (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Upewnij się, że dane logowania są poprawne."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -558,7 +566,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -567,7 +575,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -575,7 +583,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -585,8 +593,8 @@ msgstr ""
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -595,7 +603,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Nie można włączyć listy kluczy."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nazwa pliku"
@@ -609,7 +617,7 @@ msgstr "Plik już istnieje, a nadpisywanie istniejących plików jest wyłączon
 msgid "File Name"
 msgstr "Nazwa pliku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Typ pliku"
@@ -619,23 +627,23 @@ msgstr "Typ pliku"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repozytorium na Githubie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Pomoc"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -682,14 +690,14 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Lista kluczy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Dane logowania"
@@ -709,13 +717,13 @@ msgstr "Lista kluczy zablokowana"
 msgid "Language Code Information"
 msgstr "Informacje o kodzie języka"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Pozostaw puste, aby pobrać od początku."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista obsługiwanych stron internetowych"
 
@@ -726,12 +734,12 @@ msgstr "Zaloguj"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Zaloguj"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
@@ -741,7 +749,7 @@ msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
 msgid "Manage previously downloaded media."
 msgstr "Zarządzaj pobranymi multimediami."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Czat Matrix"
 
@@ -756,11 +764,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Maksymalna ilość aktywnych procesów pobierania"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Najwyższa jakość"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -772,14 +780,13 @@ msgstr ""
 "wyłączone."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Adres URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
@@ -796,40 +803,40 @@ msgstr "Minimalny rozmiar podziału (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nazwa"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nazwa (pusta)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Brak połączenia z internetem"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -843,7 +850,7 @@ msgstr "Brak danych logowania"
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Żadne pobieranie nie jest uruchomione"
@@ -858,26 +865,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Brak wcześniejszych pobrań"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Wyczyść procesy oczekujące w kolejce"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numeruj tytuły"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -895,17 +902,18 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -937,23 +945,23 @@ msgstr "Otwórz folder"
 msgid "Overwrite Existing Files"
 msgstr "Nadpisuj istniejące pliki"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -961,7 +969,7 @@ msgid "Password"
 msgstr "Hasło"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Hasło (puste)"
 
@@ -971,14 +979,13 @@ msgid "Play"
 msgstr "Odtwórz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlista"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Przygotowanie..."
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -990,7 +997,7 @@ msgstr "Przygotowanie..."
 msgid "Prevent Suspend"
 msgstr "Zapobiegaj uśpieniu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1004,19 +1011,19 @@ msgstr "Przetwarzanie..."
 msgid "Proxy URL"
 msgstr "Adres URL serwera proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Jakość"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "W kolejce"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Pobierz nieudane ponownie"
@@ -1026,7 +1033,7 @@ msgstr "Pobierz nieudane ponownie"
 msgid "Remove Source Data"
 msgstr "Usuń dane źródłowe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1036,7 +1043,7 @@ msgid "Reset"
 msgstr "Reset"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Zresetować listę kluczy?"
 
@@ -1061,22 +1068,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Pobierz ponownie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Pobierz nieudane ponownie"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Folder docelowy"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Folder docelowy (błędne dane)"
 
@@ -1086,7 +1093,7 @@ msgstr "Folder docelowy (błędne dane)"
 msgid "Search history"
 msgstr "Wyczyść historię"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Zaznacz wszystko"
@@ -1097,29 +1104,29 @@ msgstr "Zaznacz wszystko"
 msgid "Select Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Wybierz by pobrać lub zmienić nazwy plików."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Wybierz folder docelowy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1131,19 +1138,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Niektóre procesy pobierania zostały zakończone z błędami!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limit prędkości pobierania"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Podziel według rozdziałów"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Dzieli wideo na mniejsze części według jego rozdziałów."
@@ -1154,19 +1161,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informacje o SponsorBlock (otworzą się w przeglądarce internetowej)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Początek"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Początek (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1203,7 +1210,8 @@ msgstr "Języki napisów (błędne dane)"
 msgid "Success"
 msgstr "Sukces"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1225,7 +1233,7 @@ msgid "Theme"
 msgstr "Motyw"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "To działanie jest nieodwracalne. Czy na pewno chcesz usunąć te dane?"
 
@@ -1239,12 +1247,8 @@ msgstr ""
 "prędkości pobierania. Zmiana tej wartości nie będzie miała wpływu na "
 "uruchomione dotychczas procesy pobierania."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1252,36 +1256,30 @@ msgstr ""
 "To usunie poprzednią listę kluczy wraz ze wszystkimi hasłami. To działanie "
 "jest nieodwracalne."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Nie można wyłączyć listy kluczy."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Nie można zresetować listy kluczy."
-
-#: ../../../Controllers/MainWindowController.cs:274
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Nie udało się skonfigurować zależności. Uruchom ponownie aplikację i spróbuj "
-"jeszcze raz."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Cofnij edycję tytułu"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Odblokuj listę kluczy"
 
@@ -1290,19 +1288,19 @@ msgstr "Odblokuj listę kluczy"
 msgid "Unset Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Adres URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
@@ -1336,28 +1334,33 @@ msgid "User Interface"
 msgstr "Interfejs użytkownika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nazwa użytkownika (pusta)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Sprawdź"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Sprawdź"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Wideo"
 
@@ -1375,7 +1378,7 @@ msgid "Waiting..."
 msgstr "Oczekiwanie..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Najgorsza"
 
@@ -1388,10 +1391,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Tak"
@@ -1538,6 +1541,15 @@ msgstr "- Obsługuje pobieranie wielu plików jednocześnie"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Obsługuje pobieranie metadanych i napisów do wideo"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Przygotowanie..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Nie udało się skonfigurować zależności. Uruchom ponownie aplikację i "
+#~ "spróbuj jeszcze raz."
 
 #~ msgid "Search..."
 #~ msgstr "Szukaj..."

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-11-01 16:03+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,20 +20,20 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Pobieranie \"{0}\" zostało zakończone."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Pobieranie \"{0}\" zakończyło się błędem!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Konfigurowalne w preferencjach)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -69,8 +69,8 @@ msgstr[2] "pobieranie - {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -92,7 +92,7 @@ msgstr ""
 "Ciasteczko może zostać udostępnione yt-dlp, aby umożliwić pobieranie plików "
 "dostępnych po zalogowaniu."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -103,18 +103,18 @@ msgstr ""
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Dodaj adres URL wideo, audio lub playlisty, aby rozpocząć pobieranie."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -128,14 +128,14 @@ msgid "Add Login"
 msgstr "Dodaj dane logowania"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opcje zaawansowane"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Pobieranie wszystkich plików zostało zakończone."
 
@@ -154,17 +154,17 @@ msgstr "Zastosuj"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Język dźwięku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Uwierzytelnij"
@@ -173,7 +173,7 @@ msgstr "Uwierzytelnij"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -181,7 +181,7 @@ msgid "Back"
 msgstr "Wstecz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Najlepsza"
 
@@ -193,7 +193,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -222,21 +222,21 @@ msgstr ""
 "Usuń metadane zawierające adres URL i inne dane, które mogą prowadzić do "
 "źródła multimediów"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Wyczyść procesy oczekujące w kolejce"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Zamknąć i zatrzymać pobieranie?"
 
@@ -244,8 +244,8 @@ msgstr "Zamknąć i zatrzymać pobieranie?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Zakończone"
@@ -255,7 +255,7 @@ msgstr "Zakończone"
 msgid "Completed Notification Trigger"
 msgstr "Powiadamiaj o ukończeniu"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Kontrybutorzy GitHub ❤️"
 
@@ -304,16 +304,16 @@ msgstr "Dane logowania"
 msgid "Crop Audio Thumbnails"
 msgstr "Przycinaj miniatury plików audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Przytnij miniaturę"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -331,7 +331,7 @@ msgstr "Usuń"
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Odznacz wszystko"
@@ -404,15 +404,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Nie zezwalaj na konwersję"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +423,13 @@ msgstr "Pobierz"
 msgid "Download Again"
 msgstr "Pobierz ponownie"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Pobieranie zostało zakończone"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Pobieranie zostało zakończone z błędami"
 
@@ -438,17 +438,17 @@ msgstr "Pobieranie zostało zakończone z błędami"
 msgid "Download log was copied to clipboard."
 msgstr "Dziennik pobierania został skopiowany do schowka."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Pobierz"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Pobierz określony fragment"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Pobierz napisy"
@@ -461,20 +461,20 @@ msgstr "Rozpoczęto pobieranie za pomocą aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Rozpoczęto pobieranie za pomocą ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Pobieraj wideo i audio z Internetu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Pobieranie"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Pobierane"
@@ -491,12 +491,12 @@ msgstr "Pobieranie {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Pobierane"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Pobieranie zostało zakończone"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -530,27 +530,27 @@ msgstr ""
 "postępu nie będzie widoczny."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Koniec"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Koniec (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Upewnij się, że dane logowania są poprawne."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -585,8 +585,8 @@ msgstr ""
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Nie można włączyć listy kluczy."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nazwa pliku"
@@ -609,7 +609,7 @@ msgstr "Plik już istnieje, a nadpisywanie istniejących plików jest wyłączon
 msgid "File Name"
 msgstr "Nazwa pliku"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Typ pliku"
@@ -619,23 +619,23 @@ msgstr "Typ pliku"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repozytorium na Githubie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Pomoc"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -683,13 +683,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Lista kluczy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Dane logowania"
@@ -709,13 +709,13 @@ msgstr "Lista kluczy zablokowana"
 msgid "Language Code Information"
 msgstr "Informacje o kodzie języka"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Pozostaw puste, aby pobrać od początku."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lista obsługiwanych stron internetowych"
 
@@ -731,7 +731,7 @@ msgstr "Zaloguj"
 msgid "Login"
 msgstr "Zaloguj"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
@@ -741,7 +741,7 @@ msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
 msgid "Manage previously downloaded media."
 msgstr "Zarządzaj pobranymi multimediami."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Czat Matrix"
 
@@ -756,11 +756,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Maksymalna ilość aktywnych procesów pobierania"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Najwyższa jakość"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -772,14 +772,13 @@ msgstr ""
 "wyłączone."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Adres URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
@@ -806,30 +805,30 @@ msgstr "Nazwa"
 msgid "Name (Empty)"
 msgstr "Nazwa (pusta)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Brak połączenia z internetem"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -843,7 +842,7 @@ msgstr "Brak danych logowania"
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Żadne pobieranie nie jest uruchomione"
@@ -858,26 +857,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Brak wcześniejszych pobrań"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Wyczyść procesy oczekujące w kolejce"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numeruj tytuły"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -898,14 +897,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -937,21 +936,21 @@ msgstr "Otwórz folder"
 msgid "Overwrite Existing Files"
 msgstr "Nadpisuj istniejące pliki"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -971,11 +970,15 @@ msgid "Play"
 msgstr "Odtwórz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlista"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Przygotowanie..."
@@ -990,7 +993,7 @@ msgstr "Przygotowanie..."
 msgid "Prevent Suspend"
 msgstr "Zapobiegaj uśpieniu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1004,19 +1007,19 @@ msgstr "Przetwarzanie..."
 msgid "Proxy URL"
 msgstr "Adres URL serwera proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Jakość"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "W kolejce"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Pobierz nieudane ponownie"
@@ -1026,7 +1029,7 @@ msgstr "Pobierz nieudane ponownie"
 msgid "Remove Source Data"
 msgstr "Usuń dane źródłowe"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1061,22 +1064,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Pobierz ponownie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Pobierz nieudane ponownie"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Folder docelowy"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Folder docelowy (błędne dane)"
 
@@ -1086,7 +1089,7 @@ msgstr "Folder docelowy (błędne dane)"
 msgid "Search history"
 msgstr "Wyczyść historię"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Zaznacz wszystko"
@@ -1097,29 +1100,29 @@ msgstr "Zaznacz wszystko"
 msgid "Select Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Wybierz by pobrać lub zmienić nazwy plików."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Wybierz folder docelowy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1131,19 +1134,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Niektóre procesy pobierania zostały zakończone z błędami!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limit prędkości pobierania"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Podziel według rozdziałów"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Dzieli wideo na mniejsze części według jego rozdziałów."
@@ -1154,19 +1157,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informacje o SponsorBlock (otworzą się w przeglądarce internetowej)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Początek"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Początek (błędne dane)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1203,7 +1206,7 @@ msgstr "Języki napisów (błędne dane)"
 msgid "Success"
 msgstr "Sukces"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1239,7 +1242,7 @@ msgstr ""
 "prędkości pobierania. Zmiana tej wartości nie będzie miała wpływu na "
 "uruchomione dotychczas procesy pobierania."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1252,7 +1255,7 @@ msgstr ""
 "To usunie poprzednią listę kluczy wraz ze wszystkimi hasłami. To działanie "
 "jest nieodwracalne."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 
@@ -1261,7 +1264,7 @@ msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 msgid "Unable to disable keyring."
 msgstr "Nie można wyłączyć listy kluczy."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1270,7 +1273,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Nie można zresetować listy kluczy."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Nie udało się skonfigurować zależności. Uruchom ponownie aplikację i spróbuj "
@@ -1281,7 +1284,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Cofnij edycję tytułu"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Odblokuj listę kluczy"
 
@@ -1290,7 +1293,7 @@ msgstr "Odblokuj listę kluczy"
 msgid "Unset Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1342,7 +1345,7 @@ msgid "User Name (Empty)"
 msgstr "Nazwa użytkownika (pusta)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1351,13 +1354,18 @@ msgid "Username"
 msgstr "Nazwa użytkownika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Sprawdź"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Sprawdź"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Wideo"
 
@@ -1375,7 +1383,7 @@ msgid "Waiting..."
 msgstr "Oczekiwanie..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Najgorsza"
 
@@ -1388,10 +1396,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Tak"

--- a/NickvisionTubeConverter.Shared/Resources/po/pl.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-01 16:03+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -21,13 +21,13 @@ msgstr ""
 "X-Generator: Weblate 5.2-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "Pobieranie \"{0}\" zostało zakończone."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "Pobieranie \"{0}\" zakończyło się błędem!"
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Dodaj adres URL wideo, audio lub playlisty, aby rozpocząć pobieranie."
@@ -112,9 +112,9 @@ msgstr "Dodaj adres URL wideo, audio lub playlisty, aby rozpocząć pobieranie."
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -135,7 +135,7 @@ msgid "Advanced Options"
 msgstr "Opcje zaawansowane"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Pobieranie wszystkich plików zostało zakończone."
 
@@ -203,7 +203,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -223,7 +223,7 @@ msgstr ""
 "źródła multimediów"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -236,7 +236,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Zamknąć i zatrzymać pobieranie?"
 
@@ -244,8 +244,8 @@ msgstr "Zamknąć i zatrzymać pobieranie?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Zakończone"
@@ -255,7 +255,7 @@ msgstr "Zakończone"
 msgid "Completed Notification Trigger"
 msgstr "Powiadamiaj o ukończeniu"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Kontrybutorzy GitHub ❤️"
 
@@ -309,11 +309,11 @@ msgstr "Przycinaj miniatury plików audio"
 msgid "Crop Thumbnail"
 msgstr "Przytnij miniaturę"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -327,7 +327,7 @@ msgid "Delete"
 msgstr "Usuń"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Usunąć dane logowania?"
 
@@ -424,12 +424,12 @@ msgid "Download Again"
 msgstr "Pobierz ponownie"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Pobieranie zostało zakończone"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Pobieranie zostało zakończone z błędami"
 
@@ -438,7 +438,7 @@ msgstr "Pobieranie zostało zakończone z błędami"
 msgid "Download log was copied to clipboard."
 msgstr "Dziennik pobierania został skopiowany do schowka."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Pobierz"
@@ -461,7 +461,7 @@ msgstr "Rozpoczęto pobieranie za pomocą aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Rozpoczęto pobieranie za pomocą ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -473,8 +473,8 @@ msgstr "Pobieraj wideo i audio z Internetu"
 msgid "Downloader"
 msgstr "Pobieranie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Pobierane"
@@ -492,7 +492,7 @@ msgid "Downloading..."
 msgstr "Pobierane"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Pobieranie zostało zakończone"
 
@@ -586,7 +586,7 @@ msgid "Error"
 msgstr "Błąd"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgstr "Typ pliku"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -682,7 +682,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -715,7 +715,7 @@ msgstr "Informacje o kodzie języka"
 msgid "Leave empty to download from start."
 msgstr "Pozostaw puste, aby pobrać od początku."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista obsługiwanych stron internetowych"
 
@@ -726,8 +726,8 @@ msgstr "Zaloguj"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Zaloguj"
 
@@ -741,7 +741,7 @@ msgstr "Zmień miniaturę na kwadratową. Przydatne przy pobieraniu muzyki."
 msgid "Manage previously downloaded media."
 msgstr "Zarządzaj pobranymi multimediami."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Czat Matrix"
 
@@ -795,40 +795,40 @@ msgstr "Minimalny rozmiar podziału (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nazwa"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nazwa (pusta)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Brak połączenia z internetem"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Wyczyść ukończone procesy pobierania"
@@ -842,7 +842,7 @@ msgstr "Brak danych logowania"
 msgid "No downloads running"
 msgstr "Żadne pobieranie nie jest uruchomione"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Żadne pobieranie nie jest uruchomione"
@@ -857,7 +857,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Brak wcześniejszych pobrań"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Wyczyść procesy oczekujące w kolejce"
@@ -936,14 +936,14 @@ msgstr "Otwórz folder"
 msgid "Overwrite Existing Files"
 msgstr "Nadpisuj istniejące pliki"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -952,7 +952,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -960,7 +960,7 @@ msgid "Password"
 msgstr "Hasło"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Hasło (puste)"
 
@@ -977,11 +977,6 @@ msgstr "Playlista"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Przygotowanie..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1012,14 +1007,14 @@ msgstr "Adres URL serwera proxy"
 msgid "Quality"
 msgstr "Jakość"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "W kolejce"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Pobierz nieudane ponownie"
@@ -1039,7 +1034,7 @@ msgid "Reset"
 msgstr "Reset"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Zresetować listę kluczy?"
 
@@ -1065,7 +1060,7 @@ msgid "Retry Download"
 msgstr "Pobierz ponownie"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1112,17 +1107,17 @@ msgid "Select Save Folder"
 msgstr "Wybierz folder docelowy"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1169,7 +1164,7 @@ msgid "Start Time (Invalid)"
 msgstr "Początek (błędne dane)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1228,7 +1223,7 @@ msgid "Theme"
 msgstr "Motyw"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "To działanie jest nieodwracalne. Czy na pewno chcesz usunąć te dane?"
 
@@ -1242,12 +1237,8 @@ msgstr ""
 "prędkości pobierania. Zmiana tej wartości nie będzie miała wpływu na "
 "uruchomione dotychczas procesy pobierania."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1255,36 +1246,30 @@ msgstr ""
 "To usunie poprzednią listę kluczy wraz ze wszystkimi hasłami. To działanie "
 "jest nieodwracalne."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Nie można wyłączyć listy kluczy."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Nie można zresetować listy kluczy."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Nie udało się skonfigurować zależności. Uruchom ponownie aplikację i spróbuj "
-"jeszcze raz."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Cofnij edycję tytułu"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Odblokuj listę kluczy"
 
@@ -1293,19 +1278,19 @@ msgstr "Odblokuj listę kluczy"
 msgid "Unset Cookies File"
 msgstr "Wybierz ciasteczko"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Adres URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "Adres URL (błędne dane)"
 
@@ -1339,7 +1324,7 @@ msgid "User Interface"
 msgstr "Interfejs użytkownika"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nazwa użytkownika (pusta)"
@@ -1347,7 +1332,7 @@ msgstr "Nazwa użytkownika (pusta)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1397,9 +1382,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Tak"
@@ -1546,6 +1531,15 @@ msgstr "- Obsługuje pobieranie wielu plików jednocześnie"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Obsługuje pobieranie metadanych i napisów do wideo"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Przygotowanie..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Nie udało się skonfigurować zależności. Uruchom ponownie aplikację i "
+#~ "spróbuj jeszcze raz."
 
 #~ msgid "Search..."
 #~ msgstr "Szukaj..."

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" teve o seu download concluído."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" finalizou com um erro!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Pode ser alterado nas preferências)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "Downloads: {0} — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Um arquivo de cookies pode ser fornecido ao yt-dlp para permitir o download "
 "de arquivos de mídia que exijam um login."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Sobre {0}"
@@ -100,18 +100,18 @@ msgstr "Sobre {0}"
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Adicione a URL de um áudio, vídeo ou playlist para iniciar o download"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr "Adicionar login"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opções avançadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Todos os downloads foram finalizados."
 
@@ -151,17 +151,17 @@ msgstr "Aplicar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Áudio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Idioma do áudio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autenticar"
@@ -170,7 +170,7 @@ msgstr "Autenticar"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr "Voltar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Melhor"
 
@@ -190,7 +190,7 @@ msgstr "Cancelar"
 msgid "Changelog"
 msgstr "Histório de mudanças"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Limpar downloads concluídos"
@@ -217,21 +217,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Limpar downloads em fila"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Fechar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e parar os downloads?"
 
@@ -239,8 +239,8 @@ msgstr "Fechar e parar os downloads?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Concluído"
@@ -250,7 +250,7 @@ msgstr "Concluído"
 msgid "Completed Notification Trigger"
 msgstr "Notificação de conclusão do download"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores no GitHub ❤️"
 
@@ -299,16 +299,16 @@ msgstr "Credenciais"
 msgid "Crop Audio Thumbnails"
 msgstr "Cortar miniaturas para áudio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -326,7 +326,7 @@ msgstr "Excluir"
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Desmarcar todos"
@@ -398,15 +398,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Não permitir conversões"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussões"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -417,13 +417,13 @@ msgstr "Baixar"
 msgid "Download Again"
 msgstr "Baixar novamente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Download finalizado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Download finalizado com erro"
 
@@ -432,17 +432,17 @@ msgstr "Download finalizado com erro"
 msgid "Download log was copied to clipboard."
 msgstr "O registro de download foi copiado para a área de transferência."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Download de mídia"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Baixar trecho específico"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -456,20 +456,20 @@ msgstr "O download utilizando aria2 foi inciado"
 msgid "Download using ffmpeg has started"
 msgstr "O download utilizando FFmpeg foi inciado"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Fazer download do áudio e vídeo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Gerenciador de downloads"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Baixando"
@@ -486,12 +486,12 @@ msgstr "Baixando {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Baixando"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Downloads concluídos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -526,28 +526,28 @@ msgstr ""
 "porém você não verá o progresso do download."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Fim"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Fim (inválido)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Insira a URL do vídeo aqui"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Certifique-se de que as credenciais estão corretas."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Insira a URL do vídeo aqui"
@@ -557,7 +557,7 @@ msgstr "Insira a URL do vídeo aqui"
 msgid "Enter name here"
 msgstr "Insira a URL do vídeo aqui"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -568,7 +568,7 @@ msgstr "Insira a URL do vídeo aqui"
 msgid "Enter proxy url here"
 msgstr "Insira a URL do vídeo aqui"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Insira a URL do vídeo aqui"
@@ -578,7 +578,7 @@ msgstr "Insira a URL do vídeo aqui"
 msgid "Enter url here"
 msgstr "Insira a URL do vídeo aqui"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -589,8 +589,8 @@ msgstr "Insira a URL do vídeo aqui"
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nome do arquivo"
@@ -614,7 +614,7 @@ msgstr "O arquivo já existe e a substituição não é permitida"
 msgid "File Name"
 msgstr "Nome do arquivo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo de arquivo"
@@ -624,23 +624,23 @@ msgstr "Tipo de arquivo"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Ajuda"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -686,13 +686,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Chaveiro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Credencial do chaveiro"
@@ -712,13 +712,13 @@ msgstr "Chaveiro bloqueado"
 msgid "Language Code Information"
 msgstr "Informações sobre o código do idioma"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Deixe em branco para fazer o download do início."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lista de sites suportados"
 
@@ -734,7 +734,7 @@ msgstr "Login"
 msgid "Login"
 msgstr "Login"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Cria miniaturas quadradas, útil ao fazer download de músicas."
@@ -744,7 +744,7 @@ msgstr "Cria miniaturas quadradas, útil ao fazer download de músicas."
 msgid "Manage previously downloaded media."
 msgstr "Gerenciar mídia baixada anteriormente."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -759,11 +759,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Número máximo de downloads ativos"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Qualidade máxima"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -775,14 +775,13 @@ msgstr ""
 "de downloads, se ele estiver habilitado."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL da mídia"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL de vídeo (inválida)"
 
@@ -809,30 +808,30 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (vazio)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Sem conexão com a internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Limpar downloads concluídos"
@@ -846,7 +845,7 @@ msgstr "Sem credenciais"
 msgid "No downloads running"
 msgstr "Nenhum download em andamento"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nenhum download em andamento"
@@ -861,26 +860,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Não há downloads anteriores"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Limpar downloads em fila"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Numerar os títulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -901,14 +900,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -940,21 +939,21 @@ msgstr "Abrir pasta"
 msgid "Overwrite Existing Files"
 msgstr "Sobrescrever arquivos existentes"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -974,11 +973,15 @@ msgid "Play"
 msgstr "Reproduzir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Preparando..."
@@ -993,7 +996,7 @@ msgstr "Preparando..."
 msgid "Prevent Suspend"
 msgstr "Impedir suspensão da tela"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1007,19 +1010,19 @@ msgstr "Processando..."
 msgid "Proxy URL"
 msgstr "URL da Proxy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Qualidade"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Em fila"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir downloads com falha"
@@ -1029,7 +1032,7 @@ msgstr "Repetir downloads com falha"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Reportar um Bug"
 
@@ -1064,22 +1067,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Tentar baixar novamente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Repetir downloads com falha"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Pasta de destino"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Pasta de destino (Inválida)"
 
@@ -1089,7 +1092,7 @@ msgstr "Pasta de destino (Inválida)"
 msgid "Search history"
 msgstr "Apagar histórico"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Selecionar todos"
@@ -1100,31 +1103,31 @@ msgstr "Selecionar todos"
 msgid "Select Cookies File"
 msgstr "Selecione o arquivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr ""
 "Selecione os itens que deseja fazer download ou altere os nomes dos arquivos."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Selecione a pasta de destino"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Configurações"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1137,19 +1140,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Alguns downloads terminaram com erros!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite de velocidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dividir capítulos"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Divide o vídeo em vários vídeos menores com base nos capítulos."
@@ -1161,19 +1164,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Informações sobre o SponsorBlock"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Início"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Início (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1210,7 +1213,7 @@ msgstr "Idiomas das legendas (inválido)"
 msgid "Success"
 msgstr "Sucesso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1245,7 +1248,7 @@ msgstr ""
 "velocidade ativo. A alteração do valor não afeta os downloads que já estão "
 "em execução."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1258,7 +1261,7 @@ msgstr ""
 "Isso excluirá o chaveiro anterior e todas as senhas armazenadas nele. Essa "
 "ação é irreversível."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Lun3wi <lun3witch@gmail.com>"
 
@@ -1267,7 +1270,7 @@ msgstr "Lun3wi <lun3witch@gmail.com>"
 msgid "Unable to disable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1276,7 +1279,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Não foi possível redefinir o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Não foi possível baixar as dependências. Por favor, reinicie o aplicativo e "
@@ -1287,7 +1290,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Desfazer edição do título"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1296,7 +1299,7 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Selecione o arquivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1348,7 +1351,7 @@ msgid "User Name (Empty)"
 msgstr "Nome de usuário (vazio)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1357,13 +1360,18 @@ msgid "Username"
 msgstr "Nome de usuário"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validar"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Vídeo"
 
@@ -1381,7 +1389,7 @@ msgid "Waiting..."
 msgstr "Esperando..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Pior"
 
@@ -1394,10 +1402,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" teve o seu download concluído."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" finalizou com um erro!"
@@ -131,8 +131,8 @@ msgstr "Adicionar login"
 msgid "Advanced Options"
 msgstr "Opções avançadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Todos os downloads foram finalizados."
 
@@ -230,8 +230,8 @@ msgstr "Limpar downloads em fila"
 msgid "Close"
 msgstr "Fechar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e parar os downloads?"
 
@@ -398,12 +398,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Não permitir conversões"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Discussões"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -417,13 +425,13 @@ msgstr "Baixar"
 msgid "Download Again"
 msgstr "Baixar novamente"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Download finalizado"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Download finalizado com erro"
 
@@ -486,8 +494,8 @@ msgstr "Baixando {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Baixando"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Downloads concluídos"
 
@@ -628,7 +636,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
@@ -808,7 +816,7 @@ msgstr "Nome"
 msgid "Name (Empty)"
 msgstr "Nome (vazio)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -819,15 +827,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Sem conexão com a internet"
 
@@ -897,6 +905,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1017,7 +1026,7 @@ msgid "Queued"
 msgstr "Em fila"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir downloads com falha"
@@ -1121,8 +1130,8 @@ msgstr "Configurações"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1208,7 +1217,8 @@ msgstr "Idiomas das legendas (inválido)"
 msgid "Success"
 msgstr "Sucesso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1261,7 +1271,7 @@ msgstr "Lun3wi <lun3witch@gmail.com>"
 msgid "Unable to disable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1275,7 +1285,7 @@ msgstr "Não foi possível redefinir o chaveiro."
 msgid "Undo Title Editing"
 msgstr "Desfazer edição do título"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1284,7 +1294,7 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Selecione o arquivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1387,10 +1397,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-08-30 20:42+0000\n"
 "Last-Translator: lune <lune@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.0.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" teve o seu download concluído."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" finalizou com um erro!"
@@ -100,7 +100,7 @@ msgstr "Sobre {0}"
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Adicione a URL de um áudio, vídeo ou playlist para iniciar o download"
@@ -109,9 +109,9 @@ msgstr "Adicione a URL de um áudio, vídeo ou playlist para iniciar o download"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "Opções avançadas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Todos os downloads foram finalizados."
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Limpar downloads concluídos"
@@ -218,7 +218,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -231,7 +231,7 @@ msgid "Close"
 msgstr "Fechar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e parar os downloads?"
 
@@ -239,8 +239,8 @@ msgstr "Fechar e parar os downloads?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Concluído"
@@ -250,7 +250,7 @@ msgstr "Concluído"
 msgid "Completed Notification Trigger"
 msgstr "Notificação de conclusão do download"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores no GitHub ❤️"
 
@@ -304,11 +304,11 @@ msgstr "Cortar miniaturas para áudio"
 msgid "Crop Thumbnail"
 msgstr "Cortar miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -322,7 +322,7 @@ msgid "Delete"
 msgstr "Excluir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Excluir credencial?"
 
@@ -418,12 +418,12 @@ msgid "Download Again"
 msgstr "Baixar novamente"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Download finalizado"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Download finalizado com erro"
 
@@ -432,7 +432,7 @@ msgstr "Download finalizado com erro"
 msgid "Download log was copied to clipboard."
 msgstr "O registro de download foi copiado para a área de transferência."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Download de mídia"
@@ -456,7 +456,7 @@ msgstr "O download utilizando aria2 foi inciado"
 msgid "Download using ffmpeg has started"
 msgstr "O download utilizando FFmpeg foi inciado"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -468,8 +468,8 @@ msgstr "Fazer download do áudio e vídeo"
 msgid "Downloader"
 msgstr "Gerenciador de downloads"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Baixando"
@@ -487,7 +487,7 @@ msgid "Downloading..."
 msgstr "Baixando"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Downloads concluídos"
 
@@ -590,7 +590,7 @@ msgid "Error"
 msgstr "Erro"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr "Tipo de arquivo"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -685,7 +685,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -718,7 +718,7 @@ msgstr "Informações sobre o código do idioma"
 msgid "Leave empty to download from start."
 msgstr "Deixe em branco para fazer o download do início."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista de sites suportados"
 
@@ -729,8 +729,8 @@ msgstr "Login"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Login"
 
@@ -744,7 +744,7 @@ msgstr "Cria miniaturas quadradas, útil ao fazer download de músicas."
 msgid "Manage previously downloaded media."
 msgstr "Gerenciar mídia baixada anteriormente."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -798,40 +798,40 @@ msgstr "Tamanho mínimo da divisão (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Nome"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Nome (vazio)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Sem conexão com a internet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Limpar downloads concluídos"
@@ -845,7 +845,7 @@ msgstr "Sem credenciais"
 msgid "No downloads running"
 msgstr "Nenhum download em andamento"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Nenhum download em andamento"
@@ -860,7 +860,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Não há downloads anteriores"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Limpar downloads em fila"
@@ -939,14 +939,14 @@ msgstr "Abrir pasta"
 msgid "Overwrite Existing Files"
 msgstr "Sobrescrever arquivos existentes"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -955,7 +955,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -963,7 +963,7 @@ msgid "Password"
 msgstr "Senha"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Senha (vazia)"
 
@@ -980,11 +980,6 @@ msgstr "Playlist"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Preparando..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1015,14 +1010,14 @@ msgstr "URL da Proxy"
 msgid "Quality"
 msgstr "Qualidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Em fila"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir downloads com falha"
@@ -1042,7 +1037,7 @@ msgid "Reset"
 msgstr "Redefinir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Redefinir o chaveiro?"
 
@@ -1068,7 +1063,7 @@ msgid "Retry Download"
 msgstr "Tentar baixar novamente"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1116,18 +1111,18 @@ msgid "Select Save Folder"
 msgstr "Selecione a pasta de destino"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Configurações"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1176,7 +1171,7 @@ msgid "Start Time (Invalid)"
 msgstr "Início (Inválido)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1234,7 +1229,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Essa ação é irreversível. Tem certeza de que deseja excluí-lo?"
 
@@ -1248,12 +1243,8 @@ msgstr ""
 "velocidade ativo. A alteração do valor não afeta os downloads que já estão "
 "em execução."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1261,36 +1252,30 @@ msgstr ""
 "Isso excluirá o chaveiro anterior e todas as senhas armazenadas nele. Essa "
 "ação é irreversível."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Lun3wi <lun3witch@gmail.com>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Não foi possível desativar o chaveiro."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Não foi possível redefinir o chaveiro."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Não foi possível baixar as dependências. Por favor, reinicie o aplicativo e "
-"tente novamente."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Desfazer edição do título"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Desbloquear chaveiro"
 
@@ -1299,19 +1284,19 @@ msgstr "Desbloquear chaveiro"
 msgid "Unset Cookies File"
 msgstr "Selecione o arquivo de cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (inválida)"
 
@@ -1345,7 +1330,7 @@ msgid "User Interface"
 msgstr "Interface de usuário"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Nome de usuário (vazio)"
@@ -1353,7 +1338,7 @@ msgstr "Nome de usuário (vazio)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1403,9 +1388,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"
@@ -1554,6 +1539,15 @@ msgstr "— Execute vários downloads ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta o download de metadados e legendas"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Preparando..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Não foi possível baixar as dependências. Por favor, reinicie o aplicativo "
+#~ "e tente novamente."
 
 #~ msgid "Search..."
 #~ msgstr "Pesquisar..."

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" terminou de ser transferido."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" terminou com um erro!"
@@ -100,7 +100,7 @@ msgstr ""
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Adicione um video, audio, ou URL de playlist para começar a transferir"
@@ -109,9 +109,9 @@ msgstr "Adicione um video, audio, ou URL de playlist para começar a transferir"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "Opções Avançadas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Terminaram todas as transferências."
 
@@ -201,7 +201,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Limpar Transferências Terminadas"
@@ -219,7 +219,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -232,7 +232,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e Parar Transferências?"
 
@@ -240,8 +240,8 @@ msgstr "Fechar e Parar Transferências?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Terminado"
@@ -251,7 +251,7 @@ msgstr "Terminado"
 msgid "Completed Notification Trigger"
 msgstr "Acionador de Notificação de Conclusão"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -309,11 +309,11 @@ msgstr "Cortar Miniatura"
 msgid "Crop Thumbnail"
 msgstr "Cortar Miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -415,12 +415,12 @@ msgid "Download Again"
 msgstr "A transferir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Transferência Terminada"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Transferência Terminada com Erro"
 
@@ -429,7 +429,7 @@ msgstr "Transferência Terminada com Erro"
 msgid "Download log was copied to clipboard."
 msgstr "O Histórico de transferências for copiado para o clipboard."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Transferir Media"
@@ -454,7 +454,7 @@ msgstr "Transferência a usar aria2 iniciou-se"
 msgid "Download using ffmpeg has started"
 msgstr "Transferência a usar aria2 iniciou-se"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -466,8 +466,8 @@ msgstr ""
 msgid "Downloader"
 msgstr "Descarregador"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "A transferir"
@@ -485,7 +485,7 @@ msgid "Downloading..."
 msgstr "A transferir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Transferências Terminadas"
 
@@ -581,7 +581,7 @@ msgid "Error"
 msgstr "Erro"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr "Tipo de Ficheiro"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista de sítios suportados"
 
@@ -717,8 +717,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr "Tornar miniatura quadrada, útil ao transferir músicas."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -783,41 +783,41 @@ msgstr "Tamanho mínimo da divisão (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "Nome do Ficheiro"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Limpar Transferências Terminadas"
@@ -831,7 +831,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "Não há transferências a decorrer"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Não há transferências a decorrer"
@@ -847,7 +847,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Parar Todas as Transferências"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Limpar Fila de Transferências"
@@ -928,14 +928,14 @@ msgstr "Abrir Pasta de Destino"
 msgid "Overwrite Existing Files"
 msgstr "Sobrescrever Ficheiros Existentes"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -944,7 +944,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -952,7 +952,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -970,11 +970,6 @@ msgstr "Playlist"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "A preparar..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1005,14 +1000,14 @@ msgstr ""
 msgid "Quality"
 msgstr "Qualidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Em Fila de Espera"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir Transferências Falhadas"
@@ -1032,7 +1027,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1058,7 +1053,7 @@ msgid "Retry Download"
 msgstr "Tentar Transferir Novamente"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1105,17 +1100,17 @@ msgid "Select Save Folder"
 msgstr "Selecione Pasta de Destino"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1166,7 +1161,7 @@ msgid "Start Time (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1227,7 +1222,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1240,47 +1235,37 @@ msgstr ""
 "Este limite (em KiB/s) é aplicado às transferências que tiverem o limite de "
 "velocidade ativado. Alterar o valor não afeta as transferências já em curso."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Ricardo Simões https://xmcorporation.com"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Não é possível configurar as dependências. Reinicie a aplicação e tente "
-"novamente."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Desfazer Edição de Título"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1289,19 +1274,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Selecione Ficheiro de Cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "URL da Media (Inválido)"
@@ -1333,7 +1318,7 @@ msgid "User Interface"
 msgstr "Interface do Utilizador"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Interface do Utilizador"
@@ -1341,7 +1326,7 @@ msgstr "Interface do Utilizador"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
@@ -1392,9 +1377,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"
@@ -1541,6 +1526,15 @@ msgstr "— Corre múltiplas transferências ao mesmo tempo"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Suporta transferência de metadados e legendas de vídeo"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "A preparar..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Não é possível configurar as dependências. Reinicie a aplicação e tente "
+#~ "novamente."
 
 #~ msgctxt "Subtitle"
 #~ msgid "None"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" terminou de ser transferido."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" terminou com um erro!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Configurável nas preferências)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "{0} transferências — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Um ficheiro de cookies pode ser fornecido ao yt-dlp para permitir "
 "descarregar media que requer um login."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -100,18 +100,18 @@ msgstr ""
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Adicione um video, audio, ou URL de playlist para começar a transferir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Opções Avançadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Terminaram todas as transferências."
 
@@ -151,17 +151,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Audio"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 #, fuzzy
 msgid "Authenticate"
@@ -171,7 +171,7 @@ msgstr "Aplicação"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -179,7 +179,7 @@ msgid "Back"
 msgstr "Atrás"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Melhor"
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -200,8 +200,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Limpar Transferências Terminadas"
@@ -218,21 +218,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Limpar Fila de Transferências"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e Parar Transferências?"
 
@@ -240,8 +240,8 @@ msgstr "Fechar e Parar Transferências?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Terminado"
@@ -251,7 +251,7 @@ msgstr "Terminado"
 msgid "Completed Notification Trigger"
 msgstr "Acionador de Notificação de Conclusão"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -304,16 +304,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr "Cortar Miniatura"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cortar Miniatura"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -394,15 +394,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Não Permitir Conversões"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -414,13 +414,13 @@ msgstr "Transferência"
 msgid "Download Again"
 msgstr "A transferir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Transferência Terminada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Transferência Terminada com Erro"
 
@@ -429,17 +429,17 @@ msgstr "Transferência Terminada com Erro"
 msgid "Download log was copied to clipboard."
 msgstr "O Histórico de transferências for copiado para o clipboard."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Transferir Media"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -454,20 +454,20 @@ msgstr "Transferência a usar aria2 iniciou-se"
 msgid "Download using ffmpeg has started"
 msgstr "Transferência a usar aria2 iniciou-se"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Descarregador"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "A transferir"
@@ -484,12 +484,12 @@ msgstr "A transferir {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "A transferir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Transferências Terminadas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -524,28 +524,28 @@ msgstr ""
 "progresso da transferência."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "URL da Media (Inválido)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -562,7 +562,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -570,7 +570,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -580,8 +580,8 @@ msgstr ""
 msgid "Error"
 msgstr "Erro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -590,7 +590,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Nome do Ficheiro"
@@ -604,7 +604,7 @@ msgstr "O ficheiro já existe, e a sobrescrita não é permitida"
 msgid "File Name"
 msgstr "Nome do Ficheiro"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Tipo de Ficheiro"
@@ -614,23 +614,23 @@ msgstr "Tipo de Ficheiro"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -675,13 +675,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -701,13 +701,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lista de sítios suportados"
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Tornar miniatura quadrada, útil ao transferir músicas."
@@ -732,7 +732,7 @@ msgstr "Tornar miniatura quadrada, útil ao transferir músicas."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -747,11 +747,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Número Máx de Transferências Ativas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Qualidade Máxima"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -760,14 +760,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL da Media"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL da Media (Inválido)"
 
@@ -795,30 +794,30 @@ msgstr "Nome do Ficheiro"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Limpar Transferências Terminadas"
@@ -832,7 +831,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr "Não há transferências a decorrer"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Não há transferências a decorrer"
@@ -848,27 +847,27 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Parar Todas as Transferências"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Limpar Fila de Transferências"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 #, fuzzy
 msgid "Number Titles"
 msgstr "Títulos de Números"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -889,14 +888,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -929,21 +928,21 @@ msgstr "Abrir Pasta de Destino"
 msgid "Overwrite Existing Files"
 msgstr "Sobrescrever Ficheiros Existentes"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -964,11 +963,15 @@ msgid "Play"
 msgstr "Playlist"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "A preparar..."
@@ -983,7 +986,7 @@ msgstr "A preparar..."
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -997,19 +1000,19 @@ msgstr "A processar..."
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Qualidade"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Em Fila de Espera"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir Transferências Falhadas"
@@ -1019,7 +1022,7 @@ msgstr "Repetir Transferências Falhadas"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1054,22 +1057,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Tentar Transferir Novamente"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Repetir Transferências Falhadas"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Pasta de Destino"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
 
@@ -1078,7 +1081,7 @@ msgstr "Pasta de Destino (Inválida)"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1090,29 +1093,29 @@ msgstr "Parar Tudo"
 msgid "Select Cookies File"
 msgstr "Selecione Ficheiro de Cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Selecione itens para transferir ou altere os nomes dos ficheiros."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Selecione Pasta de Destino"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1126,19 +1129,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Algumas transferências terminaram com erros!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Limite de Velocidade"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1150,20 +1153,20 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Ficheiros de Cookies"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "Pasta de Destino (Inválida)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1201,7 +1204,7 @@ msgstr "Pasta de Destino (Inválida)"
 msgid "Success"
 msgstr "Sucesso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1237,7 +1240,7 @@ msgstr ""
 "Este limite (em KiB/s) é aplicado às transferências que tiverem o limite de "
 "velocidade ativado. Alterar o valor não afeta as transferências já em curso."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1248,7 +1251,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Ricardo Simões https://xmcorporation.com"
 
@@ -1257,7 +1260,7 @@ msgstr "Ricardo Simões https://xmcorporation.com"
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1266,7 +1269,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Não é possível configurar as dependências. Reinicie a aplicação e tente "
@@ -1277,7 +1280,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Desfazer Edição de Título"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1286,7 +1289,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Selecione Ficheiro de Cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1336,7 +1339,7 @@ msgid "User Name (Empty)"
 msgstr "Interface do Utilizador"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1346,13 +1349,18 @@ msgid "Username"
 msgstr "Interface do Utilizador"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validar"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1370,7 +1378,7 @@ msgid "Waiting..."
 msgstr "À espera..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Pior"
 
@@ -1383,10 +1391,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"

--- a/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/pt_PT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-05-30 20:10+0100\n"
 "Last-Translator: Ricardo Simões xmcorporation.com <simplelogin-"
 "newsletter.635e2@aleeas.com>\n"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" terminou de ser transferido."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" terminou com um erro!"
@@ -131,8 +131,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "Opções Avançadas"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Terminaram todas as transferências."
 
@@ -231,8 +231,8 @@ msgstr "Limpar Fila de Transferências"
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Fechar e Parar Transferências?"
 
@@ -394,12 +394,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Não Permitir Conversões"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -414,13 +422,13 @@ msgstr "Transferência"
 msgid "Download Again"
 msgstr "A transferir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Transferência Terminada"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Transferência Terminada com Erro"
 
@@ -484,8 +492,8 @@ msgstr "A transferir {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "A transferir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Transferências Terminadas"
 
@@ -618,7 +626,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
@@ -794,7 +802,7 @@ msgstr "Nome do Ficheiro"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -805,15 +813,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Não"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -885,6 +893,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -1007,7 +1016,7 @@ msgid "Queued"
 msgstr "Em Fila de Espera"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Repetir Transferências Falhadas"
@@ -1109,8 +1118,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1199,7 +1208,8 @@ msgstr "Pasta de Destino (Inválida)"
 msgid "Success"
 msgstr "Sucesso"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1251,7 +1261,7 @@ msgstr "Ricardo Simões https://xmcorporation.com"
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1265,7 +1275,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Desfazer Edição de Título"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1274,7 +1284,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "Selecione Ficheiro de Cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1376,10 +1386,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Sim"

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-27 15:41+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,20 +20,20 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" загружено."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершилось с ошибкой!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Изменяется в настройках)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} ГиБ/с"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} КиБ/с"
@@ -69,8 +69,8 @@ msgstr[2] "{0} загрузок — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -92,7 +92,7 @@ msgstr ""
 "Можно предоставить файл куки для yt-dlp, чтобы скачивать медиа, которые "
 "требуют входа на сайт."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, fuzzy, csharp-format
 msgid "About {0}"
 msgstr "О приложении"
@@ -103,18 +103,18 @@ msgstr "О приложении"
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Добавьте ссылку на видео, аудио или плейлист, чтобы начать загрузку"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -128,14 +128,14 @@ msgid "Add Login"
 msgstr "Добавить учётные данные"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Дополнительные опции"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Все загрузки завершены."
 
@@ -154,17 +154,17 @@ msgstr "Применить"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Язык аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Аутентификация"
@@ -173,7 +173,7 @@ msgstr "Аутентификация"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -181,7 +181,7 @@ msgid "Back"
 msgstr "Назад"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Лучшее"
 
@@ -193,7 +193,7 @@ msgstr "Отмена"
 msgid "Changelog"
 msgstr "Список изменений"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Очистить завершённые загрузки"
@@ -222,21 +222,21 @@ msgstr ""
 "Очистить поля с URL и прочей информацией, по которой можно было бы "
 "определить источник содержимого"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Очистить очередь"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Закрыть и остановить загрузки?"
 
@@ -244,8 +244,8 @@ msgstr "Закрыть и остановить загрузки?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Завершено"
@@ -255,7 +255,7 @@ msgstr "Завершено"
 msgid "Completed Notification Trigger"
 msgstr "Отображение уведомлений"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Соавторы на GitHub ❤️"
 
@@ -303,16 +303,16 @@ msgstr "Учётные данные"
 msgid "Crop Audio Thumbnails"
 msgstr "Обрезать миниатюры для аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Обрезать миниатюру"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "Давид Лапшин"
 
@@ -330,7 +330,7 @@ msgstr "Удалить"
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Убрать всё"
@@ -404,15 +404,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Отключить конвертирование"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Обсуждения"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +423,13 @@ msgstr "Загрузка"
 msgid "Download Again"
 msgstr "Скачать снова"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Загрузка завершена"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Загрузка завершилась с ошибкой"
 
@@ -438,17 +438,17 @@ msgstr "Загрузка завершилась с ошибкой"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал загрузки скопирован в буфер обмена."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Загрузить медиа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Скачать фрагмент"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Загрузить субтитры"
@@ -461,20 +461,20 @@ msgstr "Началась загрузка с помощью aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Началась загрузка с помощью ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Загружайте веб-видео и аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Загрузчик"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Загружается"
@@ -491,12 +491,12 @@ msgstr "Загрузка {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Загружается"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Загрузки завершены"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Правка"
 
@@ -530,28 +530,28 @@ msgstr ""
 "вы не увидите прогресс загрузки."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Время конца"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Время конца (Некорректное)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Убедитесь, что данные корректны."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
@@ -561,7 +561,7 @@ msgstr "Введите ссылку на видео, аудио или плей�
 msgid "Enter name here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -572,7 +572,7 @@ msgstr "Введите ссылку на видео, аудио или плей�
 msgid "Enter proxy url here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
@@ -582,7 +582,7 @@ msgstr "Введите ссылку на видео, аудио или плей�
 msgid "Enter url here"
 msgstr "Введите ссылку на видео, аудио или плейлист"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -593,8 +593,8 @@ msgstr "Введите ссылку на видео, аудио или плей�
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Выход"
 
@@ -603,7 +603,7 @@ msgstr "Выход"
 msgid "Failed to enable keyring."
 msgstr "Не удалось включить связку ключей."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Файл"
 
@@ -616,7 +616,7 @@ msgstr "Файл уже существует, а перезапись файло
 msgid "File Name"
 msgstr "Имя файла"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Тип файла"
@@ -626,23 +626,23 @@ msgstr "Тип файла"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Помощь"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -689,13 +689,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Связка ключей"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Данные из связки ключей"
@@ -715,13 +715,13 @@ msgstr "Связка ключей заблокирована"
 msgid "Language Code Information"
 msgstr "Информация о языковых кодах"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Оставьте пустым, чтобы скачать с начала."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Список поддерживаемых сайтов"
 
@@ -737,7 +737,7 @@ msgstr "Учётные данные"
 msgid "Login"
 msgstr "Учётные данные"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Сделать миниатюру квадратной, полезно при скачивании музыки."
@@ -747,7 +747,7 @@ msgstr "Сделать миниатюру квадратной, полезно �
 msgid "Manage previously downloaded media."
 msgstr "Действия с предыдущими загрузками."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -762,11 +762,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Максимальное число активных загрузок"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Максимальное качество"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -777,14 +777,13 @@ msgstr ""
 "При включении этой опции не будет использоваться загрузчик aria2."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Ссылка"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
@@ -811,30 +810,30 @@ msgstr "Имя"
 msgid "Name (Empty)"
 msgstr "Имя (пустое)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Отсутствует подключение к интернету"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Очистить завершённые загрузки"
@@ -848,7 +847,7 @@ msgstr "Нет учётных данных"
 msgid "No downloads running"
 msgstr "Ничего не загружается"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Ничего не загружается"
@@ -863,26 +862,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Нет предыдущих загрузок"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Очистить очередь"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Пронумеровать заголовки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -903,14 +902,14 @@ msgstr ""
 msgid "OK"
 msgstr "ОК"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -942,21 +941,21 @@ msgstr "Открыть папку"
 msgid "Overwrite Existing Files"
 msgstr "Перезаписывать существующие файлы"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -976,11 +975,15 @@ msgid "Play"
 msgstr "Играть"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Подготовка..."
@@ -995,7 +998,7 @@ msgstr "Подготовка..."
 msgid "Prevent Suspend"
 msgstr "Предотвращать приостановку системы"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1009,19 +1012,19 @@ msgstr "Обработка..."
 msgid "Proxy URL"
 msgstr "Адрес прокси-сервера"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Качество"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "В очереди"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Осталось загрузок: {0}"
@@ -1031,7 +1034,7 @@ msgstr "Осталось загрузок: {0}"
 msgid "Remove Source Data"
 msgstr "Удалить метаданные об источнике"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Сообщить об ошибке"
 
@@ -1066,22 +1069,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Попробовать снова"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Перезапустить неудавшиеся загрузки"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Папка сохранения"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Папка сохранения (Некорректная)"
 
@@ -1091,7 +1094,7 @@ msgstr "Папка сохранения (Некорректная)"
 msgid "Search history"
 msgstr "Очистить историю"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Выбрать всё"
@@ -1102,30 +1105,30 @@ msgstr "Выбрать всё"
 msgid "Select Cookies File"
 msgstr "Выберите файл куки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Выберите элементы для загрузки или смените имена файлов."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Выберите папку загрузки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Настройки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1137,19 +1140,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Некоторые загрузки завершились с ошибкой!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Ограничение скорости"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Разделить по главам"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Разделить видео на несколько частей согласно оглавлению."
@@ -1160,19 +1163,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Информация о SponsorBlock (откроется в браузере)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Время начала"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Время начала (Некорректное)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1209,7 +1212,7 @@ msgstr "Языки субтитров (Некорректные)"
 msgid "Success"
 msgstr "Успешно"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1244,7 +1247,7 @@ msgstr ""
 "включено ограничение скорости. Изменение значения не затрагивает уже "
 "запущенные загрузки."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1257,7 +1260,7 @@ msgstr ""
 "Это приведёт к удалению предыдущей связки ключей вместе со всеми паролями в "
 "ней. Это действие необратимо."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "Фёдор Соболев https://github.com/fsobolev"
 
@@ -1266,7 +1269,7 @@ msgstr "Фёдор Соболев https://github.com/fsobolev"
 msgid "Unable to disable keyring."
 msgstr "Невозможно отключить связку ключей."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1275,7 +1278,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Невозможно сбросить связку ключей."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Невозможно установить зависимости. Пожалуйста, перезапустите приложение и "
@@ -1286,7 +1289,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Отменить изменение заголовка"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Разблокировать связку ключей"
 
@@ -1295,7 +1298,7 @@ msgstr "Разблокировать связку ключей"
 msgid "Unset Cookies File"
 msgstr "Выберите файл куки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1347,7 +1350,7 @@ msgid "User Name (Empty)"
 msgstr "Имя пользователя (пустое)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1356,13 +1359,18 @@ msgid "Username"
 msgstr "Имя пользователя"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Проверить"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Проверить"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Видео"
 
@@ -1380,7 +1388,7 @@ msgid "Waiting..."
 msgstr "Ожидание..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Худшее"
 
@@ -1393,10 +1401,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Да"

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-07 16:35+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,14 +20,14 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" загружено."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершилось с ошибкой!"
@@ -134,8 +134,8 @@ msgstr "Добавить учётные данные"
 msgid "Advanced Options"
 msgstr "Дополнительные опции"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Все загрузки завершены."
 
@@ -235,8 +235,8 @@ msgstr "Очистить очередь"
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Закрыть и остановить загрузки?"
 
@@ -413,6 +413,10 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Отключить конвертирование"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Обсуждения"
@@ -420,6 +424,10 @@ msgstr "Обсуждения"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Документация"
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
@@ -432,13 +440,13 @@ msgstr "Загрузка"
 msgid "Download Again"
 msgstr "Скачать снова"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Загрузка завершена"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Загрузка завершилась с ошибкой"
 
@@ -499,8 +507,8 @@ msgstr "Загрузка {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Скачивание..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Загрузки завершены"
 
@@ -630,7 +638,7 @@ msgstr "Firefox"
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
@@ -811,7 +819,7 @@ msgstr "Имя"
 msgid "Name (Empty)"
 msgstr "Имя (пустое)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
@@ -822,15 +830,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Отсутствует подключение к интернету"
 
@@ -897,6 +905,7 @@ msgstr "Выкл"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "ОК"
 
@@ -1016,7 +1025,7 @@ msgid "Queued"
 msgstr "В очереди"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Осталось загрузок: {0}"
@@ -1117,8 +1126,8 @@ msgstr "Настройки"
 msgid "Show Window"
 msgstr "Показать окно"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1201,7 +1210,8 @@ msgstr "Языки субтитров (Некорректные)"
 msgid "Success"
 msgstr "Успешно"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1254,7 +1264,7 @@ msgstr "Фёдор Соболев https://github.com/fsobolev"
 msgid "Unable to disable keyring."
 msgstr "Невозможно отключить связку ключей."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr "Не удалось скачать и установить обновление."
 
@@ -1268,7 +1278,7 @@ msgstr "Невозможно сбросить связку ключей."
 msgid "Undo Title Editing"
 msgstr "Отменить изменение заголовка"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Разблокировать связку ключей"
 
@@ -1276,7 +1286,7 @@ msgstr "Разблокировать связку ключей"
 msgid "Unset Cookies File"
 msgstr "Сбросить файл куки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr "Обновить"
 
@@ -1379,10 +1389,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Да"

--- a/NickvisionTubeConverter.Shared/Resources/po/ru.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ru.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-07 16:35+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tube-converter/app/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-tube-"
+"converter/app/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,20 +20,20 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" загружено."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершилось с ошибкой!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Изменяется в настройках)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} ГиБ/с"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} КиБ/с"
@@ -69,8 +69,8 @@ msgstr[2] "{0} загрузок — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -92,7 +92,7 @@ msgstr ""
 "Можно предоставить файл куки для yt-dlp, чтобы скачивать медиа, которые "
 "требуют входа на сайт."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "О приложении"
@@ -103,18 +103,18 @@ msgstr "О приложении"
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "Добавьте ссылку на видео, аудио или плейлист, чтобы начать загрузку"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -128,14 +128,14 @@ msgid "Add Login"
 msgstr "Добавить учётные данные"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Дополнительные опции"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Все загрузки завершены."
 
@@ -154,17 +154,17 @@ msgstr "Применить"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Язык аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Аутентификация"
@@ -173,7 +173,7 @@ msgstr "Аутентификация"
 msgid "Automatically Check for Updates"
 msgstr "Проверять наличие обновлений автоматически"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -181,7 +181,7 @@ msgid "Back"
 msgstr "Назад"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Лучшее"
 
@@ -193,7 +193,7 @@ msgstr "Отмена"
 msgid "Changelog"
 msgstr "Список изменений"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr "Проверить обновления"
 
@@ -202,8 +202,8 @@ msgstr "Проверить обновления"
 msgid "Chrome/Edge"
 msgstr "Chrome/Edge"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Очистить завершённые загрузки"
@@ -222,21 +222,21 @@ msgstr ""
 "Очистить поля с URL и прочей информацией, по которой можно было бы "
 "определить источник содержимого"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Очистить очередь"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Закрыть и остановить загрузки?"
 
@@ -244,8 +244,8 @@ msgstr "Закрыть и остановить загрузки?"
 msgid "Comma separated list"
 msgstr "Список, разделённый запятыми"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Завершено"
@@ -255,7 +255,7 @@ msgstr "Завершено"
 msgid "Completed Notification Trigger"
 msgstr "Отображение уведомлений"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Соавторы на GitHub ❤️"
 
@@ -301,16 +301,16 @@ msgstr "Авторы"
 msgid "Crop Audio Thumbnails"
 msgstr "Обрезать миниатюры для аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Обрезать миниатюру"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "Давид Лапшин"
 
@@ -324,17 +324,17 @@ msgid "Delete"
 msgstr "Удалить"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Удалить учётные данные?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Убрать всё"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:38
-#, csharp-format, fuzzy
+#, fuzzy, csharp-format
 msgid ""
 "Developers:\n"
 "{0}\n"
@@ -413,15 +413,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Отключить конвертирование"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Обсуждения"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr "Документация"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -432,13 +432,13 @@ msgstr "Загрузка"
 msgid "Download Again"
 msgstr "Скачать снова"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Загрузка завершена"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Загрузка завершилась с ошибкой"
 
@@ -447,17 +447,17 @@ msgstr "Загрузка завершилась с ошибкой"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал загрузки скопирован в буфер обмена."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Загрузить медиа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Скачать фрагмент"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Загрузить субтитры"
@@ -470,20 +470,20 @@ msgstr "Началась загрузка с помощью aria2"
 msgid "Download using ffmpeg has started"
 msgstr "Началась загрузка с помощью ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Загружайте веб-видео и аудио"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Загрузчик"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Загружается"
@@ -499,12 +499,12 @@ msgstr "Загрузка {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Скачивание..."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Загрузки завершены"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Правка"
 
@@ -538,27 +538,27 @@ msgstr ""
 "вы не увидите прогресс загрузки."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Время конца"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Время конца (Некорректное)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr "Введите здесь ссылку на медиа"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Убедитесь, что данные корректны."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr "Введите временную метку конца здесь"
 
@@ -566,7 +566,7 @@ msgstr "Введите временную метку конца здесь"
 msgid "Enter name here"
 msgstr "Введите имя здесь"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr "Введите пароль здесь"
@@ -575,7 +575,7 @@ msgstr "Введите пароль здесь"
 msgid "Enter proxy url here"
 msgstr "Введите ссылку на прокси здесь"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr "Введите временную метку начала здесь"
 
@@ -583,7 +583,7 @@ msgstr "Введите временную метку начала здесь"
 msgid "Enter url here"
 msgstr "Введите ссылку здесь"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr "Введите имя пользователя здесь"
@@ -593,8 +593,8 @@ msgstr "Введите имя пользователя здесь"
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Выход"
 
@@ -603,7 +603,7 @@ msgstr "Выход"
 msgid "Failed to enable keyring."
 msgstr "Не удалось включить связку ключей."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Файл"
 
@@ -616,7 +616,7 @@ msgstr "Файл уже существует, а перезапись файло
 msgid "File Name"
 msgstr "Имя файла"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Тип файла"
@@ -626,23 +626,23 @@ msgstr "Тип файла"
 msgid "Firefox"
 msgstr "Firefox"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Помощь"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -688,14 +688,14 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Связка ключей"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Данные из связки ключей"
@@ -715,13 +715,13 @@ msgstr "Связка ключей заблокирована"
 msgid "Language Code Information"
 msgstr "Информация о языковых кодах"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Оставьте пустым, чтобы скачать с начала."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Список поддерживаемых сайтов"
 
@@ -731,12 +731,12 @@ msgstr "Журнал"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Учётные данные"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Сделать миниатюру квадратной, полезно при скачивании музыки."
@@ -746,7 +746,7 @@ msgstr "Сделать миниатюру квадратной, полезно �
 msgid "Manage previously downloaded media."
 msgstr "Действия с предыдущими загрузками."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -761,11 +761,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Максимальное число активных загрузок"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Максимальное качество"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -776,14 +776,13 @@ msgstr ""
 "При включении этой опции не будет использоваться загрузчик aria2."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Ссылка"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
@@ -802,40 +801,40 @@ msgstr "Минимальный размер фрагмента (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Имя"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Имя (пустое)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Отсутствует подключение к интернету"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 msgid "No Completed Downloads"
 msgstr "Нет завершённых загрузок"
 
@@ -848,7 +847,7 @@ msgstr "Нет учётных данных"
 msgid "No downloads running"
 msgstr "Ничего не загружается"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 msgid "No Downloads Running"
 msgstr "Ничего не загружается"
 
@@ -862,25 +861,25 @@ msgstr "Файл не выбран"
 msgid "No Previous Downloads"
 msgstr "Нет предыдущих загрузок"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 msgid "No Queued Downloads"
 msgstr "Нет загрузок в очереди"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Пронумеровать заголовки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -901,14 +900,14 @@ msgstr "Выкл"
 msgid "OK"
 msgstr "ОК"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -939,23 +938,23 @@ msgstr "Открыть папку"
 msgid "Overwrite Existing Files"
 msgstr "Перезаписывать существующие файлы"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr "Документация и каналы помощи Parabolic доступны через меню Помощь."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -963,7 +962,7 @@ msgid "Password"
 msgstr "Пароль"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Пароль (пустой)"
 
@@ -973,13 +972,13 @@ msgid "Play"
 msgstr "Играть"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "Preparing required tools..."
-msgstr "Подготовка необходимых инструментов..."
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -991,7 +990,7 @@ msgstr "Подготовка..."
 msgid "Prevent Suspend"
 msgstr "Предотвращать приостановку системы"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr "ПРЕДВАРИТЕЛЬНАЯ ВЕРСИЯ"
 
@@ -1005,19 +1004,19 @@ msgstr "Обработка..."
 msgid "Proxy URL"
 msgstr "Адрес прокси-сервера"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Качество"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "В очереди"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Осталось загрузок: {0}"
@@ -1027,7 +1026,7 @@ msgstr "Осталось загрузок: {0}"
 msgid "Remove Source Data"
 msgstr "Удалить метаданные об источнике"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Сообщить об ошибке"
 
@@ -1037,7 +1036,7 @@ msgid "Reset"
 msgstr "Сбросить"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Сбросить связку ключей?"
 
@@ -1062,22 +1061,22 @@ msgstr "Перезапустить для применения темы?"
 msgid "Retry Download"
 msgstr "Попробовать снова"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Перезапустить неудавшиеся загрузки"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Папка сохранения"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Папка сохранения (Некорректная)"
 
@@ -1086,7 +1085,7 @@ msgstr "Папка сохранения (Некорректная)"
 msgid "Search history"
 msgstr "Поиск в истории"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Выбрать всё"
@@ -1097,29 +1096,29 @@ msgstr "Выбрать всё"
 msgid "Select Cookies File"
 msgstr "Выберите файл куки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Выберите элементы для загрузки или смените имена файлов."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Выберите папку загрузки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr "Настройки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr "Показать окно"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1131,19 +1130,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Некоторые загрузки завершились с ошибкой!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Ограничение скорости"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Разделить по главам"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Разделить видео на несколько частей согласно оглавлению."
@@ -1154,19 +1153,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Информация о SponsorBlock (откроется в браузере)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Время начала"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Время начала (Некорректное)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1202,7 +1201,7 @@ msgstr "Языки субтитров (Некорректные)"
 msgid "Success"
 msgstr "Успешно"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1223,7 +1222,7 @@ msgid "Theme"
 msgstr "Тема"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Это действие необратимо. Вы уверены, что хотите удалить?"
 
@@ -1237,12 +1236,8 @@ msgstr ""
 "включено ограничение скорости. Изменение значения не затрагивает уже "
 "запущенные загрузки."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
-msgid "This may take a while"
-msgstr "Это займёт некоторое время"
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1250,36 +1245,30 @@ msgstr ""
 "Это приведёт к удалению предыдущей связки ключей вместе со всеми паролями в "
 "ней. Это действие необратимо."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "Фёдор Соболев https://github.com/fsobolev"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Невозможно отключить связку ключей."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr "Не удалось скачать и установить обновление."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Невозможно сбросить связку ключей."
-
-#: ../../../Controllers/MainWindowController.cs:274
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Невозможно установить зависимости. Пожалуйста, перезапустите приложение и "
-"попробуйте снова."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Отменить изменение заголовка"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Разблокировать связку ключей"
 
@@ -1287,19 +1276,19 @@ msgstr "Разблокировать связку ключей"
 msgid "Unset Cookies File"
 msgstr "Сбросить файл куки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr "Обновить"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Ссылка"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "Ссылка (Некорректная)"
 
@@ -1332,27 +1321,32 @@ msgid "User Interface"
 msgstr "Интерфейс"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 msgid "User Name (Empty)"
 msgstr "Имя пользователя (пусто)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
 msgstr "Имя пользователя"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Проверить"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Проверить"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Видео"
 
@@ -1370,7 +1364,7 @@ msgid "Waiting..."
 msgstr "Ожидание..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Худшее"
 
@@ -1385,10 +1379,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Да"
@@ -1534,6 +1528,17 @@ msgstr "— Запускайте несколько загрузок однов�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Возможно скачать метаданные и субтитры к видео"
+
+#~ msgid "Preparing required tools..."
+#~ msgstr "Подготовка необходимых инструментов..."
+
+#~ msgid "This may take a while"
+#~ msgstr "Это займёт некоторое время"
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Невозможно установить зависимости. Пожалуйста, перезапустите приложение и "
+#~ "попробуйте снова."
 
 #~ msgid "Search..."
 #~ msgstr "Искать..."

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-10-01 08:00+0000\n"
 "Last-Translator: Tomas Andersson <jotakswe@users.noreply.hosted.weblate."
 "org>\n"
@@ -21,13 +21,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" har laddats ned."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" har avslutats med ett fel!"
@@ -101,7 +101,7 @@ msgstr "Om {0}"
 msgid "Add"
 msgstr "Lägg till"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -111,9 +111,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -134,7 +134,7 @@ msgid "Advanced Options"
 msgstr "Avancerade inställningar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Alla nedladdningar är klara."
 
@@ -202,7 +202,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Rensa slutförda nedladdningar"
@@ -222,7 +222,7 @@ msgstr ""
 "information om mediekällan"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -235,7 +235,7 @@ msgid "Close"
 msgstr "Stäng"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Stänga och stoppa nedladdningarna?"
 
@@ -243,8 +243,8 @@ msgstr "Stänga och stoppa nedladdningarna?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Slutförda"
@@ -254,7 +254,7 @@ msgstr "Slutförda"
 msgid "Completed Notification Trigger"
 msgstr "Avslutad aviseringsutlösare"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "Bidragsgivare på GitHub ❤️"
 
@@ -307,11 +307,11 @@ msgstr "Beskär ljudminiatyrbilder"
 msgid "Crop Thumbnail"
 msgstr "Beskär miniatyrbild"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -325,7 +325,7 @@ msgid "Delete"
 msgstr "Radera"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Ta bort autentiseringsuppgifter?"
 
@@ -424,12 +424,12 @@ msgid "Download Again"
 msgstr "Ladda ner igen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Nedladdning klar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Nedladdningen slutfördes med fel"
 
@@ -438,7 +438,7 @@ msgstr "Nedladdningen slutfördes med fel"
 msgid "Download log was copied to clipboard."
 msgstr "Nedladdningsloggen kopierades till urklipp."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Ladda ned media"
@@ -461,7 +461,7 @@ msgstr "Nedladdning med aria2 har startat"
 msgid "Download using ffmpeg has started"
 msgstr "Nedladdning med ffmpeg har startat"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -473,8 +473,8 @@ msgstr "Ladda ner webbvideo och ljud"
 msgid "Downloader"
 msgstr "Nedladdare"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Laddar ned"
@@ -492,7 +492,7 @@ msgid "Downloading..."
 msgstr "Laddar ned"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Nedladdningarna är klara"
 
@@ -594,7 +594,7 @@ msgid "Error"
 msgstr "Fel"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Avsluta"
 
@@ -626,7 +626,7 @@ msgstr "Filtyp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -690,7 +690,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -723,7 +723,7 @@ msgstr "Information om språkkod"
 msgid "Leave empty to download from start."
 msgstr "Lämna tomt för att ladda ned från början."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Lista över webbplatser som stöds"
 
@@ -734,8 +734,8 @@ msgstr "Logga in"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Logga in"
 
@@ -749,7 +749,7 @@ msgstr "Gör miniatyrbilden fyrkantig, användbart när du laddar ner musik."
 msgid "Manage previously downloaded media."
 msgstr "Hantera tidigare nedladdade media."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -803,40 +803,40 @@ msgstr "Minsta delade storlek (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Namn"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Namn (tomt)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nej"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Ingen aktiv internetanslutning"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Rensa slutförda nedladdningar"
@@ -850,7 +850,7 @@ msgstr "Inga inloggningsuppgifter"
 msgid "No downloads running"
 msgstr "Inga nedladdningar körs"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Inga nedladdningar körs"
@@ -865,7 +865,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Inga tidigare nedladdningar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Rensa köade nedladdningar"
@@ -944,14 +944,14 @@ msgstr "Öppna mapp"
 msgid "Overwrite Existing Files"
 msgstr "Skriv över existerande filer"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -960,7 +960,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -968,7 +968,7 @@ msgid "Password"
 msgstr "Lösenord"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Lösenord (tomt)"
 
@@ -985,11 +985,6 @@ msgstr "Spellista"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Förbereder..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1020,14 +1015,14 @@ msgstr "Proxy URL"
 msgid "Quality"
 msgstr "Kvalitet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Köas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Återstående nedladdningar: {0}"
@@ -1047,7 +1042,7 @@ msgid "Reset"
 msgstr "Nollställ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Nollställa nyckelringen?"
 
@@ -1073,7 +1068,7 @@ msgid "Retry Download"
 msgstr "Försök ladda ner igen"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1120,18 +1115,18 @@ msgid "Select Save Folder"
 msgstr "Välj lagringsmapp"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Inställningar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1179,7 +1174,7 @@ msgid "Start Time (Invalid)"
 msgstr "Starttid (ogiltig)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1237,7 +1232,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Denna åtgärd är oåterkallelig. Är du säker på att du vill ta bort den?"
 
@@ -1250,12 +1245,8 @@ msgstr ""
 "Denna gräns (i KiB/s) tillämpas på nedladdningar som har hastighetsgräns "
 "aktiverad. Att ändra värdet påverkar inte nedladdningar som redan körs."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1263,34 +1254,30 @@ msgstr ""
 "Detta tar bort den tidigare nyckelringen, och tar bort alla lösenord med "
 "den. Denna åtgärd är oåterkallelig."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "översättarkredits"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Det går inte att inaktivera nyckelringen."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Det gick inte att nollställa nyckelringen."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr "Det går inte att ställa in beroenden. Starta om appen och försök igen."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Ångra titelredigering"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Lås upp nyckelring"
 
@@ -1299,19 +1286,19 @@ msgstr "Lås upp nyckelring"
 msgid "Unset Cookies File"
 msgstr "Välj Cookies fil"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (ogiltig)"
 
@@ -1345,7 +1332,7 @@ msgid "User Interface"
 msgstr "Användargränssnitt"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Användarnamn (tomt)"
@@ -1353,7 +1340,7 @@ msgstr "Användarnamn (tomt)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1403,9 +1390,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"
@@ -1552,6 +1539,14 @@ msgstr "— Kör flera nedladdningar samtidigt"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Stöder nedladdning av metadata och video undertexter"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Förbereder..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Det går inte att ställa in beroenden. Starta om appen och försök igen."
 
 #~ msgid "Search..."
 #~ msgstr "Sök..."

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-10-01 08:00+0000\n"
 "Last-Translator: Tomas Andersson <jotakswe@users.noreply.hosted.weblate."
 "org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" har laddats ned."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" har avslutats med ett fel!"
@@ -133,8 +133,8 @@ msgstr "Lägg till inloggning"
 msgid "Advanced Options"
 msgstr "Avancerade inställningar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Alla nedladdningar är klara."
 
@@ -234,8 +234,8 @@ msgstr "Rensa köade nedladdningar"
 msgid "Close"
 msgstr "Stäng"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Stänga och stoppa nedladdningarna?"
 
@@ -404,12 +404,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Tillåt inte konverteringar"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskussioner"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -423,13 +431,13 @@ msgstr "Ladda ner"
 msgid "Download Again"
 msgstr "Ladda ner igen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Nedladdning klar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Nedladdningen slutfördes med fel"
 
@@ -491,8 +499,8 @@ msgstr "Laddar ned {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Laddar ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Nedladdningarna är klara"
 
@@ -630,7 +638,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
@@ -813,7 +821,7 @@ msgstr "Namn"
 msgid "Name (Empty)"
 msgstr "Namn (tomt)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -824,15 +832,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nej"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Ingen aktiv internetanslutning"
 
@@ -902,6 +910,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "OK"
 
@@ -1022,7 +1031,7 @@ msgid "Queued"
 msgstr "Köas"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Återstående nedladdningar: {0}"
@@ -1125,8 +1134,8 @@ msgstr "Inställningar"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1211,7 +1220,8 @@ msgstr "Undertextspråk (ogiltigt)"
 msgid "Success"
 msgstr "Klar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1263,7 +1273,7 @@ msgstr "översättarkredits"
 msgid "Unable to disable keyring."
 msgstr "Det går inte att inaktivera nyckelringen."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1277,7 +1287,7 @@ msgstr "Det gick inte att nollställa nyckelringen."
 msgid "Undo Title Editing"
 msgstr "Ångra titelredigering"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Lås upp nyckelring"
 
@@ -1286,7 +1296,7 @@ msgstr "Lås upp nyckelring"
 msgid "Unset Cookies File"
 msgstr "Välj Cookies fil"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1389,10 +1399,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/sv.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-10-01 08:00+0000\n"
 "Last-Translator: Tomas Andersson <jotakswe@users.noreply.hosted.weblate."
 "org>\n"
@@ -20,20 +20,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" har laddats ned."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" har avslutats med ett fel!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Konfigurerbar i inställningarna)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -68,8 +68,8 @@ msgstr[1] "{0} nedladdningarna — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -90,7 +90,7 @@ msgstr ""
 "En cookies fil kan tillhandahållas till yt-dlp för att tillåta nedladdning "
 "av media som kräver inloggning."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Om {0}"
@@ -101,19 +101,19 @@ msgstr "Om {0}"
 msgid "Add"
 msgstr "Lägg till"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 "Lägg till en URL för video, ljud eller spellista för att börja ladda ned"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -127,14 +127,14 @@ msgid "Add Login"
 msgstr "Lägg till inloggning"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Avancerade inställningar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Alla nedladdningar är klara."
 
@@ -153,17 +153,17 @@ msgstr "Tillämpa"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Ljud"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Ljudspråk"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Autentisera"
@@ -172,7 +172,7 @@ msgstr "Autentisera"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -180,7 +180,7 @@ msgid "Back"
 msgstr "Tillbaka"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Bäst"
 
@@ -192,7 +192,7 @@ msgstr "Avbryt"
 msgid "Changelog"
 msgstr "Ändringslogg"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -201,8 +201,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Rensa slutförda nedladdningar"
@@ -221,21 +221,21 @@ msgstr ""
 "Rensa metadatafält som innehåller webbadresser och annan identifierbar "
 "information om mediekällan"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Rensa köade nedladdningar"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Stäng"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Stänga och stoppa nedladdningarna?"
 
@@ -243,8 +243,8 @@ msgstr "Stänga och stoppa nedladdningarna?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Slutförda"
@@ -254,7 +254,7 @@ msgstr "Slutförda"
 msgid "Completed Notification Trigger"
 msgstr "Avslutad aviseringsutlösare"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "Bidragsgivare på GitHub ❤️"
 
@@ -302,16 +302,16 @@ msgstr "Bidragsgivare"
 msgid "Crop Audio Thumbnails"
 msgstr "Beskär ljudminiatyrbilder"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Beskär miniatyrbild"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -329,7 +329,7 @@ msgstr "Radera"
 msgid "Delete Credential?"
 msgstr "Ta bort autentiseringsuppgifter?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Avmarkera alla"
@@ -404,15 +404,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Tillåt inte konverteringar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Diskussioner"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -423,13 +423,13 @@ msgstr "Ladda ner"
 msgid "Download Again"
 msgstr "Ladda ner igen"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Nedladdning klar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Nedladdningen slutfördes med fel"
 
@@ -438,17 +438,17 @@ msgstr "Nedladdningen slutfördes med fel"
 msgid "Download log was copied to clipboard."
 msgstr "Nedladdningsloggen kopierades till urklipp."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Ladda ned media"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Ladda ner specifik tidsram"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Ladda ner undertext"
@@ -461,20 +461,20 @@ msgstr "Nedladdning med aria2 har startat"
 msgid "Download using ffmpeg has started"
 msgstr "Nedladdning med ffmpeg har startat"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Ladda ner webbvideo och ljud"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Nedladdare"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Laddar ned"
@@ -491,12 +491,12 @@ msgstr "Laddar ned {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Laddar ned"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Nedladdningarna är klara"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Redigera"
 
@@ -530,28 +530,28 @@ msgstr ""
 "kommer inte kunna se nedladdningsförloppet."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Sluttid"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Sluttid (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Ange media-URL här"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Se till att inloggningsuppgifterna är korrekta."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Ange media-URL här"
@@ -561,7 +561,7 @@ msgstr "Ange media-URL här"
 msgid "Enter name here"
 msgstr "Ange media-URL här"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -572,7 +572,7 @@ msgstr "Ange media-URL här"
 msgid "Enter proxy url here"
 msgstr "Ange media-URL här"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Ange media-URL här"
@@ -582,7 +582,7 @@ msgstr "Ange media-URL här"
 msgid "Enter url here"
 msgstr "Ange media-URL här"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -593,8 +593,8 @@ msgstr "Ange media-URL här"
 msgid "Error"
 msgstr "Fel"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Avsluta"
 
@@ -603,7 +603,7 @@ msgstr "Avsluta"
 msgid "Failed to enable keyring."
 msgstr "Det gick inte att aktivera nyckelringen."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Fil"
 
@@ -616,7 +616,7 @@ msgstr "Filen finns redan och överskrivning är inte tillåten"
 msgid "File Name"
 msgstr "Filnamn"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Filtyp"
@@ -626,23 +626,23 @@ msgstr "Filtyp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Hjälp"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -691,13 +691,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Nyckelring"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Nyckelringsuppgifter"
@@ -717,13 +717,13 @@ msgstr "Nyckelring låst"
 msgid "Language Code Information"
 msgstr "Information om språkkod"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Lämna tomt för att ladda ned från början."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Lista över webbplatser som stöds"
 
@@ -739,7 +739,7 @@ msgstr "Logga in"
 msgid "Login"
 msgstr "Logga in"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Gör miniatyrbilden fyrkantig, användbart när du laddar ner musik."
@@ -749,7 +749,7 @@ msgstr "Gör miniatyrbilden fyrkantig, användbart när du laddar ner musik."
 msgid "Manage previously downloaded media."
 msgstr "Hantera tidigare nedladdade media."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -764,11 +764,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Max antal aktiva nedladdningar"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Maximal kvalitet"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -780,14 +780,13 @@ msgstr ""
 "aria2 som nedladdare om det är aktiverat."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Media URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Media URL (ogiltig)"
 
@@ -814,30 +813,30 @@ msgstr "Namn"
 msgid "Name (Empty)"
 msgstr "Namn (tomt)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Nej"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Ingen aktiv internetanslutning"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Rensa slutförda nedladdningar"
@@ -851,7 +850,7 @@ msgstr "Inga inloggningsuppgifter"
 msgid "No downloads running"
 msgstr "Inga nedladdningar körs"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Inga nedladdningar körs"
@@ -866,26 +865,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Inga tidigare nedladdningar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Rensa köade nedladdningar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Antal titlar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -906,14 +905,14 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -945,21 +944,21 @@ msgstr "Öppna mapp"
 msgid "Overwrite Existing Files"
 msgstr "Skriv över existerande filer"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -979,11 +978,15 @@ msgid "Play"
 msgstr "Spela upp"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Spellista"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Förbereder..."
@@ -998,7 +1001,7 @@ msgstr "Förbereder..."
 msgid "Prevent Suspend"
 msgstr "Förhindra Suspend"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1012,19 +1015,19 @@ msgstr "Bearbetar..."
 msgid "Proxy URL"
 msgstr "Proxy URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kvalitet"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Köas"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Återstående nedladdningar: {0}"
@@ -1034,7 +1037,7 @@ msgstr "Återstående nedladdningar: {0}"
 msgid "Remove Source Data"
 msgstr "Ta bort källinformation"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Rapportera ett problem"
 
@@ -1069,22 +1072,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Försök ladda ner igen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Ladda ner misslyckade nedladdningar igen"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Lagringsmapp"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Lagringsmapp (ogiltig)"
 
@@ -1094,7 +1097,7 @@ msgstr "Lagringsmapp (ogiltig)"
 msgid "Search history"
 msgstr "Rensa historiken"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Välj alla"
@@ -1105,30 +1108,30 @@ msgstr "Välj alla"
 msgid "Select Cookies File"
 msgstr "Välj Cookies fil"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Välj objekt att ladda ned eller ändra filnamn."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Välj lagringsmapp"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Inställningar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1141,19 +1144,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Vissa nedladdningar avslutades med fel!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hastighetsgräns"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Dela upp kapitlen"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Delar upp videon i flera mindre delar baserat på kapitlen."
@@ -1164,19 +1167,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "SponsorBlock Information (öppnas i en webbläsare)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Starttid"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Starttid (ogiltig)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1213,7 +1216,7 @@ msgstr "Undertextspråk (ogiltigt)"
 msgid "Success"
 msgstr "Klar"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1247,7 +1250,7 @@ msgstr ""
 "Denna gräns (i KiB/s) tillämpas på nedladdningar som har hastighetsgräns "
 "aktiverad. Att ändra värdet påverkar inte nedladdningar som redan körs."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1260,7 +1263,7 @@ msgstr ""
 "Detta tar bort den tidigare nyckelringen, och tar bort alla lösenord med "
 "den. Denna åtgärd är oåterkallelig."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "översättarkredits"
 
@@ -1269,7 +1272,7 @@ msgstr "översättarkredits"
 msgid "Unable to disable keyring."
 msgstr "Det går inte att inaktivera nyckelringen."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1278,7 +1281,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Det gick inte att nollställa nyckelringen."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr "Det går inte att ställa in beroenden. Starta om appen och försök igen."
 
@@ -1287,7 +1290,7 @@ msgstr "Det går inte att ställa in beroenden. Starta om appen och försök ige
 msgid "Undo Title Editing"
 msgstr "Ångra titelredigering"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Lås upp nyckelring"
 
@@ -1296,7 +1299,7 @@ msgstr "Lås upp nyckelring"
 msgid "Unset Cookies File"
 msgstr "Välj Cookies fil"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1348,7 +1351,7 @@ msgid "User Name (Empty)"
 msgstr "Användarnamn (tomt)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1357,13 +1360,18 @@ msgid "Username"
 msgstr "Användarnamn"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Validera"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Validera"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1381,7 +1389,7 @@ msgid "Waiting..."
 msgstr "Väntar..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Sämsta"
 
@@ -1394,10 +1402,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Ja"

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-11-03 03:31+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" வின் பதிவிறக்கம் முடிந்தது."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" பிழையுடன் முடிந்தது!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(விருப்பங்களில் கட்டமைக்கக்கூடியது)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} ஜிபிபைட்/வினாடி (GiB/s)"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} கிலோபிட்/வினாடி (KiB/s)"
@@ -67,8 +67,8 @@ msgstr[1] "{0} பதிவிறக்கங்கள் — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "உள்நுழைவு தேவைப்படும் மீடியாவைப் பதிவிறக்க அனுமதிக்க குக்கீகள் கோப்பு yt-dlp க்கு "
 "வழங்கப்படலாம்."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -100,18 +100,18 @@ msgstr ""
 msgid "Add"
 msgstr "சேர்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "பதிவிறக்கம் செய்ய, காணொளி, ஒலி அமைவு அல்லது பாடல் பட்டியல் URL ஐச் சேர்க்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr "உள்நுழைவைச் சேர்க்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "மேம்பட்ட விருப்பங்கள்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "அனைத்து பதிவிறக்கங்களும் முடிந்துவிட்டன."
 
@@ -151,17 +151,17 @@ msgstr "விண்ணப்பிக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "ஒலி அமைவு"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "ஒலி மொழி"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "அங்கீகரிக்கவும்"
@@ -170,7 +170,7 @@ msgstr "அங்கீகரிக்கவும்"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr "திரும்பவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "சிறந்த"
 
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "முடிக்கப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
@@ -220,21 +220,21 @@ msgstr ""
 "ஊடகம் மூலத்திற்கு வழிவகுக்கும் URL மற்றும் மற்றொரு தரவைக் கொண்ட மெட்டாடேட்டா புலங்களை "
 "அழிக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "வரிசைப்படுத்தப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "பதிவிறக்கங்களை மூடிவிட்டு நிறுத்தவா?"
 
@@ -242,8 +242,8 @@ msgstr "பதிவிறக்கங்களை மூடிவிட்ட�
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "முடிக்கப்பட்டது"
@@ -253,7 +253,7 @@ msgstr "முடிக்கப்பட்டது"
 msgid "Completed Notification Trigger"
 msgstr "நிறைவு செய்யப்பட்ட அறிவிப்பு தூண்டுதல்"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub இல் பங்களிப்பாளர்கள் ❤️"
 
@@ -302,16 +302,16 @@ msgstr "சான்றுகள்"
 msgid "Crop Audio Thumbnails"
 msgstr "ஒலி அமைப்பு சிறுபடங்களை செதுக்கு"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "சிறுபடத்தை வெட்டவும்"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "டேவிட் லாப்ஷின்"
 
@@ -329,7 +329,7 @@ msgstr "நீக்கு"
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "அனைத்து தெரிவுகளையும் நிராகரி"
@@ -401,15 +401,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "மாற்றங்களை அனுமதிக்காதே"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -420,13 +420,13 @@ msgstr "பதிவிறக்கு"
 msgid "Download Again"
 msgstr "மீண்டும் பதிவிறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "பதிவிறக்கம் முடிந்தது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "பதிவிறக்கம் பிழையுடன் முடிந்தது"
 
@@ -435,17 +435,17 @@ msgstr "பதிவிறக்கம் பிழையுடன் முட�
 msgid "Download log was copied to clipboard."
 msgstr "பதிவிறக்கப் பதிவு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "ஊடகத்தைப் பதிவிறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "குறிப்பிட்ட காலக்கெடுவைப் பதிவிறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "வசனத்தைப் பதிவிறக்கவும்"
@@ -458,20 +458,20 @@ msgstr "aria2 ஐப் பயன்படுத்தி பதிவிறக�
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg ஐப் பயன்படுத்தி பதிவிறக்கம் தொடங்கப்பட்டது"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "இணைய காணொளி மற்றும் ஒலி அமைவைப் பதிவிறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "பதிவிறக்குபவர்"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "பதிவிறக்குகிறது"
@@ -488,12 +488,12 @@ msgstr "பதிவிறக்குகிறது {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "பதிவிறக்குகிறது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "பதிவிறக்கங்கள் முடிந்தது"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -528,27 +528,27 @@ msgstr ""
 "முன்னேற்றத்தைக் காண மாட்டீர்கள்."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "முடிவு நேரம்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "முடிவு நேரம் (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "சான்றுகள் சரியானவை என்பதை உறுதிப்படுத்தவும்."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -583,8 +583,8 @@ msgstr ""
 msgid "Error"
 msgstr "பிழை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "சாவி வலயத்தை இயக்குவதில் தோல்வி."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "கோப்பு பெயர்"
@@ -607,7 +607,7 @@ msgstr "கோப்பு ஏற்கனவே உள்ளது, மேல�
 msgid "File Name"
 msgstr "கோப்பு பெயர்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "கோப்பு வகை"
@@ -617,23 +617,23 @@ msgstr "கோப்பு வகை"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "ஃபியோடர் சோபோலேவ்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub களஞ்சியம்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "உதவி"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -679,13 +679,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "சாவி வளையம்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "சாவி வளைய நற்சான்றிதழ்"
@@ -705,13 +705,13 @@ msgstr "சாவி வளையம் பூட்டப்பட்டது"
 msgid "Language Code Information"
 msgstr "மொழி குறியீடு தகவல்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "தொடக்கத்தில் இருந்து பதிவிறக்கம் செய்ய காலியாக விடவும்."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "ஆதரிக்கப்படும் தளங்களின் பட்டியல்"
 
@@ -727,7 +727,7 @@ msgstr "உள்நுழை"
 msgid "Login"
 msgstr "உள்நுழை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "இசை பதிவிறக்கம் செய்யும் போது உபயோகமான சிறுபடவுரு சதுரத்தை உருவாக்கவும்."
@@ -737,7 +737,7 @@ msgstr "இசை பதிவிறக்கம் செய்யும் ப
 msgid "Manage previously downloaded media."
 msgstr "முன்பு பதிவிறக்கம் செய்யப்பட்ட மீடியாவை நிர்வகிக்கவும்."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "மேட்ரிக்ஸ் மன்றம்"
 
@@ -752,11 +752,11 @@ msgid "Max Number of Active Downloads"
 msgstr "செயலில் உள்ள பதிவிறக்கங்களின் அதிகபட்ச எண்ணிக்கை"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "அதிகபட்ச தரம்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -768,14 +768,13 @@ msgstr ""
 "பயன்படுத்துவது முடக்கப்படும்."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "ஊடகத்தின் URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "ஊடகத்தின் URL (செல்லாதது)"
 
@@ -802,30 +801,30 @@ msgstr "பெயர்"
 msgid "Name (Empty)"
 msgstr "பெயர் (காலி)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "நிக்கோலஸ் லோகோசோ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "இல்லை"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "செயலில் இணைய இணைப்பு இல்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "முடிக்கப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
@@ -839,7 +838,7 @@ msgstr "நற்சான்றிதழ்கள் இல்லை"
 msgid "No downloads running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
@@ -854,26 +853,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "முந்தைய பதிவிறக்கங்கள் இல்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "வரிசைப்படுத்தப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "எண் தலைப்புகள்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -894,14 +893,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -933,21 +932,21 @@ msgstr "கோப்புறையைத் திறக்கவும்"
 msgid "Overwrite Existing Files"
 msgstr "ஏற்கனவே உள்ள கோப்புகளை மேலெழுதவும்"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "பரபோலிக்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -967,11 +966,15 @@ msgid "Play"
 msgstr "தொடங்கு"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "பாடல் பட்டியல்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "தயாராகிறது..."
@@ -986,7 +989,7 @@ msgstr "தயாராகிறது..."
 msgid "Prevent Suspend"
 msgstr "இடைநிறுத்தத்தைத் தடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1000,19 +1003,19 @@ msgstr "செயலாக்குகிறது..."
 msgid "Proxy URL"
 msgstr "ப்ராக்ஸி URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "தரம்"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "வரிசையில் நிற்கிறது"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "தோல்வியடைந்த பதிவிறக்கங்களை மீண்டும் முயற்சிக்கவும்"
@@ -1022,7 +1025,7 @@ msgstr "தோல்வியடைந்த பதிவிறக்கங்�
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1057,22 +1060,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "பதிவிறக்க மீண்டும் முயற்சிக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "தோல்வியடைந்த பதிவிறக்கங்களை மீண்டும் முயற்சிக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "கோப்புறையை சேமி"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "கோப்புறையைச் சேமி (செல்லாதது)"
 
@@ -1082,7 +1085,7 @@ msgstr "கோப்புறையைச் சேமி (செல்லாத
 msgid "Search history"
 msgstr "வரலாற்றை அழிக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "அனைத்தையும் தெரிவுசெய்"
@@ -1093,29 +1096,29 @@ msgstr "அனைத்தையும் தெரிவுசெய்"
 msgid "Select Cookies File"
 msgstr "குக்கீகள் கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "கோப்புப் பெயர்களைப் பதிவிறக்க அல்லது மாற்ற உருப்படிகளைத் தேர்ந்தெடுக்கவும்."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "சேமி கோப்புறையை தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1127,19 +1130,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "சில பதிவிறக்கங்கள் பிழைகளுடன் முடிந்தது!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "வேக வரம்பு"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "அத்தியாயங்களைப் பிரிக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "காணொளியை அதன் அத்தியாயங்களின் அடிப்படையில் பல சிறியதாகப் பிரிக்கிறது."
@@ -1150,19 +1153,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "SponsorBlock தகவல் (இணைய உலாவியில் திறக்கும்)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "ஆரம்பிக்கும் நேரம்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "தொடக்க நேரம் (செல்லாதது)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1199,7 +1202,7 @@ msgstr "வசன மொழிகள் (செல்லாதது)"
 msgid "Success"
 msgstr "வெற்றி"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1233,7 +1236,7 @@ msgstr ""
 "வேக வரம்பு இயக்கப்பட்ட பதிவிறக்கங்களுக்கு இந்த வரம்பு (KiB/s - கிலோபிட்/வினாடி இல்) "
 "பயன்படுத்தப்படும். மதிப்பை மாற்றுவது ஏற்கனவே இயங்கும் பதிவிறக்கங்களைப் பாதிக்காது."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1246,7 +1249,7 @@ msgstr ""
 "இது அனைத்து கடவுச்சொற்களையும் அகற்றும் முந்தைய சாவி வலயத்தை நீக்கும். இந்த நடவடிக்கை மீள "
 "முடியாதது."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>, 2023"
 
@@ -1255,7 +1258,7 @@ msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>, 2023"
 msgid "Unable to disable keyring."
 msgstr "சாவி வலயத்தை முடக்க முடியவில்லை."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1264,7 +1267,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "சாவி வலயத்தை மீட்டமைக்க முடியவில்லை."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr "சார்புகளை அமைக்க முடியவில்லை. பயன்பாட்டை மறுதொடக்கம் செய்து மீண்டும் முயற்சிக்கவும்."
 
@@ -1273,7 +1276,7 @@ msgstr "சார்புகளை அமைக்க முடியவில�
 msgid "Undo Title Editing"
 msgstr "தலைப்பு திருத்தத்தை செயல்தவிர்க்கவும்"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "சாவி வளையத்தைத் திறக்கவும்"
 
@@ -1282,7 +1285,7 @@ msgstr "சாவி வளையத்தைத் திறக்கவும�
 msgid "Unset Cookies File"
 msgstr "குக்கீகள் கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1334,7 +1337,7 @@ msgid "User Name (Empty)"
 msgstr "பயனர் பெயர் (காலி)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1343,13 +1346,18 @@ msgid "Username"
 msgstr "பயனர் பெயர்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "சரிபார்க்கவும்"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "சரிபார்க்கவும்"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "காணொளி"
 
@@ -1367,7 +1375,7 @@ msgid "Waiting..."
 msgstr "காத்திருக்கிறது..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "மோசமான"
 
@@ -1380,10 +1388,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ஆம்"

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-11-03 03:31+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.2-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" வின் பதிவிறக்கம் முடிந்தது."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" பிழையுடன் முடிந்தது!"
@@ -100,7 +100,7 @@ msgstr ""
 msgid "Add"
 msgstr "சேர்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "பதிவிறக்கம் செய்ய, காணொளி, ஒலி அமைவு அல்லது பாடல் பட்டியல் URL ஐச் சேர்க்கவும்"
@@ -109,9 +109,9 @@ msgstr "பதிவிறக்கம் செய்ய, காணொளி
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "மேம்பட்ட விருப்பங்கள்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "அனைத்து பதிவிறக்கங்களும் முடிந்துவிட்டன."
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "முடிக்கப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
@@ -221,7 +221,7 @@ msgstr ""
 "அழிக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -234,7 +234,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "பதிவிறக்கங்களை மூடிவிட்டு நிறுத்தவா?"
 
@@ -242,8 +242,8 @@ msgstr "பதிவிறக்கங்களை மூடிவிட்ட�
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "முடிக்கப்பட்டது"
@@ -253,7 +253,7 @@ msgstr "முடிக்கப்பட்டது"
 msgid "Completed Notification Trigger"
 msgstr "நிறைவு செய்யப்பட்ட அறிவிப்பு தூண்டுதல்"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub இல் பங்களிப்பாளர்கள் ❤️"
 
@@ -307,11 +307,11 @@ msgstr "ஒலி அமைப்பு சிறுபடங்களை செ
 msgid "Crop Thumbnail"
 msgstr "சிறுபடத்தை வெட்டவும்"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "டேவிட் லாப்ஷின்"
 
@@ -325,7 +325,7 @@ msgid "Delete"
 msgstr "நீக்கு"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "நற்சான்றிதழை நீக்கவா?"
 
@@ -421,12 +421,12 @@ msgid "Download Again"
 msgstr "மீண்டும் பதிவிறக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "பதிவிறக்கம் முடிந்தது"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "பதிவிறக்கம் பிழையுடன் முடிந்தது"
 
@@ -435,7 +435,7 @@ msgstr "பதிவிறக்கம் பிழையுடன் முட�
 msgid "Download log was copied to clipboard."
 msgstr "பதிவிறக்கப் பதிவு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "ஊடகத்தைப் பதிவிறக்கவும்"
@@ -458,7 +458,7 @@ msgstr "aria2 ஐப் பயன்படுத்தி பதிவிறக�
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg ஐப் பயன்படுத்தி பதிவிறக்கம் தொடங்கப்பட்டது"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -470,8 +470,8 @@ msgstr "இணைய காணொளி மற்றும் ஒலி அ�
 msgid "Downloader"
 msgstr "பதிவிறக்குபவர்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "பதிவிறக்குகிறது"
@@ -489,7 +489,7 @@ msgid "Downloading..."
 msgstr "பதிவிறக்குகிறது"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "பதிவிறக்கங்கள் முடிந்தது"
 
@@ -584,7 +584,7 @@ msgid "Error"
 msgstr "பிழை"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -617,7 +617,7 @@ msgstr "கோப்பு வகை"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "ஃபியோடர் சோபோலேவ்"
 
@@ -678,7 +678,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -711,7 +711,7 @@ msgstr "மொழி குறியீடு தகவல்"
 msgid "Leave empty to download from start."
 msgstr "தொடக்கத்தில் இருந்து பதிவிறக்கம் செய்ய காலியாக விடவும்."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "ஆதரிக்கப்படும் தளங்களின் பட்டியல்"
 
@@ -722,8 +722,8 @@ msgstr "உள்நுழை"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "உள்நுழை"
 
@@ -737,7 +737,7 @@ msgstr "இசை பதிவிறக்கம் செய்யும் ப
 msgid "Manage previously downloaded media."
 msgstr "முன்பு பதிவிறக்கம் செய்யப்பட்ட மீடியாவை நிர்வகிக்கவும்."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "மேட்ரிக்ஸ் மன்றம்"
 
@@ -791,40 +791,40 @@ msgstr "குறைந்தபட்ச பிளவு அளவு (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "பெயர்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "பெயர் (காலி)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "நிக்கோலஸ் லோகோசோ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "இல்லை"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "செயலில் இணைய இணைப்பு இல்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "முடிக்கப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
@@ -838,7 +838,7 @@ msgstr "நற்சான்றிதழ்கள் இல்லை"
 msgid "No downloads running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "பதிவிறக்கங்கள் எதுவும் இயங்கவில்லை"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "முந்தைய பதிவிறக்கங்கள் இல்லை"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "வரிசைப்படுத்தப்பட்ட பதிவிறக்கங்களை அழிக்கவும்"
@@ -932,14 +932,14 @@ msgstr "கோப்புறையைத் திறக்கவும்"
 msgid "Overwrite Existing Files"
 msgstr "ஏற்கனவே உள்ள கோப்புகளை மேலெழுதவும்"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "பரபோலிக்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -948,7 +948,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -956,7 +956,7 @@ msgid "Password"
 msgstr "கடவுச்சொல்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "கடவுச்சொல் (காலி)"
 
@@ -973,11 +973,6 @@ msgstr "பாடல் பட்டியல்"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "தயாராகிறது..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1008,14 +1003,14 @@ msgstr "ப்ராக்ஸி URL"
 msgid "Quality"
 msgstr "தரம்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "வரிசையில் நிற்கிறது"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "தோல்வியடைந்த பதிவிறக்கங்களை மீண்டும் முயற்சிக்கவும்"
@@ -1035,7 +1030,7 @@ msgid "Reset"
 msgstr "மீட்டமைக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "சாவி வளையத்தை மீட்டமைக்கவா?"
 
@@ -1061,7 +1056,7 @@ msgid "Retry Download"
 msgstr "பதிவிறக்க மீண்டும் முயற்சிக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1108,17 +1103,17 @@ msgid "Select Save Folder"
 msgstr "சேமி கோப்புறையை தேர்ந்தெடுக்கவும்"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1165,7 +1160,7 @@ msgid "Start Time (Invalid)"
 msgstr "தொடக்க நேரம் (செல்லாதது)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1223,7 +1218,7 @@ msgid "Theme"
 msgstr "தீம்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "இந்த நடவடிக்கை மீள முடியாதது. நிச்சயமாக அதை நீக்க வேண்டுமா?"
 
@@ -1236,12 +1231,8 @@ msgstr ""
 "வேக வரம்பு இயக்கப்பட்ட பதிவிறக்கங்களுக்கு இந்த வரம்பு (KiB/s - கிலோபிட்/வினாடி இல்) "
 "பயன்படுத்தப்படும். மதிப்பை மாற்றுவது ஏற்கனவே இயங்கும் பதிவிறக்கங்களைப் பாதிக்காது."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1249,34 +1240,30 @@ msgstr ""
 "இது அனைத்து கடவுச்சொற்களையும் அகற்றும் முந்தைய சாவி வலயத்தை நீக்கும். இந்த நடவடிக்கை மீள "
 "முடியாதது."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>, 2023"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "சாவி வலயத்தை முடக்க முடியவில்லை."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "சாவி வலயத்தை மீட்டமைக்க முடியவில்லை."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr "சார்புகளை அமைக்க முடியவில்லை. பயன்பாட்டை மறுதொடக்கம் செய்து மீண்டும் முயற்சிக்கவும்."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "தலைப்பு திருத்தத்தை செயல்தவிர்க்கவும்"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "சாவி வளையத்தைத் திறக்கவும்"
 
@@ -1285,19 +1272,19 @@ msgstr "சாவி வளையத்தைத் திறக்கவும�
 msgid "Unset Cookies File"
 msgstr "குக்கீகள் கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (செல்லாதது)"
 
@@ -1331,7 +1318,7 @@ msgid "User Interface"
 msgstr "பயனர் இடைமுகம்"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "பயனர் பெயர் (காலி)"
@@ -1339,7 +1326,7 @@ msgstr "பயனர் பெயர் (காலி)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1389,9 +1376,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ஆம்"
@@ -1538,6 +1525,14 @@ msgstr "- ஒரே நேரத்தில் பல பதிவிறக்�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— மெட்டாடேட்டா மற்றும் காணொளி வசனங்களைப் பதிவிறக்குவதை ஆதரிக்கிறது"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "தயாராகிறது..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "சார்புகளை அமைக்க முடியவில்லை. பயன்பாட்டை மறுதொடக்கம் செய்து மீண்டும் முயற்சிக்கவும்."
 
 #~ msgid "Search..."
 #~ msgstr "தேடுங்கள்..."

--- a/NickvisionTubeConverter.Shared/Resources/po/ta.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-11-03 03:31+0000\n"
 "Last-Translator: \"K.B.Dharun Krishna\" <kbdharunkrishna@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" வின் பதிவிறக்கம் முடிந்தது."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" பிழையுடன் முடிந்தது!"
@@ -131,8 +131,8 @@ msgstr "உள்நுழைவைச் சேர்க்கவும்"
 msgid "Advanced Options"
 msgstr "மேம்பட்ட விருப்பங்கள்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "அனைத்து பதிவிறக்கங்களும் முடிந்துவிட்டன."
 
@@ -233,8 +233,8 @@ msgstr "வரிசைப்படுத்தப்பட்ட பதிவ�
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "பதிவிறக்கங்களை மூடிவிட்டு நிறுத்தவா?"
 
@@ -401,12 +401,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "மாற்றங்களை அனுமதிக்காதே"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -420,13 +428,13 @@ msgstr "பதிவிறக்கு"
 msgid "Download Again"
 msgstr "மீண்டும் பதிவிறக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "பதிவிறக்கம் முடிந்தது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "பதிவிறக்கம் பிழையுடன் முடிந்தது"
 
@@ -488,8 +496,8 @@ msgstr "பதிவிறக்குகிறது {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "பதிவிறக்குகிறது"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "பதிவிறக்கங்கள் முடிந்தது"
 
@@ -621,7 +629,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "ஃபியோடர் சோபோலேவ்"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub களஞ்சியம்"
@@ -801,7 +809,7 @@ msgstr "பெயர்"
 msgid "Name (Empty)"
 msgstr "பெயர் (காலி)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -812,15 +820,15 @@ msgstr "நிக்கோலஸ் லோகோசோ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "இல்லை"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "செயலில் இணைய இணைப்பு இல்லை"
 
@@ -890,6 +898,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgid "Queued"
 msgstr "வரிசையில் நிற்கிறது"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "தோல்வியடைந்த பதிவிறக்கங்களை மீண்டும் முயற்சிக்கவும்"
@@ -1112,8 +1121,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1197,7 +1206,8 @@ msgstr "வசன மொழிகள் (செல்லாதது)"
 msgid "Success"
 msgstr "வெற்றி"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1249,7 +1259,7 @@ msgstr "K.B.Dharun Krishna <kbdharunkrishna@gmail.com>, 2023"
 msgid "Unable to disable keyring."
 msgstr "சாவி வலயத்தை முடக்க முடியவில்லை."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1263,7 +1273,7 @@ msgstr "சாவி வலயத்தை மீட்டமைக்க மு
 msgid "Undo Title Editing"
 msgstr "தலைப்பு திருத்தத்தை செயல்தவிர்க்கவும்"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "சாவி வளையத்தைத் திறக்கவும்"
 
@@ -1272,7 +1282,7 @@ msgstr "சாவி வளையத்தைத் திறக்கவும�
 msgid "Unset Cookies File"
 msgstr "குக்கீகள் கோப்பைத் தேர்ந்தெடுக்கவும்"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1375,10 +1385,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ஆம்"

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" indirmeyi tamamladı."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" bir hatayla tamamlandı!"
@@ -132,8 +132,8 @@ msgstr "Giriş Ekle"
 msgid "Advanced Options"
 msgstr "Gelişmiş Seçenekler"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Tüm indirmeler tamamlandı."
 
@@ -233,8 +233,8 @@ msgstr "Kuyruktaki İndirmeleri Temizle"
 msgid "Close"
 msgstr "Kapat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "İndirmeler Kapatılsın ve Durdurulsun mu?"
 
@@ -403,12 +403,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Dönüşümlere İzin Verme"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Tartışmalar"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -422,13 +430,13 @@ msgstr "İndir"
 msgid "Download Again"
 msgstr "Tekrar İndir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "İndirme Tamamlandı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "İndirme Hata İle Tamamlandı"
 
@@ -490,8 +498,8 @@ msgstr "İndiriliyor %{0:f2} ({1})"
 msgid "Downloading..."
 msgstr "İndiriliyor"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "İndirmeler Tamamlandı"
 
@@ -629,7 +637,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
@@ -810,7 +818,7 @@ msgstr "Ad"
 msgid "Name (Empty)"
 msgstr "Ad (Boş)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -821,15 +829,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Aktif internet bağlantısı yok"
 
@@ -899,6 +907,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "Tamam"
 
@@ -1019,7 +1028,7 @@ msgid "Queued"
 msgstr "Kuyrukta"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Kalan İndirme: {0}"
@@ -1122,8 +1131,8 @@ msgstr "Ayarlar"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1208,7 +1217,8 @@ msgstr "Altyazı Dilleri (Geçersiz)"
 msgid "Success"
 msgstr "Başarılı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1264,7 +1274,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Anahtarlık devre dışı bırakılamadı."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1278,7 +1288,7 @@ msgstr "Anahtarlık sıfırlanamadı."
 msgid "Undo Title Editing"
 msgstr "Başlık Düzenlemesini Geri Al"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Anahtarlık Kilidini Aç"
 
@@ -1287,7 +1297,7 @@ msgstr "Anahtarlık Kilidini Aç"
 msgid "Unset Cookies File"
 msgstr "Çerez Dosyasını Seç"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1390,10 +1400,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Evet"

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" indirmeyi tamamladı."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" bir hatayla tamamlandı!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Tercihlerden yapılandırılabilir)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "İndirmeler: {0} — %{1:f1} ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "Oturum açma gerektiren ortamın indirilmesine izin vermek için yt-dlp'ye bir "
 "çerez dosyası sağlanabilir."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "{0} Hakkında"
@@ -100,19 +100,19 @@ msgstr "{0} Hakkında"
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
 "İndirmeye başlamak için video, ses ya da oynatma listesi URLʼsi ekleyin"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -126,14 +126,14 @@ msgid "Add Login"
 msgstr "Giriş Ekle"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Gelişmiş Seçenekler"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Tüm indirmeler tamamlandı."
 
@@ -152,17 +152,17 @@ msgstr "Uygula"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Ses"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Ses Dili"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Kimlik Doğrula"
@@ -171,7 +171,7 @@ msgstr "Kimlik Doğrula"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -179,7 +179,7 @@ msgid "Back"
 msgstr "Geri"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "En İyi"
 
@@ -191,7 +191,7 @@ msgstr "İptal Et"
 msgid "Changelog"
 msgstr "Değişiklik Günlüğü"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -200,8 +200,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Tamamlanan İndirmeleri Temizle"
@@ -220,21 +220,21 @@ msgstr ""
 "Ortam kaynağının URL'sini ve diğer tanımlayıcı bilgileri içeren üst veri "
 "alanlarını temizle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Kuyruktaki İndirmeleri Temizle"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Kapat"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "İndirmeler Kapatılsın ve Durdurulsun mu?"
 
@@ -242,8 +242,8 @@ msgstr "İndirmeler Kapatılsın ve Durdurulsun mu?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Tamamlandı"
@@ -253,7 +253,7 @@ msgstr "Tamamlandı"
 msgid "Completed Notification Trigger"
 msgstr "Tamamlandı Bildirim Tetikleyicisi"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
@@ -302,16 +302,16 @@ msgstr "Kimlik Bilgileri"
 msgid "Crop Audio Thumbnails"
 msgstr "Ses Küçük Resimlerini Kırp"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Küçük Resmi Kırp"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -329,7 +329,7 @@ msgstr "Sil"
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Tüm Seçimi Kaldır"
@@ -403,15 +403,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Dönüşümlere İzin Verme"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Tartışmalar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -422,13 +422,13 @@ msgstr "İndir"
 msgid "Download Again"
 msgstr "Tekrar İndir"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "İndirme Tamamlandı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "İndirme Hata İle Tamamlandı"
 
@@ -437,17 +437,17 @@ msgstr "İndirme Hata İle Tamamlandı"
 msgid "Download log was copied to clipboard."
 msgstr "İndirme günlüğü panoya kopyalandı."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Ortam İndirici"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Belirli Zaman Dilimini İndir"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Alt Yazı İndir"
@@ -460,20 +460,20 @@ msgstr "Aria2 kullanarak indirme işlemi başladı"
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg kullanarak indirme işlemi başladı"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Web video ve seslerini indir"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "İndirici"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "İndiriliyor"
@@ -490,12 +490,12 @@ msgstr "İndiriliyor %{0:f2} ({1})"
 msgid "Downloading..."
 msgstr "İndiriliyor"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "İndirmeler Tamamlandı"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Düzenle"
 
@@ -529,28 +529,28 @@ msgstr ""
 "indirme ilerlemesini göremezsiniz."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Bitiş Zamanı"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Bitiş Zamanı (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Ortam URLʼsini buraya giriniz"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Kimlik bilgilerinin doğru olduğundan emin olun."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Ortam URLʼsini buraya giriniz"
@@ -560,7 +560,7 @@ msgstr "Ortam URLʼsini buraya giriniz"
 msgid "Enter name here"
 msgstr "Ortam URLʼsini buraya giriniz"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -571,7 +571,7 @@ msgstr "Ortam URLʼsini buraya giriniz"
 msgid "Enter proxy url here"
 msgstr "Ortam URLʼsini buraya giriniz"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Ortam URLʼsini buraya giriniz"
@@ -581,7 +581,7 @@ msgstr "Ortam URLʼsini buraya giriniz"
 msgid "Enter url here"
 msgstr "Ortam URLʼsini buraya giriniz"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -592,8 +592,8 @@ msgstr "Ortam URLʼsini buraya giriniz"
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Çık"
 
@@ -602,7 +602,7 @@ msgstr "Çık"
 msgid "Failed to enable keyring."
 msgstr "Anahtarlık etkinleştirilemedi."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Dosya"
 
@@ -615,7 +615,7 @@ msgstr "Dosya zaten var ve üzerine yazılmasına izin verilmiyor"
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Dosya Türü"
@@ -625,23 +625,23 @@ msgstr "Dosya Türü"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Yardım"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -688,13 +688,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Anahtarlık"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Anahtarlık Kimlik Bilgisi"
@@ -714,13 +714,13 @@ msgstr "Anahtarlık kilitli"
 msgid "Language Code Information"
 msgstr "Dil Kodu Bilgisi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Başlangıçtan indirmek için boş bırakın."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Desteklenen sitelerin listesi"
 
@@ -736,7 +736,7 @@ msgstr "Giriş"
 msgid "Login"
 msgstr "Giriş"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Küçük resmi kare yap, müzik indirirken kullanışlıdır."
@@ -746,7 +746,7 @@ msgstr "Küçük resmi kare yap, müzik indirirken kullanışlıdır."
 msgid "Manage previously downloaded media."
 msgstr "Önceden indirilmiş ortamı yönet."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
@@ -761,11 +761,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Azami Etkin İndirme Sayısı"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Azami Kalite"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -777,14 +777,13 @@ msgstr ""
 "kullanımını devre dışı bırakır."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Ortam URLʼsi"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Ortam URLʼsi (Geçersiz)"
 
@@ -811,30 +810,30 @@ msgstr "Ad"
 msgid "Name (Empty)"
 msgstr "Ad (Boş)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Aktif internet bağlantısı yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tamamlanan İndirmeleri Temizle"
@@ -848,7 +847,7 @@ msgstr "Kimlik Bilgisi Yok"
 msgid "No downloads running"
 msgstr "Çalışan indirme yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Çalışan indirme yok"
@@ -863,26 +862,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Önceki İndirme Yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Kuyruktaki İndirmeleri Temizle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Başlıkları Numaralandır"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -903,14 +902,14 @@ msgstr ""
 msgid "OK"
 msgstr "Tamam"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -942,21 +941,21 @@ msgstr "Klasörü Aç"
 msgid "Overwrite Existing Files"
 msgstr "Varolan Dosyaların Üzerine Yaz"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -976,11 +975,15 @@ msgid "Play"
 msgstr "Oynat"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Hazırlanıyor..."
@@ -995,7 +998,7 @@ msgstr "Hazırlanıyor..."
 msgid "Prevent Suspend"
 msgstr "Askıya Almayı Engelle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1009,19 +1012,19 @@ msgstr "İşleniyor..."
 msgid "Proxy URL"
 msgstr "Proxy URLʼsi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Kalite"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Kuyrukta"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Kalan İndirme: {0}"
@@ -1031,7 +1034,7 @@ msgstr "Kalan İndirme: {0}"
 msgid "Remove Source Data"
 msgstr "Kaynak Verileri Kaldır"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Hata Raporla"
 
@@ -1066,22 +1069,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "İndirmeyi Yeniden Dene"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Başarısız İndirmeleri Yeniden Dene"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Kayıt Klasörü"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Kayıt Klasörü (Geçersiz)"
 
@@ -1091,7 +1094,7 @@ msgstr "Kayıt Klasörü (Geçersiz)"
 msgid "Search history"
 msgstr "Geçmişi Temizle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Tümünü Seç"
@@ -1102,30 +1105,30 @@ msgstr "Tümünü Seç"
 msgid "Select Cookies File"
 msgstr "Çerez Dosyasını Seç"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "İndirmek veya dosya adlarını değiştirmek için ögeleri seçin."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Kayıt Klasörünü Seçin"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1138,19 +1141,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Bazı indirmeler hatalarla tamamlandı!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Hız Sınırı"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Bölümleri Ayır"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Videoyu bölümlerine göre birden çok küçük parçaya böler."
@@ -1161,19 +1164,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "SponsorBlock Bilgisi (web tarayıcısında açılır)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Başlangıç Zamanı"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Başlangıç Zamanı (Geçersiz)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1210,7 +1213,7 @@ msgstr "Altyazı Dilleri (Geçersiz)"
 msgid "Success"
 msgstr "Başarılı"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1246,7 +1249,7 @@ msgstr ""
 "uygulanır. Değerin değiştirilmesi zaten çalışmakta olan indirmeleri "
 "etkilemez."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1259,7 +1262,7 @@ msgstr ""
 "Bu, tüm şifreleri kaldırarak önceki anahtarlığı silecektir. Bu işlem geri "
 "alınamaz."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "Sabri Ünal <libreajans@gmail.com>\n"
@@ -1270,7 +1273,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Anahtarlık devre dışı bırakılamadı."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1279,7 +1282,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Anahtarlık sıfırlanamadı."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Bağımlılıklar kurulamıyor. Lütfen uygulamayı yeniden başlatın ve tekrar "
@@ -1290,7 +1293,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Başlık Düzenlemesini Geri Al"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Anahtarlık Kilidini Aç"
 
@@ -1299,7 +1302,7 @@ msgstr "Anahtarlık Kilidini Aç"
 msgid "Unset Cookies File"
 msgstr "Çerez Dosyasını Seç"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1351,7 +1354,7 @@ msgid "User Name (Empty)"
 msgstr "Kullanıcı adı (Boş)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1360,13 +1363,18 @@ msgid "Username"
 msgstr "Kullanıcı adı"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Doğrula"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Doğrula"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Video"
 
@@ -1384,7 +1392,7 @@ msgid "Waiting..."
 msgstr "Bekliyor..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "En Kötü"
 
@@ -1397,10 +1405,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Evet"

--- a/NickvisionTubeConverter.Shared/Resources/po/tr.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-09-26 13:20+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" indirmeyi tamamladı."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" bir hatayla tamamlandı!"
@@ -100,7 +100,7 @@ msgstr "{0} Hakkında"
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -110,9 +110,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -133,7 +133,7 @@ msgid "Advanced Options"
 msgstr "Gelişmiş Seçenekler"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Tüm indirmeler tamamlandı."
 
@@ -201,7 +201,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Tamamlanan İndirmeleri Temizle"
@@ -221,7 +221,7 @@ msgstr ""
 "alanlarını temizle"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -234,7 +234,7 @@ msgid "Close"
 msgstr "Kapat"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "İndirmeler Kapatılsın ve Durdurulsun mu?"
 
@@ -242,8 +242,8 @@ msgstr "İndirmeler Kapatılsın ve Durdurulsun mu?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Tamamlandı"
@@ -253,7 +253,7 @@ msgstr "Tamamlandı"
 msgid "Completed Notification Trigger"
 msgstr "Tamamlandı Bildirim Tetikleyicisi"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
@@ -307,11 +307,11 @@ msgstr "Ses Küçük Resimlerini Kırp"
 msgid "Crop Thumbnail"
 msgstr "Küçük Resmi Kırp"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -325,7 +325,7 @@ msgid "Delete"
 msgstr "Sil"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Kimlik Bilgileri Silinsin mi?"
 
@@ -423,12 +423,12 @@ msgid "Download Again"
 msgstr "Tekrar İndir"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "İndirme Tamamlandı"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "İndirme Hata İle Tamamlandı"
 
@@ -437,7 +437,7 @@ msgstr "İndirme Hata İle Tamamlandı"
 msgid "Download log was copied to clipboard."
 msgstr "İndirme günlüğü panoya kopyalandı."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Ortam İndirici"
@@ -460,7 +460,7 @@ msgstr "Aria2 kullanarak indirme işlemi başladı"
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg kullanarak indirme işlemi başladı"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -472,8 +472,8 @@ msgstr "Web video ve seslerini indir"
 msgid "Downloader"
 msgstr "İndirici"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "İndiriliyor"
@@ -491,7 +491,7 @@ msgid "Downloading..."
 msgstr "İndiriliyor"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "İndirmeler Tamamlandı"
 
@@ -593,7 +593,7 @@ msgid "Error"
 msgstr "Hata"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Çık"
 
@@ -625,7 +625,7 @@ msgstr "Dosya Türü"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -687,7 +687,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -720,7 +720,7 @@ msgstr "Dil Kodu Bilgisi"
 msgid "Leave empty to download from start."
 msgstr "Başlangıçtan indirmek için boş bırakın."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Desteklenen sitelerin listesi"
 
@@ -731,8 +731,8 @@ msgstr "Giriş"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Giriş"
 
@@ -746,7 +746,7 @@ msgstr "Küçük resmi kare yap, müzik indirirken kullanışlıdır."
 msgid "Manage previously downloaded media."
 msgstr "Önceden indirilmiş ortamı yönet."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
@@ -800,40 +800,40 @@ msgstr "Asgari Ayırma Boyutu (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Ad"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Ad (Boş)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Aktif internet bağlantısı yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Tamamlanan İndirmeleri Temizle"
@@ -847,7 +847,7 @@ msgstr "Kimlik Bilgisi Yok"
 msgid "No downloads running"
 msgstr "Çalışan indirme yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Çalışan indirme yok"
@@ -862,7 +862,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Önceki İndirme Yok"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Kuyruktaki İndirmeleri Temizle"
@@ -941,14 +941,14 @@ msgstr "Klasörü Aç"
 msgid "Overwrite Existing Files"
 msgstr "Varolan Dosyaların Üzerine Yaz"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -957,7 +957,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -965,7 +965,7 @@ msgid "Password"
 msgstr "Parola"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Parola (Boş)"
 
@@ -982,11 +982,6 @@ msgstr "Çalma Listesi"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Hazırlanıyor..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1017,14 +1012,14 @@ msgstr "Proxy URLʼsi"
 msgid "Quality"
 msgstr "Kalite"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Kuyrukta"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Kalan İndirme: {0}"
@@ -1044,7 +1039,7 @@ msgid "Reset"
 msgstr "Sıfırla"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Anahtarlık Sıfırlansın Mı?"
 
@@ -1070,7 +1065,7 @@ msgid "Retry Download"
 msgstr "İndirmeyi Yeniden Dene"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1117,18 +1112,18 @@ msgid "Select Save Folder"
 msgstr "Kayıt Klasörünü Seçin"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1176,7 +1171,7 @@ msgid "Start Time (Invalid)"
 msgstr "Başlangıç Zamanı (Geçersiz)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1235,7 +1230,7 @@ msgid "Theme"
 msgstr "Tema"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Bu işlem geri alınamaz. Silmek istediğinizden emin misiniz?"
 
@@ -1249,12 +1244,8 @@ msgstr ""
 "uygulanır. Değerin değiştirilmesi zaten çalışmakta olan indirmeleri "
 "etkilemez."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1262,38 +1253,32 @@ msgstr ""
 "Bu, tüm şifreleri kaldırarak önceki anahtarlığı silecektir. Bu işlem geri "
 "alınamaz."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "Sabri Ünal <libreajans@gmail.com>\n"
 "Anonim Weblate Çevirmenleri"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Anahtarlık devre dışı bırakılamadı."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Anahtarlık sıfırlanamadı."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Bağımlılıklar kurulamıyor. Lütfen uygulamayı yeniden başlatın ve tekrar "
-"deneyin."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Başlık Düzenlemesini Geri Al"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Anahtarlık Kilidini Aç"
 
@@ -1302,19 +1287,19 @@ msgstr "Anahtarlık Kilidini Aç"
 msgid "Unset Cookies File"
 msgstr "Çerez Dosyasını Seç"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (Geçersiz)"
 
@@ -1348,7 +1333,7 @@ msgid "User Interface"
 msgstr "Kullanıcı Arayüzü"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Kullanıcı adı (Boş)"
@@ -1356,7 +1341,7 @@ msgstr "Kullanıcı adı (Boş)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1406,9 +1391,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Evet"
@@ -1557,6 +1542,15 @@ msgstr "— Aynı anda birden fazla indirme çalıştırın"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Üst veri ve video altyazı indirmeyi destekler"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Hazırlanıyor..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Bağımlılıklar kurulamıyor. Lütfen uygulamayı yeniden başlatın ve tekrar "
+#~ "deneyin."
 
 #~ msgid "Search..."
 #~ msgstr "Ara..."

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-10-30 13:00+0000\n"
 "Last-Translator: volkov <d2oo1dle2x@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,20 +20,20 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" завершено завантаження."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершився з помилкою!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Налаштовується в параметрах)"
 
@@ -49,7 +49,7 @@ msgstr "{0:f1} ГіБ/с"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} КіБ/с"
@@ -69,8 +69,8 @@ msgstr[2] "{0} завантажень - {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -92,7 +92,7 @@ msgstr ""
 "Файл cookies може бути наданий yt-dlp, щоб дозволити завантажувати медіа, "
 "які потребують входу."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Про застосунок {0}"
@@ -103,7 +103,7 @@ msgstr "Про застосунок {0}"
 msgid "Add"
 msgstr "Додати"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -111,12 +111,12 @@ msgstr ""
 "завантаження"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -130,14 +130,14 @@ msgid "Add Login"
 msgstr "Додати логін"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Розширені налаштування"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Всі завантаження завершено."
 
@@ -156,17 +156,17 @@ msgstr "Застосувати"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Аудіо"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "Мова аудіо"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "Автентифікація"
@@ -175,7 +175,7 @@ msgstr "Автентифікація"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -183,7 +183,7 @@ msgid "Back"
 msgstr "Назад"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Найкраще"
 
@@ -195,7 +195,7 @@ msgstr "Скасувати"
 msgid "Changelog"
 msgstr "Список змін"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Очистити завершені завантаження"
@@ -224,21 +224,21 @@ msgstr ""
 "Очистити поля метаданих, що містять URL та іншу ідентифікаційну інформацію "
 "джерела медіа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Очистити завантаження в черзі"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Закрити"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Закрити та зупинити завантаження?"
 
@@ -246,8 +246,8 @@ msgstr "Закрити та зупинити завантаження?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Завершено"
@@ -257,7 +257,7 @@ msgstr "Завершено"
 msgid "Completed Notification Trigger"
 msgstr "Показувати сповіщення про завершення"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
@@ -308,16 +308,16 @@ msgstr "Облікові дані"
 msgid "Crop Audio Thumbnails"
 msgstr "Обрізати мініатюри аудіо"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Обрізати мініатюру"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -335,7 +335,7 @@ msgstr "Видалити"
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "Зняти все"
@@ -409,15 +409,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Заборонити конвертацію"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Обговорення"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -428,13 +428,13 @@ msgstr "Завантаження"
 msgid "Download Again"
 msgstr "Завантажити знову"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Завантаження завершено"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Завантаження завершено з помилкою"
 
@@ -443,17 +443,17 @@ msgstr "Завантаження завершено з помилкою"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал завантажень скопійовано до буфера обміну."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Завантажити медіа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Завантажити конкретний часовий проміжок"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "Завантажити субтитри"
@@ -466,20 +466,20 @@ msgstr "Розпочато завантаження за допомогою aria
 msgid "Download using ffmpeg has started"
 msgstr "Розпочато завантаження за допомогою ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Завантажити веб відео та аудіо"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Завантажувач"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Завантаження"
@@ -496,12 +496,12 @@ msgstr "Завантаження {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Завантаження"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Завантаження завершені"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "Редагувати"
 
@@ -535,28 +535,28 @@ msgstr ""
 "побачите прогрес завантаження."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Час закінчення"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Час закінчення (неправильний)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Введіть URL-адресу медіа"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "Переконайтеся, що облікові дані правильні."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Введіть URL-адресу медіа"
@@ -566,7 +566,7 @@ msgstr "Введіть URL-адресу медіа"
 msgid "Enter name here"
 msgstr "Введіть URL-адресу медіа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -577,7 +577,7 @@ msgstr "Введіть URL-адресу медіа"
 msgid "Enter proxy url here"
 msgstr "Введіть URL-адресу медіа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Введіть URL-адресу медіа"
@@ -587,7 +587,7 @@ msgstr "Введіть URL-адресу медіа"
 msgid "Enter url here"
 msgstr "Введіть URL-адресу медіа"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -598,8 +598,8 @@ msgstr "Введіть URL-адресу медіа"
 msgid "Error"
 msgstr "Помилка"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "Вийти"
 
@@ -608,7 +608,7 @@ msgstr "Вийти"
 msgid "Failed to enable keyring."
 msgstr "Не вдалося ввімкнути keyring."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "Файл"
 
@@ -621,7 +621,7 @@ msgstr "Файл вже існує, і його перезапис заборо�
 msgid "File Name"
 msgstr "Ім'я файлу"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Тип файлу"
@@ -631,23 +631,23 @@ msgstr "Тип файлу"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Репозиторій GitHub"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "Допомога"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -695,13 +695,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Облікові дані Keyring"
@@ -721,13 +721,13 @@ msgstr "Keyring заблоковано"
 msgid "Language Code Information"
 msgstr "Інформація про мовний код"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Залиште порожнім, щоб завантажити з самого початку."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Список підтримуваних сайтів"
 
@@ -743,7 +743,7 @@ msgstr "Логін"
 msgid "Login"
 msgstr "Логін"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Зробіть мініатюру квадратною, корисно при завантаженні музики."
@@ -753,7 +753,7 @@ msgstr "Зробіть мініатюру квадратною, корисно �
 msgid "Manage previously downloaded media."
 msgstr "Керуйте раніше завантаженими медіа."
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -768,11 +768,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Максимальна кількість активних завантажень"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Максимальна якість"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -784,14 +784,13 @@ msgstr ""
 "ввімкнений."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "URL-адреса медіа"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "URL-адреса медіа (неправильна)"
 
@@ -818,30 +817,30 @@ msgstr "Ім'я"
 msgid "Name (Empty)"
 msgstr "Ім'я (Порожньо)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ні"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "Немає активного з'єднання з Інтернетом"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Очистити завершені завантаження"
@@ -855,7 +854,7 @@ msgstr "Немає облікових даних"
 msgid "No downloads running"
 msgstr "Немає завантажень"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Немає завантажень"
@@ -870,26 +869,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Немає попередніх завантажень"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Очистити завантаження в черзі"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Пронумерувати заголовки"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -910,14 +909,14 @@ msgstr ""
 msgid "OK"
 msgstr "ОК"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -949,21 +948,21 @@ msgstr "Відкрити папку"
 msgid "Overwrite Existing Files"
 msgstr "Перезаписати наявні файли"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -983,11 +982,15 @@ msgid "Play"
 msgstr "Відтворити"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Список відтворення"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Підготовка..."
@@ -1002,7 +1005,7 @@ msgstr "Підготовка..."
 msgid "Prevent Suspend"
 msgstr "Запобігти призупиненню системи"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1016,19 +1019,19 @@ msgstr "Обробка..."
 msgid "Proxy URL"
 msgstr "Проксі URL"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Якість"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "У черзі"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Залишилося завантажити: {0}"
@@ -1038,7 +1041,7 @@ msgstr "Залишилося завантажити: {0}"
 msgid "Remove Source Data"
 msgstr "Вилучити вихідні дані"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Повідомити про помилку"
 
@@ -1073,22 +1076,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Повторити завантаження"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Повторити невдалу спробу завантаження"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Зберегти теку"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Зберегти папку (неправильно)"
 
@@ -1098,7 +1101,7 @@ msgstr "Зберегти папку (неправильно)"
 msgid "Search history"
 msgstr "Очистити історію"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "Вибрати все"
@@ -1109,30 +1112,30 @@ msgstr "Вибрати все"
 msgid "Select Cookies File"
 msgstr "Виберіть файл cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Виберіть елементи для завантаження або зміни назв файлів."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Натисніть \"Зберегти папку\""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Налаштування"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1144,19 +1147,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Деякі завантаження завершено з помилками!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Обмеження швидкості"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "Розділити розділи"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "Розділяє відео на кілька менших на основі його розділів."
@@ -1167,19 +1170,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Інформація про SponsorBlock (відкривається у веббраузері)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Час початку"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Час початку (неправильний)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1216,7 +1219,7 @@ msgstr "Мови субтитрів (неправильні)"
 msgid "Success"
 msgstr "Успіх"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1251,7 +1254,7 @@ msgstr ""
 "Цей ліміт (у Кбіт/с) застосовується до завантажень, для яких увімкнено "
 "обмеження швидкості. Зміна значення не впливає на вже запущені завантаження."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1264,7 +1267,7 @@ msgstr ""
 "Це видалить попередній keyring, видаливши всі паролі з ним. Ця дія "
 "незворотна."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 "kefir2105\n"
@@ -1276,7 +1279,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Неможливо вимкнути keyring."
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1285,7 +1288,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "Не вдалося скинути keyring."
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Не вдалося налаштувати залежності. Будь ласка, перезапустіть застосунок та "
@@ -1296,7 +1299,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Скасувати редагування назви"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Розблокувати Keyring"
 
@@ -1305,7 +1308,7 @@ msgstr "Розблокувати Keyring"
 msgid "Unset Cookies File"
 msgstr "Виберіть файл cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1357,7 +1360,7 @@ msgid "User Name (Empty)"
 msgstr "Ім'я користувача (Порожнє)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1366,13 +1369,18 @@ msgid "Username"
 msgstr "Ім'я користувача"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Підтвердити"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Підтвердити"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Відео"
 
@@ -1390,7 +1398,7 @@ msgid "Waiting..."
 msgstr "Очікування..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Найгірше"
 
@@ -1403,10 +1411,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Так"

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-10-30 13:00+0000\n"
 "Last-Translator: volkov <d2oo1dle2x@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,14 +20,14 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.2-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" завершено завантаження."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершився з помилкою!"
@@ -136,8 +136,8 @@ msgstr "Додати логін"
 msgid "Advanced Options"
 msgstr "Розширені налаштування"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Всі завантаження завершено."
 
@@ -237,8 +237,8 @@ msgstr "Очистити завантаження в черзі"
 msgid "Close"
 msgstr "Закрити"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Закрити та зупинити завантаження?"
 
@@ -409,12 +409,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Заборонити конвертацію"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Обговорення"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -428,13 +436,13 @@ msgstr "Завантаження"
 msgid "Download Again"
 msgstr "Завантажити знову"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Завантаження завершено"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Завантаження завершено з помилкою"
 
@@ -496,8 +504,8 @@ msgstr "Завантаження {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "Завантаження"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Завантаження завершені"
 
@@ -635,7 +643,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "Репозиторій GitHub"
@@ -817,7 +825,7 @@ msgstr "Ім'я"
 msgid "Name (Empty)"
 msgstr "Ім'я (Порожньо)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -828,15 +836,15 @@ msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ні"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "Немає активного з'єднання з Інтернетом"
 
@@ -906,6 +914,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "ОК"
 
@@ -1026,7 +1035,7 @@ msgid "Queued"
 msgstr "У черзі"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Залишилося завантажити: {0}"
@@ -1129,8 +1138,8 @@ msgstr "Налаштування"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1214,7 +1223,8 @@ msgstr "Мови субтитрів (неправильні)"
 msgid "Success"
 msgstr "Успіх"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1270,7 +1280,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Неможливо вимкнути keyring."
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1284,7 +1294,7 @@ msgstr "Не вдалося скинути keyring."
 msgid "Undo Title Editing"
 msgstr "Скасувати редагування назви"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Розблокувати Keyring"
 
@@ -1293,7 +1303,7 @@ msgstr "Розблокувати Keyring"
 msgid "Unset Cookies File"
 msgstr "Виберіть файл cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1396,10 +1406,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Так"

--- a/NickvisionTubeConverter.Shared/Resources/po/uk.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-10-30 13:00+0000\n"
 "Last-Translator: volkov <d2oo1dle2x@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/nickvision-"
@@ -21,13 +21,13 @@ msgstr ""
 "X-Generator: Weblate 5.2-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" завершено завантаження."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" завершився з помилкою!"
@@ -103,7 +103,7 @@ msgstr "Про застосунок {0}"
 msgid "Add"
 msgstr "Додати"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -114,9 +114,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -137,7 +137,7 @@ msgid "Advanced Options"
 msgstr "Розширені налаштування"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Всі завантаження завершено."
 
@@ -205,7 +205,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Очистити завершені завантаження"
@@ -225,7 +225,7 @@ msgstr ""
 "джерела медіа"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -238,7 +238,7 @@ msgid "Close"
 msgstr "Закрити"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Закрити та зупинити завантаження?"
 
@@ -246,8 +246,8 @@ msgstr "Закрити та зупинити завантаження?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Завершено"
@@ -257,7 +257,7 @@ msgstr "Завершено"
 msgid "Completed Notification Trigger"
 msgstr "Показувати сповіщення про завершення"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
@@ -313,11 +313,11 @@ msgstr "Обрізати мініатюри аудіо"
 msgid "Crop Thumbnail"
 msgstr "Обрізати мініатюру"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -331,7 +331,7 @@ msgid "Delete"
 msgstr "Видалити"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Видалити облікові дані?"
 
@@ -429,12 +429,12 @@ msgid "Download Again"
 msgstr "Завантажити знову"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Завантаження завершено"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Завантаження завершено з помилкою"
 
@@ -443,7 +443,7 @@ msgstr "Завантаження завершено з помилкою"
 msgid "Download log was copied to clipboard."
 msgstr "Журнал завантажень скопійовано до буфера обміну."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Завантажити медіа"
@@ -466,7 +466,7 @@ msgstr "Розпочато завантаження за допомогою aria
 msgid "Download using ffmpeg has started"
 msgstr "Розпочато завантаження за допомогою ffmpeg"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -478,8 +478,8 @@ msgstr "Завантажити веб відео та аудіо"
 msgid "Downloader"
 msgstr "Завантажувач"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Завантаження"
@@ -497,7 +497,7 @@ msgid "Downloading..."
 msgstr "Завантаження"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Завантаження завершені"
 
@@ -599,7 +599,7 @@ msgid "Error"
 msgstr "Помилка"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "Вийти"
 
@@ -631,7 +631,7 @@ msgstr "Тип файлу"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
@@ -694,7 +694,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -727,7 +727,7 @@ msgstr "Інформація про мовний код"
 msgid "Leave empty to download from start."
 msgstr "Залиште порожнім, щоб завантажити з самого початку."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Список підтримуваних сайтів"
 
@@ -738,8 +738,8 @@ msgstr "Логін"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "Логін"
 
@@ -753,7 +753,7 @@ msgstr "Зробіть мініатюру квадратною, корисно �
 msgid "Manage previously downloaded media."
 msgstr "Керуйте раніше завантаженими медіа."
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -807,40 +807,40 @@ msgstr "Мінімальний розмір розділення (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Ім'я"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Ім'я (Порожньо)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Ні"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "Немає активного з'єднання з Інтернетом"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Очистити завершені завантаження"
@@ -854,7 +854,7 @@ msgstr "Немає облікових даних"
 msgid "No downloads running"
 msgstr "Немає завантажень"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Немає завантажень"
@@ -869,7 +869,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Немає попередніх завантажень"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Очистити завантаження в черзі"
@@ -948,14 +948,14 @@ msgstr "Відкрити папку"
 msgid "Overwrite Existing Files"
 msgstr "Перезаписати наявні файли"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "Parabolic"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -964,7 +964,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -972,7 +972,7 @@ msgid "Password"
 msgstr "Пароль"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Пароль (Порожньо)"
 
@@ -989,11 +989,6 @@ msgstr "Список відтворення"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Підготовка..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1024,14 +1019,14 @@ msgstr "Проксі URL"
 msgid "Quality"
 msgstr "Якість"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "У черзі"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Залишилося завантажити: {0}"
@@ -1051,7 +1046,7 @@ msgid "Reset"
 msgstr "Скинути"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "Скинути Keyring?"
 
@@ -1077,7 +1072,7 @@ msgid "Retry Download"
 msgstr "Повторити завантаження"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1124,18 +1119,18 @@ msgid "Select Save Folder"
 msgstr "Натисніть \"Зберегти папку\""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Налаштування"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1182,7 +1177,7 @@ msgid "Start Time (Invalid)"
 msgstr "Час початку (неправильний)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1241,7 +1236,7 @@ msgid "Theme"
 msgstr "Стиль"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Ця дія є незворотною. Ви впевнені, що хочете його видалити?"
 
@@ -1254,12 +1249,8 @@ msgstr ""
 "Цей ліміт (у Кбіт/с) застосовується до завантажень, для яких увімкнено "
 "обмеження швидкості. Зміна значення не впливає на вже запущені завантаження."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1267,7 +1258,7 @@ msgstr ""
 "Це видалить попередній keyring, видаливши всі паролі з ним. Ця дія "
 "незворотна."
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 "kefir2105\n"
@@ -1275,31 +1266,25 @@ msgstr ""
 "volkov <volkovissocool@gmail.com>"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "Неможливо вимкнути keyring."
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "Не вдалося скинути keyring."
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Не вдалося налаштувати залежності. Будь ласка, перезапустіть застосунок та "
-"спробуйте ще раз."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Скасувати редагування назви"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Розблокувати Keyring"
 
@@ -1308,19 +1293,19 @@ msgstr "Розблокувати Keyring"
 msgid "Unset Cookies File"
 msgstr "Виберіть файл cookies"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "URL"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "URL (Неправильна)"
 
@@ -1354,7 +1339,7 @@ msgid "User Interface"
 msgstr "Інтерфейс користувача"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Ім'я користувача (Порожнє)"
@@ -1362,7 +1347,7 @@ msgstr "Ім'я користувача (Порожнє)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1412,9 +1397,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Так"
@@ -1561,6 +1546,15 @@ msgstr "- Запуск декількох завантажень одночас�
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- Підтримує завантаження метаданих і субтитрів до відео"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Підготовка..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Не вдалося налаштувати залежності. Будь ласка, перезапустіть застосунок "
+#~ "та спробуйте ще раз."
 
 #~ msgid "Search..."
 #~ msgstr "Пошук..."

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-10-09 05:02+0000\n"
 "Last-Translator: Abdur Rehman Imran <arehmanimran4@gmail.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} کا ڈاؤن لوڈ مکمل کر لیا ہے۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} ایک خرابی کے ساتھ ختم ہو گیا ہے!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "ترجیحات میں قابل ترتیب"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] "ڈاؤن لوڈز : {0} — {1:f1}%{{2}}"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -89,7 +89,7 @@ msgstr ""
 "ایک کوکیز فائل yt-dlp کو فراہم کی جا سکتی ہے تاکہ میڈیا کو ڈاؤن لوڈ کرنے کی "
 "اجازت دی جا سکے جس کے لیے لاگ ان کی ضرورت ہوتی ہے۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, fuzzy, csharp-format
 msgid "About {0}"
 msgstr "متعلق"
@@ -100,18 +100,18 @@ msgstr "متعلق"
 msgid "Add"
 msgstr "اضافہ کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "ڈاؤن لوڈ شروع کرنے کے لیے ویڈیو، آڈیو یا پلے لسٹ یو-آر-ایل شامل کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr "لاگ ان کا اضافہ کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "اعلی درجے کے اختیارات"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "تمام ڈاؤن لوڈز مکمل ہو چکے ہیں۔"
 
@@ -151,17 +151,17 @@ msgstr "درخواست کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "آڈیو"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr "آڈیو کی زبان"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr "تصدیق کریں"
@@ -170,7 +170,7 @@ msgstr "تصدیق کریں"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr "پیچھے"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "بہترین"
 
@@ -190,7 +190,7 @@ msgstr "منسوخ"
 msgid "Changelog"
 msgstr "فہرست رَدّ و بَدَل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو صاف کریں"
@@ -217,21 +217,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو ختم کریں"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "بند کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "ڈاؤن لوڈز کو روکیں اور بند کریں ؟"
 
@@ -239,8 +239,8 @@ msgstr "ڈاؤن لوڈز کو روکیں اور بند کریں ؟"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "مکمل"
@@ -250,7 +250,7 @@ msgstr "مکمل"
 msgid "Completed Notification Trigger"
 msgstr "نوٹیفکیشن ٹرگر مکمل ہوا"
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub پر تعاون کرنے والے ❤️"
 
@@ -299,16 +299,16 @@ msgstr "کریڈٹس(سہرا)"
 msgid "Crop Audio Thumbnails"
 msgstr "آڈیو تھمب نیلز کو تراشیں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "تھمب نیل کو تراشیں"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -326,7 +326,7 @@ msgstr "حذف کریں"
 msgid "Delete Credential?"
 msgstr "اسناد کو حذف کریں؟"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr "تمام چیزوں کو نہ چنیں"
@@ -398,15 +398,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "تبادلوں کی اجازت نہ دیں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "بات چیت"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -417,13 +417,13 @@ msgstr "ڈاؤن لوڈ کریں"
 msgid "Download Again"
 msgstr "دوبارہ ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "ڈاؤن لوڈ مکمل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 
@@ -432,17 +432,17 @@ msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 msgid "Download log was copied to clipboard."
 msgstr "ڈاؤن لوڈ لاگ کو کلپ بورڈ پر کاپی کرلیاگیا۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "میڈیا ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "مخصوص ٹائم فریم ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 msgid "Download Subtitle"
 msgstr "سبٹائٹل ڈاون لوڈ کریں"
@@ -455,20 +455,20 @@ msgstr "aria2 کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہ�
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہو گیا ہے"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "وئیب آڈیو اور ویدیو ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "ڈاؤن لوڈر"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ڈاؤن لوڈینگ ہو رہی ہے"
@@ -485,12 +485,12 @@ msgstr "ڈاؤن لوڈ ہو رہا ہے {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ڈاؤن لوڈینگ ہو رہی ہے"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "ڈاؤن لوڈز مکمل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr "ترمیم کریں"
 
@@ -525,28 +525,28 @@ msgstr ""
 "کو ڈاؤن لوڈ کی پیشرفت نظر نہیں آئے گی۔"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "اختتامی وقت"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "اختتامی وقت (غلط)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "میڈیا URL یہاں درج کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr "یقینی بنائیں کہ اسناد درست ہیں."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "میڈیا URL یہاں درج کریں"
@@ -556,7 +556,7 @@ msgstr "میڈیا URL یہاں درج کریں"
 msgid "Enter name here"
 msgstr "میڈیا URL یہاں درج کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -567,7 +567,7 @@ msgstr "میڈیا URL یہاں درج کریں"
 msgid "Enter proxy url here"
 msgstr "میڈیا URL یہاں درج کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "میڈیا URL یہاں درج کریں"
@@ -577,7 +577,7 @@ msgstr "میڈیا URL یہاں درج کریں"
 msgid "Enter url here"
 msgstr "میڈیا URL یہاں درج کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -588,8 +588,8 @@ msgstr "میڈیا URL یہاں درج کریں"
 msgid "Error"
 msgstr "خرابی"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr "باہر"
 
@@ -599,7 +599,7 @@ msgstr "باہر"
 msgid "Failed to enable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 msgid "File"
 msgstr "فائیل"
 
@@ -612,7 +612,7 @@ msgstr "فائل پہلے سے موجود ہے، اور دوبارہ لکھنے 
 msgid "File Name"
 msgstr "فائل کا نام"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "فائل کی قسم"
@@ -622,23 +622,23 @@ msgstr "فائل کی قسم"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr "فیوڈور سوبولیف"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "گٹ ہب رجسٹر(ریپوسٹری)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr "مدد"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -684,13 +684,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "کیڑیگ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "کی ڑینگ کی اسناد"
@@ -710,13 +710,13 @@ msgstr "کیرنگ مقفل ہے"
 msgid "Language Code Information"
 msgstr "زبان کے کوڈ کی معلومات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "شروع سے ڈاؤن لوڈ کرنے کے لیے خالی چھوڑ دیں۔"
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "ہم آہنگ سائٹس کی فہرست"
 
@@ -732,7 +732,7 @@ msgstr "لاگ ان"
 msgid "Login"
 msgstr "لاگ ان"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "تھمب نیل مربع بنائیں، موسیقی ڈاؤن لوڈ کرتے وقت کارآمد۔"
@@ -742,7 +742,7 @@ msgstr "تھمب نیل مربع بنائیں، موسیقی ڈاؤن لوڈ ک�
 msgid "Manage previously downloaded media."
 msgstr "پہلے ڈاؤن لوڈ کردہ میڈیا کا نظم کریں۔"
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr "میٹرکس چیٹ"
 
@@ -757,11 +757,11 @@ msgid "Max Number of Active Downloads"
 msgstr "فعال ڈاؤن لوڈز کی انتہاء"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "اعلیٰ ترین معیار"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -773,14 +773,13 @@ msgstr ""
 "جائے گا۔"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "میڈیا یو-آر-ایل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "میڈیا یو-آر-ایل (غلط)"
 
@@ -807,30 +806,30 @@ msgstr "نام"
 msgid "Name (Empty)"
 msgstr "نام (خالی)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr "نکولس لوگوزو"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "نہیں"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr "درست نیٹ موجود نہیں ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو صاف کریں"
@@ -844,7 +843,7 @@ msgstr "کوئی اسناد نہیں"
 msgid "No downloads running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہی ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہی ہے"
@@ -859,26 +858,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "کوئی پچھلا ڈاؤن لوڈز نہیں ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو ختم کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "نمبر ٹائٹلز"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -899,14 +898,14 @@ msgstr ""
 msgid "OK"
 msgstr "ٹھیک"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -938,21 +937,21 @@ msgstr "فولڈر کھولیں"
 msgid "Overwrite Existing Files"
 msgstr "موجودہ فائلوں کو دوبارہ لکھیں"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "پیرابولک"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -972,11 +971,15 @@ msgid "Play"
 msgstr "چلاؤ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "پلے لیٹ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "تیاری چل رہی ہے..."
@@ -991,7 +994,7 @@ msgstr "تیاری چل رہی ہے..."
 msgid "Prevent Suspend"
 msgstr "معطلی کو روکیں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1005,19 +1008,19 @@ msgstr "عمل کر رہے ہیں ..."
 msgid "Proxy URL"
 msgstr "پراکسی یو-آر-ایل"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "معیار"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "قطار میں لگے ہوئے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "باقی ڈاؤن لوڈ"
@@ -1027,7 +1030,7 @@ msgstr "باقی ڈاؤن لوڈ"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "خرابی کی اطلاع کریں"
 
@@ -1062,22 +1065,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "دوبارہ ڈاؤن لوڈ کرنے کی کوشش کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "ناکام ڈاؤن لوڈز کو ڈاؤن لوڈ کرنے کی دوبارہ کوشش کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "فولڈر محفوظ کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "محفوظہ فولڈر (غلط)"
 
@@ -1087,7 +1090,7 @@ msgstr "محفوظہ فولڈر (غلط)"
 msgid "Search history"
 msgstr "تاریخ کو صاف کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 msgid "Select All"
 msgstr "تمام چیزوں کو چنیں"
@@ -1098,30 +1101,30 @@ msgstr "تمام چیزوں کو چنیں"
 msgid "Select Cookies File"
 msgstr "کوکیز فائل کو منتخب کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "ڈاؤن لوڈ کرنے یا نام بدلنے کے لیے چیزیں منتخب کریں-"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "مطلوبہ جگہ فراہم کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "ترتیبات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1133,19 +1136,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "کچھ ڈاؤن لوڈز خرابیوں کے ساتھ ختم ہو گئے!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "رفتار کی حد"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr "ابواب کی تقسیم کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr "یہ ویڈیو کو ابواب کے مطابق چھوٹے حصوں میں تقسیم کرتا ہے۔"
@@ -1156,19 +1159,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "سپانسر بلاک کے بارے میں معلومات (ویب میں)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "ابتدائی وقت"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "ابتدائی وقت (غلط)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1205,7 +1208,7 @@ msgstr "سب ٹائٹل کی زبانیں (غلط)"
 msgid "Success"
 msgstr "کامیابی"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1240,7 +1243,7 @@ msgstr ""
 "یہ حد (KiB/s میں) ان ڈاؤن لوڈز پر لاگو ہوتی ہے جن میں رفتار کی حد فعال ہوتی "
 "ہے۔ قدر کو تبدیل کرنے سے پہلے سے چل رہے ڈاؤن لوڈز پر کوئی اثر نہیں پڑتا ہے۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1253,7 +1256,7 @@ msgstr ""
 "یہ پچھلی کیرنگ کو حذف کر دے گا اور اس کے ساتھ تمام پاس ورڈز کو ہٹا دے گا۔ یہ "
 "عمل ناقابل واپسی ہے۔"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr "مترجم کی خدمات کا اعتراف"
 
@@ -1262,7 +1265,7 @@ msgstr "مترجم کی خدمات کا اعتراف"
 msgid "Unable to disable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1271,7 +1274,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr "کیرنگ کو دوبارہ ترتیب دینے سے قاصر۔"
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "انحصار سیٹ اپ کرنے سے قاصر۔ براہ کرم ایپ کو دوبارہ شروع کریں اور دوبارہ کوشش "
@@ -1282,7 +1285,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "عنوان میں ترمیم کو کالعدم کریں"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "کی ڑینگ کو کھولیں"
 
@@ -1291,7 +1294,7 @@ msgstr "کی ڑینگ کو کھولیں"
 msgid "Unset Cookies File"
 msgstr "کوکیز فائل کو منتخب کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1343,7 +1346,7 @@ msgid "User Name (Empty)"
 msgstr "صارف کا نام (خالی)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1352,13 +1355,18 @@ msgid "Username"
 msgstr "صارف کا نام"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "توثیق کریں"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "توثیق کریں"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "ویڈیو"
 
@@ -1376,7 +1384,7 @@ msgid "Waiting..."
 msgstr "منتظر..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "بدتر"
 
@@ -1389,10 +1397,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ہاں"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-10-09 05:02+0000\n"
 "Last-Translator: Abdur Rehman Imran <arehmanimran4@gmail.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} کا ڈاؤن لوڈ مکمل کر لیا ہے۔"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} ایک خرابی کے ساتھ ختم ہو گیا ہے!"
@@ -131,8 +131,8 @@ msgstr "لاگ ان کا اضافہ کریں"
 msgid "Advanced Options"
 msgstr "اعلی درجے کے اختیارات"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "تمام ڈاؤن لوڈز مکمل ہو چکے ہیں۔"
 
@@ -230,8 +230,8 @@ msgstr "قطار میں لگے ڈاؤن لوڈز کو ختم کریں"
 msgid "Close"
 msgstr "بند کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "ڈاؤن لوڈز کو روکیں اور بند کریں ؟"
 
@@ -398,12 +398,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "تبادلوں کی اجازت نہ دیں"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "بات چیت"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -417,13 +425,13 @@ msgstr "ڈاؤن لوڈ کریں"
 msgid "Download Again"
 msgstr "دوبارہ ڈاؤن لوڈ کریں"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "ڈاؤن لوڈ مکمل"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 
@@ -485,8 +493,8 @@ msgstr "ڈاؤن لوڈ ہو رہا ہے {0:f2}% ({1})"
 msgid "Downloading..."
 msgstr "ڈاؤن لوڈینگ ہو رہی ہے"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "ڈاؤن لوڈز مکمل"
 
@@ -626,7 +634,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr "فیوڈور سوبولیف"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "گٹ ہب رجسٹر(ریپوسٹری)"
@@ -806,7 +814,7 @@ msgstr "نام"
 msgid "Name (Empty)"
 msgstr "نام (خالی)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -817,15 +825,15 @@ msgstr "نکولس لوگوزو"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "نہیں"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr "درست نیٹ موجود نہیں ہے"
 
@@ -895,6 +903,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "ٹھیک"
 
@@ -1015,7 +1024,7 @@ msgid "Queued"
 msgstr "قطار میں لگے ہوئے"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "باقی ڈاؤن لوڈ"
@@ -1118,8 +1127,8 @@ msgstr "ترتیبات"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1203,7 +1212,8 @@ msgstr "سب ٹائٹل کی زبانیں (غلط)"
 msgid "Success"
 msgstr "کامیابی"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
 "misuse of this program that may violate local copyright/DMCA laws. Users use "
@@ -1256,7 +1266,7 @@ msgstr "مترجم کی خدمات کا اعتراف"
 msgid "Unable to disable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1270,7 +1280,7 @@ msgstr "کیرنگ کو دوبارہ ترتیب دینے سے قاصر۔"
 msgid "Undo Title Editing"
 msgstr "عنوان میں ترمیم کو کالعدم کریں"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "کی ڑینگ کو کھولیں"
 
@@ -1279,7 +1289,7 @@ msgstr "کی ڑینگ کو کھولیں"
 msgid "Unset Cookies File"
 msgstr "کوکیز فائل کو منتخب کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1382,10 +1392,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ہاں"

--- a/NickvisionTubeConverter.Shared/Resources/po/ur.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-10-09 05:02+0000\n"
 "Last-Translator: Abdur Rehman Imran <arehmanimran4@gmail.com>\n"
 "Language-Team: Urdu <https://hosted.weblate.org/projects/nickvision-tube-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 5.1-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "{0} کا ڈاؤن لوڈ مکمل کر لیا ہے۔"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "{0} ایک خرابی کے ساتھ ختم ہو گیا ہے!"
@@ -100,7 +100,7 @@ msgstr "متعلق"
 msgid "Add"
 msgstr "اضافہ کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "ڈاؤن لوڈ شروع کرنے کے لیے ویڈیو، آڈیو یا پلے لسٹ یو-آر-ایل شامل کریں"
@@ -109,9 +109,9 @@ msgstr "ڈاؤن لوڈ شروع کرنے کے لیے ویڈیو، آڈیو یا
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "اعلی درجے کے اختیارات"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "تمام ڈاؤن لوڈز مکمل ہو چکے ہیں۔"
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو صاف کریں"
@@ -218,7 +218,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -231,7 +231,7 @@ msgid "Close"
 msgstr "بند کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "ڈاؤن لوڈز کو روکیں اور بند کریں ؟"
 
@@ -239,8 +239,8 @@ msgstr "ڈاؤن لوڈز کو روکیں اور بند کریں ؟"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "مکمل"
@@ -250,7 +250,7 @@ msgstr "مکمل"
 msgid "Completed Notification Trigger"
 msgstr "نوٹیفکیشن ٹرگر مکمل ہوا"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub پر تعاون کرنے والے ❤️"
 
@@ -304,11 +304,11 @@ msgstr "آڈیو تھمب نیلز کو تراشیں"
 msgid "Crop Thumbnail"
 msgstr "تھمب نیل کو تراشیں"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -322,7 +322,7 @@ msgid "Delete"
 msgstr "حذف کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "اسناد کو حذف کریں؟"
 
@@ -418,12 +418,12 @@ msgid "Download Again"
 msgstr "دوبارہ ڈاؤن لوڈ کریں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "ڈاؤن لوڈ مکمل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 
@@ -432,7 +432,7 @@ msgstr "خرابی کے ساتھ ڈاؤن لوڈ مکمل ہو گیا"
 msgid "Download log was copied to clipboard."
 msgstr "ڈاؤن لوڈ لاگ کو کلپ بورڈ پر کاپی کرلیاگیا۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "میڈیا ڈاؤن لوڈ کریں"
@@ -455,7 +455,7 @@ msgstr "aria2 کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہ�
 msgid "Download using ffmpeg has started"
 msgstr "ffmpeg کا استعمال کرتے ہوئے ڈاؤن لوڈ شروع ہو گیا ہے"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -467,8 +467,8 @@ msgstr "وئیب آڈیو اور ویدیو ڈاؤن لوڈ کریں"
 msgid "Downloader"
 msgstr "ڈاؤن لوڈر"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "ڈاؤن لوڈینگ ہو رہی ہے"
@@ -486,7 +486,7 @@ msgid "Downloading..."
 msgstr "ڈاؤن لوڈینگ ہو رہی ہے"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "ڈاؤن لوڈز مکمل"
 
@@ -589,7 +589,7 @@ msgid "Error"
 msgstr "خرابی"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr "باہر"
 
@@ -622,7 +622,7 @@ msgstr "فائل کی قسم"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr "فیوڈور سوبولیف"
 
@@ -683,7 +683,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -716,7 +716,7 @@ msgstr "زبان کے کوڈ کی معلومات"
 msgid "Leave empty to download from start."
 msgstr "شروع سے ڈاؤن لوڈ کرنے کے لیے خالی چھوڑ دیں۔"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "ہم آہنگ سائٹس کی فہرست"
 
@@ -727,8 +727,8 @@ msgstr "لاگ ان"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr "لاگ ان"
 
@@ -742,7 +742,7 @@ msgstr "تھمب نیل مربع بنائیں، موسیقی ڈاؤن لوڈ ک�
 msgid "Manage previously downloaded media."
 msgstr "پہلے ڈاؤن لوڈ کردہ میڈیا کا نظم کریں۔"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr "میٹرکس چیٹ"
 
@@ -796,40 +796,40 @@ msgstr "کم از کم تقسیم کا سائز (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "نام"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "نام (خالی)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr "نکولس لوگوزو"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "نہیں"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr "درست نیٹ موجود نہیں ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو صاف کریں"
@@ -843,7 +843,7 @@ msgstr "کوئی اسناد نہیں"
 msgid "No downloads running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہی ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "کوئی ڈاؤن لوڈ نہیں چل رہی ہے"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "کوئی پچھلا ڈاؤن لوڈز نہیں ہے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "قطار میں لگے ڈاؤن لوڈز کو ختم کریں"
@@ -937,14 +937,14 @@ msgstr "فولڈر کھولیں"
 msgid "Overwrite Existing Files"
 msgstr "موجودہ فائلوں کو دوبارہ لکھیں"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr "پیرابولک"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -953,7 +953,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -961,7 +961,7 @@ msgid "Password"
 msgstr "پاس ورڈ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "پاس ورڈ (خالی)"
 
@@ -978,11 +978,6 @@ msgstr "پلے لیٹ"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "تیاری چل رہی ہے..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1013,14 +1008,14 @@ msgstr "پراکسی یو-آر-ایل"
 msgid "Quality"
 msgstr "معیار"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "قطار میں لگے ہوئے"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "باقی ڈاؤن لوڈ"
@@ -1040,7 +1035,7 @@ msgid "Reset"
 msgstr "دوبارہ ترتیب دیں"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr "کی رینگ کو دوبارہ ترتیب کریں؟"
 
@@ -1066,7 +1061,7 @@ msgid "Retry Download"
 msgstr "دوبارہ ڈاؤن لوڈ کرنے کی کوشش کریں"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1113,18 +1108,18 @@ msgid "Select Save Folder"
 msgstr "مطلوبہ جگہ فراہم کریں"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "ترتیبات"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 msgid ""
 "Some downloads are still in progress.\n"
 "Are you sure you want to close Parabolic and stop the running downloads?"
@@ -1171,7 +1166,7 @@ msgid "Start Time (Invalid)"
 msgstr "ابتدائی وقت (غلط)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1229,7 +1224,7 @@ msgid "Theme"
 msgstr "تھیم"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 "اس عمل کر بعد کوئی واپسی نہیں ہے۔ کیا آپ اسے یقینی طور پر کرنا چاہتے ہیں؟"
@@ -1243,12 +1238,8 @@ msgstr ""
 "یہ حد (KiB/s میں) ان ڈاؤن لوڈز پر لاگو ہوتی ہے جن میں رفتار کی حد فعال ہوتی "
 "ہے۔ قدر کو تبدیل کرنے سے پہلے سے چل رہے ڈاؤن لوڈز پر کوئی اثر نہیں پڑتا ہے۔"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
@@ -1256,36 +1247,30 @@ msgstr ""
 "یہ پچھلی کیرنگ کو حذف کر دے گا اور اس کے ساتھ تمام پاس ورڈز کو ہٹا دے گا۔ یہ "
 "عمل ناقابل واپسی ہے۔"
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr "مترجم کی خدمات کا اعتراف"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr "کیرنگ کو غیر فعال کرنے سے قاصر۔"
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr "کیرنگ کو دوبارہ ترتیب دینے سے قاصر۔"
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"انحصار سیٹ اپ کرنے سے قاصر۔ براہ کرم ایپ کو دوبارہ شروع کریں اور دوبارہ کوشش "
-"کریں۔"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "عنوان میں ترمیم کو کالعدم کریں"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "کی ڑینگ کو کھولیں"
 
@@ -1294,19 +1279,19 @@ msgstr "کی ڑینگ کو کھولیں"
 msgid "Unset Cookies File"
 msgstr "کوکیز فائل کو منتخب کریں"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "یو-آر-ایل"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr "یو-آر-ایل (غلط)"
 
@@ -1340,7 +1325,7 @@ msgid "User Interface"
 msgstr "صارف انٹرفیس"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "صارف کا نام (خالی)"
@@ -1348,7 +1333,7 @@ msgstr "صارف کا نام (خالی)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1398,9 +1383,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "ہاں"
@@ -1546,6 +1531,15 @@ msgstr "- ایک وقت میں متعدد ڈاؤن لوڈز چلائیں"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "- میٹا ڈیٹا اور ویڈیو سب ٹائٹلز کو ڈاؤن لوڈ کرنے کی معرفت رکھتا ہے"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "تیاری چل رہی ہے..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "انحصار سیٹ اپ کرنے سے قاصر۔ براہ کرم ایپ کو دوبارہ شروع کریں اور دوبارہ "
+#~ "کوشش کریں۔"
 
 #~ msgid "Search..."
 #~ msgstr "تلاش کریں۔۔۔"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" đã được hoàn thành."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" đã kết thúc với lỗi!"
@@ -131,8 +131,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "Tùy chọn Nâng cao"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr "Tất cả tải xuống đều đã hoàn thành."
 
@@ -230,8 +230,8 @@ msgstr "Xóa Tải xuống Đang đợi"
 msgid "Close"
 msgstr "Đóng"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "Đóng và Dừng tất cả các quá trình tải xuống?"
 
@@ -392,12 +392,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Không cho phép Chuyển đổi"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Thảo Luận"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -412,13 +420,13 @@ msgstr "Tải xuống"
 msgid "Download Again"
 msgstr "Đang tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "Hoàn thành Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "Tải xuống kết thúc với lỗi"
 
@@ -481,8 +489,8 @@ msgstr "Đang tải về {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Đang tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "Hoàn thành Tải xuống"
 
@@ -624,7 +632,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
@@ -802,7 +810,7 @@ msgstr "Tên"
 msgid "Name (Empty)"
 msgstr "Tên (Trống)"
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -813,15 +821,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Không"
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -892,6 +900,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr "Đồng ý"
 
@@ -1013,7 +1022,7 @@ msgid "Queued"
 msgstr "Đã xếp hàng"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Thử lại Các Tải xuống Thất bại"
@@ -1117,8 +1126,8 @@ msgstr "Cài đặt"
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1206,7 +1215,8 @@ msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 msgid "Success"
 msgstr "Thành công"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1259,7 +1269,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1273,7 +1283,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Hoàn tác Chỉnh sửa Tiêu đề"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr "Mở khóa Keyring"
 
@@ -1282,7 +1292,7 @@ msgstr "Mở khóa Keyring"
 msgid "Unset Cookies File"
 msgstr "Chọn Tệp Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1383,10 +1393,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Có"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" đã được hoàn thành."
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" đã kết thúc với lỗi!"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr "(Có thể thay đổi trong tùy thích)"
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -66,8 +66,8 @@ msgstr[0] "{0} tải xuống — {1:f1}% ({2})"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgstr ""
 "Một tệp cookie có thể được cung cấp cho yt-dlp để tải những phương tiện "
 "truyền thông có yêu cầu đăng nhập."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr "Về {0}"
@@ -98,7 +98,7 @@ msgstr "Về {0}"
 msgid "Add"
 msgstr "Thêm"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -106,12 +106,12 @@ msgstr ""
 "đầu tải xuống"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -125,14 +125,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "Tùy chọn Nâng cao"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr "Tất cả tải xuống đều đã hoàn thành."
 
@@ -151,17 +151,17 @@ msgstr "Áp dụng"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "Âm thanh"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 msgid "Authenticate"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr "Quay lại"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr "Tốt nhất"
 
@@ -190,7 +190,7 @@ msgstr "Hủy"
 msgid "Changelog"
 msgstr "Lịch sử Thay đổi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Xóa Các tải xuống Đã hoàn thành"
@@ -217,21 +217,21 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
 msgstr "Xóa Tải xuống Đang đợi"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr "Đóng"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "Đóng và Dừng tất cả các quá trình tải xuống?"
 
@@ -239,8 +239,8 @@ msgstr "Đóng và Dừng tất cả các quá trình tải xuống?"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Hoàn tất"
@@ -250,7 +250,7 @@ msgstr "Hoàn tất"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -298,16 +298,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr "Cắt Thumbnail Âm thanh"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "Cắt Thumbnail"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgstr "Xóa bỏ"
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -392,15 +392,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr "Không cho phép Chuyển đổi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr "Thảo Luận"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -412,13 +412,13 @@ msgstr "Tải xuống"
 msgid "Download Again"
 msgstr "Đang tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "Hoàn thành Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "Tải xuống kết thúc với lỗi"
 
@@ -427,17 +427,17 @@ msgstr "Tải xuống kết thúc với lỗi"
 msgid "Download log was copied to clipboard."
 msgstr "Nhật ký tải xuống đã được lưu vào bảng ghi tạm."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Tải xuống Phương tiện truyền thông"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr "Tải Khung thời gian Cụ thể"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -451,20 +451,20 @@ msgstr "Tải xuống bằng aria2 đã bắt đầu"
 msgid "Download using ffmpeg has started"
 msgstr "Tải xuống bằng ffmpeg đã bắt đầu"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr "Tải xuống băng hình và âm thanh trên web"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "Trình tải xuống"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Đang tải xuống"
@@ -481,12 +481,12 @@ msgstr "Đang tải về {0:f2}% ({1:N0} KiB/s)"
 msgid "Downloading..."
 msgstr "Đang tải xuống"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "Hoàn thành Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -521,29 +521,29 @@ msgstr ""
 "không thấy tiến trình tải xuống."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr "Thời điểm Kết thúc"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 msgid "End Time (Invalid)"
 msgstr "Thời điểm Kết thúc (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 #, fuzzy
 msgid "Ender media url here"
 msgstr "Nhập địa chỉ video vào đây"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 #, fuzzy
 msgid "Ensure credentials are correct."
 msgstr "Quản lý credentials trong keyring của bạn."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 #, fuzzy
 msgid "Enter end timeframe here"
 msgstr "Nhập địa chỉ video vào đây"
@@ -553,7 +553,7 @@ msgstr "Nhập địa chỉ video vào đây"
 msgid "Enter name here"
 msgstr "Nhập địa chỉ video vào đây"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 #, fuzzy
 msgid "Enter password here"
@@ -564,7 +564,7 @@ msgstr "Nhập địa chỉ video vào đây"
 msgid "Enter proxy url here"
 msgstr "Nhập địa chỉ video vào đây"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 #, fuzzy
 msgid "Enter start timeframe here"
 msgstr "Nhập địa chỉ video vào đây"
@@ -574,7 +574,7 @@ msgstr "Nhập địa chỉ video vào đây"
 msgid "Enter url here"
 msgstr "Nhập địa chỉ video vào đây"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 #, fuzzy
 msgid "Enter user name here"
@@ -585,8 +585,8 @@ msgstr "Nhập địa chỉ video vào đây"
 msgid "Error"
 msgstr "Lỗi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "Tên Tệp"
@@ -610,7 +610,7 @@ msgstr "Tệp đã tồn tại, ghi đè không được cho phép"
 msgid "File Name"
 msgstr "Tên Tệp"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "Loại Tệp"
@@ -620,23 +620,23 @@ msgstr "Loại Tệp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -682,13 +682,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr "Keyring"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr "Chứng chỉ Keyring"
@@ -710,13 +710,13 @@ msgstr "Chứng chỉ Keyring"
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr "Để trống để tải xuống từ đầu."
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "Danh sách các trang được hỗ trợ"
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "Làm thumbnail vuông, hữu ích khi tải nhạc."
@@ -741,7 +741,7 @@ msgstr "Làm thumbnail vuông, hữu ích khi tải nhạc."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr ""
 
@@ -756,11 +756,11 @@ msgid "Max Number of Active Downloads"
 msgstr "Giới hạn Số lượng Tải xuống Đồng thời"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "Chất lượng Tối đa"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -769,14 +769,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr "Địa chỉ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
 
@@ -803,30 +802,30 @@ msgstr "Tên"
 msgid "Name (Empty)"
 msgstr "Tên (Trống)"
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Không"
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Xóa Các tải xuống Đã hoàn thành"
@@ -840,7 +839,7 @@ msgstr "Không có Credentials"
 msgid "No downloads running"
 msgstr "Không có tải xuống nào đang chạy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Không có tải xuống nào đang chạy"
@@ -856,26 +855,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Dừng Tất cả Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Xóa Tải xuống Đang đợi"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr "Đánh số Tiêu đề"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -896,14 +895,14 @@ msgstr ""
 msgid "OK"
 msgstr "Đồng ý"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -935,21 +934,21 @@ msgstr "Mở Thư mục"
 msgid "Overwrite Existing Files"
 msgstr "Ghi đè Tệp đã Tồn tại"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -970,11 +969,15 @@ msgid "Play"
 msgstr "Danh sách phát"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "Danh sách phát"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #, fuzzy
 msgid "Preparing required tools..."
 msgstr "Đang chuẩn bị..."
@@ -989,7 +992,7 @@ msgstr "Đang chuẩn bị..."
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -1003,19 +1006,19 @@ msgstr "Đang xử lý..."
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "Chất lượng"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Đã xếp hàng"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Thử lại Các Tải xuống Thất bại"
@@ -1025,7 +1028,7 @@ msgstr "Thử lại Các Tải xuống Thất bại"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr "Báo Lỗi"
 
@@ -1061,22 +1064,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "Thử tải lại"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "Thử lại Các Tải xuống Thất bại"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "Thư mục Lưu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "Thư mục Lưu (Không hợp lệ)"
 
@@ -1085,7 +1088,7 @@ msgstr "Thư mục Lưu (Không hợp lệ)"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1097,30 +1100,30 @@ msgstr "Dừng Tất cả"
 msgid "Select Cookies File"
 msgstr "Chọn Tệp Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "Chọn mục để tải xuống hoặc đổi tên tệp."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "Chọn Thư mục Lưu"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Cài đặt"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1133,20 +1136,20 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr "Một số tải xuống kết thúc với lỗi!"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr "Giới hạn Tốc độ"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 #, fuzzy
 msgid "Split Chapters"
 msgstr "Nhúng Chương"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1158,19 +1161,19 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Tệp Cookie"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr "Thời điểm Bắt đầu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 msgid "Start Time (Invalid)"
 msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1208,7 +1211,7 @@ msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 msgid "Success"
 msgstr "Thành công"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1244,7 +1247,7 @@ msgstr ""
 "hạn tốc độ. Thay đổi giá trị này không ảnh hưởng đến những tải xuống đang "
 "chạy."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1255,7 +1258,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1265,7 +1268,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1274,7 +1277,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 "Không thể tải xuống gói phụ thuộc. Vui lòng khởi động lại ứng dụng và thử "
@@ -1285,7 +1288,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "Hoàn tác Chỉnh sửa Tiêu đề"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr "Mở khóa Keyring"
 
@@ -1294,7 +1297,7 @@ msgstr "Mở khóa Keyring"
 msgid "Unset Cookies File"
 msgstr "Chọn Tệp Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1344,7 +1347,7 @@ msgid "User Name (Empty)"
 msgstr "Tên tài khoản (Trống)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1353,13 +1356,18 @@ msgid "Username"
 msgstr "Tên tài khoản"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "Xác thực"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "Xác thực"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "Băng hình"
 
@@ -1377,7 +1385,7 @@ msgid "Waiting..."
 msgstr "Đang chờ..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "Tệ nhất"
 
@@ -1390,10 +1398,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Có"

--- a/NickvisionTubeConverter.Shared/Resources/po/vi.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-06-14 01:21+0000\n"
 "Last-Translator: Khải <hvksmr1996@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/nickvision-"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr "\"{0}\" đã được hoàn thành."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr "\"{0}\" đã kết thúc với lỗi!"
@@ -98,7 +98,7 @@ msgstr "Về {0}"
 msgid "Add"
 msgstr "Thêm"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr ""
@@ -109,9 +109,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -132,7 +132,7 @@ msgid "Advanced Options"
 msgstr "Tùy chọn Nâng cao"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr "Tất cả tải xuống đều đã hoàn thành."
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr "Xóa Các tải xuống Đã hoàn thành"
@@ -218,7 +218,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 msgid "Clear Queued Downloads"
@@ -231,7 +231,7 @@ msgid "Close"
 msgstr "Đóng"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "Đóng và Dừng tất cả các quá trình tải xuống?"
 
@@ -239,8 +239,8 @@ msgstr "Đóng và Dừng tất cả các quá trình tải xuống?"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr "Hoàn tất"
@@ -250,7 +250,7 @@ msgstr "Hoàn tất"
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -303,11 +303,11 @@ msgstr "Cắt Thumbnail Âm thanh"
 msgid "Crop Thumbnail"
 msgstr "Cắt Thumbnail"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgid "Delete"
 msgstr "Xóa bỏ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr "Xóa bỏ Chứng chỉ?"
 
@@ -413,12 +413,12 @@ msgid "Download Again"
 msgstr "Đang tải xuống"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "Hoàn thành Tải xuống"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "Tải xuống kết thúc với lỗi"
 
@@ -427,7 +427,7 @@ msgstr "Tải xuống kết thúc với lỗi"
 msgid "Download log was copied to clipboard."
 msgstr "Nhật ký tải xuống đã được lưu vào bảng ghi tạm."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 msgid "Download Media"
 msgstr "Tải xuống Phương tiện truyền thông"
@@ -451,7 +451,7 @@ msgstr "Tải xuống bằng aria2 đã bắt đầu"
 msgid "Download using ffmpeg has started"
 msgstr "Tải xuống bằng ffmpeg đã bắt đầu"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -463,8 +463,8 @@ msgstr "Tải xuống băng hình và âm thanh trên web"
 msgid "Downloader"
 msgstr "Trình tải xuống"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "Đang tải xuống"
@@ -482,7 +482,7 @@ msgid "Downloading..."
 msgstr "Đang tải xuống"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "Hoàn thành Tải xuống"
 
@@ -586,7 +586,7 @@ msgid "Error"
 msgstr "Lỗi"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -620,7 +620,7 @@ msgstr "Loại Tệp"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -716,7 +716,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr "Để trống để tải xuống từ đầu."
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "Danh sách các trang được hỗ trợ"
 
@@ -726,8 +726,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr "Làm thumbnail vuông, hữu ích khi tải nhạc."
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr ""
 
@@ -792,40 +792,40 @@ msgstr "Kích thước Tách Tối thiểu (-k)"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 msgid "Name"
 msgstr "Tên"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr "Tên (Trống)"
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr "Không"
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "Xóa Các tải xuống Đã hoàn thành"
@@ -839,7 +839,7 @@ msgstr "Không có Credentials"
 msgid "No downloads running"
 msgstr "Không có tải xuống nào đang chạy"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "Không có tải xuống nào đang chạy"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "Dừng Tất cả Tải xuống"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "Xóa Tải xuống Đang đợi"
@@ -934,14 +934,14 @@ msgstr "Mở Thư mục"
 msgid "Overwrite Existing Files"
 msgstr "Ghi đè Tệp đã Tồn tại"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -950,7 +950,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -958,7 +958,7 @@ msgid "Password"
 msgstr "Mật khẩu"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr "Mật khẩu (Trống)"
 
@@ -976,11 +976,6 @@ msgstr "Danh sách phát"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
 msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-#, fuzzy
-msgid "Preparing required tools..."
-msgstr "Đang chuẩn bị..."
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:95
@@ -1011,14 +1006,14 @@ msgstr ""
 msgid "Quality"
 msgstr "Chất lượng"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr "Đã xếp hàng"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "Thử lại Các Tải xuống Thất bại"
@@ -1038,7 +1033,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #, fuzzy
 msgid "Reset Keyring?"
 msgstr "Thiết lập Keyring"
@@ -1065,7 +1060,7 @@ msgid "Retry Download"
 msgstr "Thử tải lại"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1112,18 +1107,18 @@ msgid "Select Save Folder"
 msgstr "Chọn Thư mục Lưu"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 #, fuzzy
 msgid "Settings"
 msgstr "Cài đặt"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1173,7 +1168,7 @@ msgid "Start Time (Invalid)"
 msgstr "Thời điểm Bắt đầu (Không hợp lệ)"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1233,7 +1228,7 @@ msgid "Theme"
 msgstr "Chủ đề"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr "Hành động này không thể đảo ngược. Bạn chắc chắn muốn xóa nó chứ?"
 
@@ -1247,48 +1242,38 @@ msgstr ""
 "hạn tốc độ. Thay đổi giá trị này không ảnh hưởng đến những tải xuống đang "
 "chạy."
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 #, fuzzy
 msgid "Unable to disable keyring."
 msgstr "Vô hiệu hóa Keyring?"
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
 msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
-msgstr ""
-"Không thể tải xuống gói phụ thuộc. Vui lòng khởi động lại ứng dụng và thử "
-"lại."
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
 #: NickvisionTubeConverter.GNOME/Blueprints/media_row.blp:16
 msgid "Undo Title Editing"
 msgstr "Hoàn tác Chỉnh sửa Tiêu đề"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr "Mở khóa Keyring"
 
@@ -1297,19 +1282,19 @@ msgstr "Mở khóa Keyring"
 msgid "Unset Cookies File"
 msgstr "Chọn Tệp Cookie"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr "Địa chỉ"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 #, fuzzy
 msgid "URL (Invalid)"
 msgstr "Địa chỉ (Không hợp lệ)"
@@ -1341,7 +1326,7 @@ msgid "User Interface"
 msgstr "Giao diện"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "Tên tài khoản (Trống)"
@@ -1349,7 +1334,7 @@ msgstr "Tên tài khoản (Trống)"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 msgid "Username"
@@ -1399,9 +1384,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr "Có"
@@ -1548,6 +1533,15 @@ msgstr "— Chạy nhiều tải xuống cùng một lúc"
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:13
 msgid "— Supports downloading metadata and video subtitles"
 msgstr "— Hỗ trợ tải về siêu dữ liệu và phụ đề"
+
+#, fuzzy
+#~ msgid "Preparing required tools..."
+#~ msgstr "Đang chuẩn bị..."
+
+#~ msgid "Unable to setup dependencies. Please restart the app and try again."
+#~ msgstr ""
+#~ "Không thể tải xuống gói phụ thuộc. Vui lòng khởi động lại ứng dụng và thử "
+#~ "lại."
 
 #, fuzzy
 #~ msgctxt "Subtitle"

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-07 21:58-0500\n"
+"POT-Creation-Date: 2023-11-08 10:56-0500\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,14 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -130,8 +130,8 @@ msgstr ""
 msgid "Advanced Options"
 msgstr "高级选项"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "All downloads have finished."
 msgstr ""
 
@@ -231,8 +231,8 @@ msgstr "清除排队的下载"
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:218
 msgid "Close and Stop Downloads?"
 msgstr "关闭并停止下载？"
 
@@ -389,12 +389,20 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:171
+msgid "Disclaimer"
+msgstr ""
+
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:167
+msgid "Don't show this message again"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
@@ -409,13 +417,13 @@ msgstr "下载"
 msgid "Download Again"
 msgstr "下载中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished"
 msgstr "下载完成"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:689
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:681
 msgid "Download Finished With Error"
 msgstr "下载完成，但出现错误"
 
@@ -480,8 +488,8 @@ msgstr ""
 msgid "Downloading..."
 msgstr "下载中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:693
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:685
 msgid "Downloads Finished"
 msgstr "已完成的下载"
 
@@ -612,7 +620,7 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:532
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
@@ -783,7 +791,7 @@ msgstr "文件名"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:327
+#: ../../../Controllers/MainWindowController.cs:346
 msgid "New update available."
 msgstr ""
 
@@ -794,15 +802,15 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:274
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:303
+#: ../../../Controllers/MainWindowController.cs:317
 msgid "No active internet connection"
 msgstr ""
 
@@ -873,6 +881,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/AboutDialog.xaml.cs:30
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs:206
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 msgid "OK"
 msgstr ""
 
@@ -995,7 +1004,7 @@ msgid "Queued"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:624
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "重试失败的下载"
@@ -1097,8 +1106,8 @@ msgstr ""
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:219
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1186,7 +1195,8 @@ msgstr "保存文件夹（无效）"
 msgid "Success"
 msgstr "成功"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:528
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:182
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1234,7 +1244,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:343
+#: ../../../Controllers/MainWindowController.cs:362
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1248,7 +1258,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "撤消标题编辑"
 
-#: ../../../Controllers/MainWindowController.cs:285
+#: ../../../Controllers/MainWindowController.cs:299
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1257,7 +1267,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "选择 Cookie 文件"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:326
 msgid "Update"
 msgstr ""
 
@@ -1358,10 +1368,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:277
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:220
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-04 00:13-0400\n"
+"POT-Creation-Date: 2023-11-07 21:58-0500\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -20,13 +20,13 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Add"
 msgstr "添加"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "添加视频、音频或播放列表地址以开始下载"
@@ -107,9 +107,9 @@ msgstr "添加视频、音频或播放列表地址以开始下载"
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -131,7 +131,7 @@ msgid "Advanced Options"
 msgstr "高级选项"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "All downloads have finished."
 msgstr ""
 
@@ -200,7 +200,7 @@ msgid "Chrome/Edge"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -218,7 +218,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -232,7 +232,7 @@ msgid "Close"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:184
 msgid "Close and Stop Downloads?"
 msgstr "关闭并停止下载？"
 
@@ -240,8 +240,8 @@ msgstr "关闭并停止下载？"
 msgid "Comma separated list"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:126
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -304,11 +304,11 @@ msgstr "裁剪缩略图"
 msgid "Crop Thumbnail"
 msgstr "裁剪缩略图"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:135
+#: ../../../Controllers/MainWindowController.cs:130
 msgid "David Lapshin"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgid "Delete"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:252
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
 msgid "Delete Credential?"
 msgstr ""
 
@@ -410,12 +410,12 @@ msgid "Download Again"
 msgstr "下载中"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished"
 msgstr "下载完成"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:647
 msgid "Download Finished With Error"
 msgstr "下载完成，但出现错误"
 
@@ -424,7 +424,7 @@ msgstr "下载完成，但出现错误"
 msgid "Download log was copied to clipboard."
 msgstr "下载日志已复制到剪贴板。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
@@ -450,7 +450,7 @@ msgstr "使用 aria2 的下载已经开始"
 msgid "Download using ffmpeg has started"
 msgstr "使用 aria2 的下载已经开始"
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:119
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
@@ -462,8 +462,8 @@ msgstr ""
 msgid "Downloader"
 msgstr "下载器"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "下载中"
@@ -481,7 +481,7 @@ msgid "Downloading..."
 msgstr "下载中"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:651
 msgid "Downloads Finished"
 msgstr "已完成的下载"
 
@@ -575,7 +575,7 @@ msgid "Error"
 msgstr "错误"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Exit"
 msgstr ""
 
@@ -608,7 +608,7 @@ msgstr "文件类型"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "Fyodor Sobolev"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:315
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:123
 msgid "List of supported sites"
 msgstr "支持的网站列表"
 
@@ -705,8 +705,8 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:182
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:201
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:217
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:340
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:220
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:343
 msgid "Login"
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr "使缩略图成正方形，在下载音乐时很有用。"
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:124
 msgid "Matrix Chat"
 msgstr ""
 
@@ -772,41 +772,41 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:219
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:276
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:155
 #, fuzzy
 msgid "Name"
 msgstr "文件名"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:229
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:285
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:336
+#: ../../../Controllers/MainWindowController.cs:327
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:127
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:180
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:258
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:310
+#: ../../../Controllers/MainWindowController.cs:303
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "清除排队的下载"
@@ -820,7 +820,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "下载中"
@@ -836,7 +836,7 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "停止所有下载"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "清除排队的下载"
@@ -916,14 +916,14 @@ msgstr "打开保存文件夹"
 msgid "Overwrite Existing Files"
 msgstr "覆盖现有的文件"
 
-#: ../../../Controllers/MainWindowController.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
+#: ../../../Controllers/MainWindowController.cs:118
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
@@ -932,7 +932,7 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:282
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:170
 #: NickvisionTubeConverter.GNOME/Blueprints/password_dialog.blp:52
@@ -940,7 +940,7 @@ msgid "Password"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:236
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:287
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:290
 msgid "Password (Empty)"
 msgstr ""
 
@@ -957,10 +957,6 @@ msgstr "播放列表"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
 msgid "Please wait..."
-msgstr ""
-
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
-msgid "Preparing required tools..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs:134
@@ -992,14 +988,14 @@ msgstr ""
 msgid "Quality"
 msgstr "质量"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:590
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "重试失败的下载"
@@ -1019,7 +1015,7 @@ msgid "Reset"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:175
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 msgid "Reset Keyring?"
 msgstr ""
 
@@ -1045,7 +1041,7 @@ msgid "Retry Download"
 msgstr "重试下载"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
@@ -1092,17 +1088,17 @@ msgid "Select Save Folder"
 msgstr "选择保存文件夹"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 msgid "Show Window"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:185
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1152,7 +1148,7 @@ msgid "Start Time (Invalid)"
 msgstr "保存文件夹（无效）"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1211,7 +1207,7 @@ msgid "Theme"
 msgstr "主题"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:315
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:253
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:256
 msgid "This action is irreversible. Are you sure you want to delete it?"
 msgstr ""
 
@@ -1222,37 +1218,29 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
-msgid "This may take a while"
-msgstr ""
-
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:252
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:176
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 msgid ""
 "This will delete the previous keyring removing all passwords with it. This "
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:136
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "translator-credits"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:288
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:160
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:161
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:353
+#: ../../../Controllers/MainWindowController.cs:343
 msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:269
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:194
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:196
 msgid "Unable to reset keyring."
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:284
-msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/MediaRow.xaml.cs:32
@@ -1260,7 +1248,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "撤消标题编辑"
 
-#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:285
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1269,19 +1257,19 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "选择 Cookie 文件"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:292
 msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:221
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:50
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:277
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:280
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:160
 msgid "URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:241
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:291
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:294
 msgid "URL (Invalid)"
 msgstr ""
 
@@ -1312,7 +1300,7 @@ msgid "User Interface"
 msgstr "用户界面"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:234
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:286
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:289
 #, fuzzy
 msgid "User Name (Empty)"
 msgstr "用户界面"
@@ -1320,7 +1308,7 @@ msgstr "用户界面"
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
 #: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:281
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:165
 #, fuzzy
@@ -1371,9 +1359,9 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
 #: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
-#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:179
+#: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:257
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
+++ b/NickvisionTubeConverter.Shared/Resources/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-01 20:56-0400\n"
+"POT-Creation-Date: 2023-11-04 00:13-0400\n"
 "PO-Revision-Date: 2023-06-04 16:26+0000\n"
 "Last-Translator: 刘韬 <lyuutau@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,20 +19,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished downloading."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 #, csharp-format
 msgid "\"{0}\" has finished with an error!"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 msgid "(Configurable in preferences)"
 msgstr ""
 
@@ -48,7 +48,7 @@ msgstr "{0:f1} GiB/s"
 
 #: ../../../Helpers/SpeedFormatter.cs:28
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:233
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:106
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:107
 #, csharp-format
 msgid "{0:f1} KiB/s"
 msgstr "{0:f1} KiB/s"
@@ -67,8 +67,8 @@ msgstr[1] ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:427
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:535
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:548
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:453
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:543
 #, csharp-format
 msgid "{0} of {1} items"
 msgid_plural "{0} of {1} items"
@@ -87,7 +87,7 @@ msgid ""
 "requires a login."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
 #, csharp-format
 msgid "About {0}"
 msgstr ""
@@ -98,18 +98,18 @@ msgstr ""
 msgid "Add"
 msgstr "添加"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:78
 msgid "Add a video, audio, or playlist URL to start downloading"
 msgstr "添加视频、音频或播放列表地址以开始下载"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:97
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:256
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:40
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:262
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:105
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:37
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:82
@@ -124,14 +124,14 @@ msgid "Add Login"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:96
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:255
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:261
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:160
 msgid "Advanced Options"
 msgstr "高级选项"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "All downloads have finished."
 msgstr ""
 
@@ -150,17 +150,17 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:384
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:514
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:508
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Audio"
 msgstr "音频"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:126
 msgid "Audio Language"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:63
 #, fuzzy
 msgid "Authenticate"
@@ -170,7 +170,7 @@ msgstr "应用"
 msgid "Automatically Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:43
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:36
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:24
 #: NickvisionTubeConverter.GNOME/Blueprints/keyring_dialog.blp:25
@@ -178,7 +178,7 @@ msgid "Back"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Best"
 msgstr ""
 
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
 msgid "Check for Updates"
 msgstr ""
 
@@ -199,8 +199,8 @@ msgstr ""
 msgid "Chrome/Edge"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:121
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:217
 msgid "Clear Completed Downloads"
 msgstr ""
@@ -217,8 +217,8 @@ msgid ""
 "of the media source"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:169
 #, fuzzy
@@ -226,13 +226,13 @@ msgid "Clear Queued Downloads"
 msgstr "清除排队的下载"
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:37
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:42
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:35
 msgid "Close"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:186
 msgid "Close and Stop Downloads?"
 msgstr "关闭并停止下载？"
 
@@ -240,8 +240,8 @@ msgstr "关闭并停止下载？"
 msgid "Comma separated list"
 msgstr ""
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:117
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:198
 msgid "Completed"
 msgstr ""
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Completed Notification Trigger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:122
+#: ../../../Controllers/MainWindowController.cs:131
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
@@ -299,16 +299,16 @@ msgstr ""
 msgid "Crop Audio Thumbnails"
 msgstr "裁剪缩略图"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:318
 msgid "Crop Thumbnail"
 msgstr "裁剪缩略图"
 
-#: ../../../Controllers/MainWindowController.cs:125
+#: ../../../Controllers/MainWindowController.cs:134
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:135
 msgid "David Lapshin"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Delete Credential?"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:254
 msgid "Deselect All"
 msgstr ""
@@ -389,15 +389,15 @@ msgstr ""
 msgid "Disallow Conversions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:100
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:96
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:535
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:208
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgid "Download"
@@ -409,13 +409,13 @@ msgstr "下载"
 msgid "Download Again"
 msgstr "下载中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished"
 msgstr "下载完成"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:684
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:655
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:649
 msgid "Download Finished With Error"
 msgstr "下载完成，但出现错误"
 
@@ -424,18 +424,18 @@ msgstr "下载完成，但出现错误"
 msgid "Download log was copied to clipboard."
 msgstr "下载日志已复制到剪贴板。"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:104
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:77
 #, fuzzy
 msgid "Download Media"
 msgstr "下载媒体"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:330
 msgid "Download Specific Timeframe"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:58
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:131
 #, fuzzy
 msgid "Download Subtitle"
@@ -450,20 +450,20 @@ msgstr "使用 aria2 的下载已经开始"
 msgid "Download using ffmpeg has started"
 msgstr "使用 aria2 的下载已经开始"
 
-#: ../../../Controllers/MainWindowController.cs:115
+#: ../../../Controllers/MainWindowController.cs:124
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:5
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:8
 msgid "Download web video and audio"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:58
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:76
 msgid "Downloader"
 msgstr "下载器"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:109
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:119
 msgid "Downloading"
 msgstr "下载中"
@@ -480,12 +480,12 @@ msgstr ""
 msgid "Downloading..."
 msgstr "下载中"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:688
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:659
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:653
 msgid "Downloads Finished"
 msgstr "已完成的下载"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
 msgid "Edit"
 msgstr ""
 
@@ -518,28 +518,28 @@ msgid ""
 msgstr "启用以使用 aria2 下载器。它可能会更快，但不会显示下载进度。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:457
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:580
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:575
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:341
 msgid "End Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:477
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:593
 #, fuzzy
 msgid "End Time (Invalid)"
 msgstr "保存文件夹（无效）"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:45
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
 msgid "Ender media url here"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:375
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:503
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:497
 msgid "Ensure credentials are correct."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:94
 msgid "Enter end timeframe here"
 msgstr ""
 
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Enter name here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:55
 msgid "Enter password here"
 msgstr ""
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Enter proxy url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:91
 msgid "Enter start timeframe here"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Enter url here"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:53
 msgid "Enter user name here"
 msgstr ""
@@ -574,8 +574,8 @@ msgstr ""
 msgid "Error"
 msgstr "错误"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:85
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:128
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
 msgid "Exit"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgstr ""
 msgid "Failed to enable keyring."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:82
 #, fuzzy
 msgid "File"
 msgstr "文件名"
@@ -598,7 +598,7 @@ msgstr "文件已经存在，且不允许覆盖"
 msgid "File Name"
 msgstr "文件名"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:55
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:112
 msgid "File Type"
 msgstr "文件类型"
@@ -608,23 +608,23 @@ msgstr "文件类型"
 msgid "Firefox"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:124
+#: ../../../Controllers/MainWindowController.cs:133
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:531
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:97
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:95
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:94
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:60
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:11
 msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.WinUI/Controls/HistoryDialog.xaml.cs:36
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
 #: NickvisionTubeConverter.GNOME/Blueprints/history_dialog.blp:31
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:45
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:6
@@ -663,13 +663,13 @@ msgstr ""
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:141
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:34
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:312
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:40
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:5
 msgid "Keyring"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:51
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:68
 msgid "Keyring Credential"
 msgstr ""
@@ -689,13 +689,13 @@ msgstr ""
 msgid "Language Code Information"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:93
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:337
 msgid "Leave empty to download from start."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:119
+#: ../../../Controllers/MainWindowController.cs:128
 msgid "List of supported sites"
 msgstr "支持的网站列表"
 
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:81
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:319
 msgid "Make thumbnail square, useful when downloading music."
 msgstr "使缩略图成正方形，在下载音乐时很有用。"
@@ -720,7 +720,7 @@ msgstr "使缩略图成正方形，在下载音乐时很有用。"
 msgid "Manage previously downloaded media."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:120
+#: ../../../Controllers/MainWindowController.cs:129
 msgid "Matrix Chat"
 msgstr ""
 
@@ -736,11 +736,11 @@ msgid "Max Number of Active Downloads"
 msgstr "最大活动下载数"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:428
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:546
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:541
 msgid "Maximum Quality"
 msgstr "最高质量"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:85
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:331
 msgid ""
 "Media can possibly be cut inaccurately.\n"
@@ -749,14 +749,13 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:365
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:44
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:477
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:46
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:57
 msgid "Media URL"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:372
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:500
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:494
 msgid "Media URL (Invalid)"
 msgstr ""
 
@@ -784,30 +783,30 @@ msgstr "文件名"
 msgid "Name (Empty)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:336
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
-#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:132
 msgid "Nicholas Logozzo"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:254
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:317
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:269
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:273
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:178
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:255
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:180
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:300
+#: ../../../Controllers/MainWindowController.cs:310
 msgid "No active internet connection"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
 #, fuzzy
 msgid "No Completed Downloads"
 msgstr "清除排队的下载"
@@ -821,7 +820,7 @@ msgstr ""
 msgid "No downloads running"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
 #, fuzzy
 msgid "No Downloads Running"
 msgstr "下载中"
@@ -837,26 +836,26 @@ msgstr ""
 msgid "No Previous Downloads"
 msgstr "停止所有下载"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:113
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:112
 #, fuzzy
 msgid "No Queued Downloads"
 msgstr "清除排队的下载"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:195
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:229
 msgid "Number Titles"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:48
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:68
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:80
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:84
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:45
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:53
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -877,14 +876,14 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:47
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:59
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:66
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:69
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:82
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:86
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:49
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:60
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:67
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:70
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:75
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:79
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:83
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:87
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:44
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:56
@@ -917,21 +916,21 @@ msgstr "打开保存文件夹"
 msgid "Overwrite Existing Files"
 msgstr "覆盖现有的文件"
 
-#: ../../../Controllers/MainWindowController.cs:114
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:124
+#: ../../../Controllers/MainWindowController.cs:123
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in:4
 #: NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in:6
 msgid "Parabolic"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:107
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:106
 msgid ""
 "Parabolic's documentation and support channels are accessible via the Help "
 "menu."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:225
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:54
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:279
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:76
@@ -952,11 +951,15 @@ msgid "Play"
 msgstr "播放列表"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:95
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:254
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:260
 msgid "Playlist"
 msgstr "播放列表"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:470
+msgid "Please wait..."
+msgstr ""
+
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:101
 msgid "Preparing required tools..."
 msgstr ""
 
@@ -970,7 +973,7 @@ msgstr ""
 msgid "Prevent Suspend"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:76
 msgid "PREVIEW"
 msgstr ""
 
@@ -984,19 +987,19 @@ msgstr ""
 msgid "Proxy URL"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:56
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:57
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:119
 msgid "Quality"
 msgstr "质量"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:114
 #: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:115
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:116
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:159
 msgid "Queued"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:123
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:598
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:122
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:592
 #, fuzzy, csharp-format
 msgid "Remaining Downloads: {0}"
 msgstr "重试失败的下载"
@@ -1006,7 +1009,7 @@ msgstr "重试失败的下载"
 msgid "Remove Source Data"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:99
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:98
 msgid "Report a Bug"
 msgstr ""
 
@@ -1041,22 +1044,22 @@ msgstr ""
 msgid "Retry Download"
 msgstr "重试下载"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:93
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:120
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:92
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:119
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:26
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:209
 msgid "Retry Failed Downloads"
 msgstr "重试失败的下载"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:453
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:61
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:578
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:573
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:146
 msgid "Save Folder"
 msgstr "保存文件夹"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:467
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:590
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:585
 msgid "Save Folder (Invalid)"
 msgstr "保存文件夹（无效）"
 
@@ -1065,7 +1068,7 @@ msgstr "保存文件夹（无效）"
 msgid "Search history"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:71
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:72
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:247
 #, fuzzy
 msgid "Select All"
@@ -1077,29 +1080,29 @@ msgstr "全部停止"
 msgid "Select Cookies File"
 msgstr "选择 Cookie 文件"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:64
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:65
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:183
 msgid "Select items to download or change file names."
 msgstr "选择要下载的项目或更改文件名。"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:510
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:62
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:153
 msgid "Select Save Folder"
 msgstr "选择保存文件夹"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:89
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:127
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:88
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:34
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:126
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:125
 msgid "Show Window"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:267
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:271
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:187
 #, fuzzy
 msgid ""
 "Some downloads are still in progress.\n"
@@ -1112,19 +1115,19 @@ msgstr ""
 msgid "Some downloads finished with errors!"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:73
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:74
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:63
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:295
 #: NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Speed Limit"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:76
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:306
 msgid "Split Chapters"
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:77
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:78
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:307
 msgid "Splits the video into multiple smaller ones based on its chapters."
 msgstr ""
@@ -1136,20 +1139,20 @@ msgid "SponsorBlock Information (opens in a web browser)"
 msgstr "Cookie 文件"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:455
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:88
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:579
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:89
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:574
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:336
 msgid "Start Time"
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:472
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:594
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:589
 #, fuzzy
 msgid "Start Time (Invalid)"
 msgstr "保存文件夹（无效）"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:91
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:111
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:90
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTubeConverter.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTubeConverter.GNOME/Blueprints/window.blp:129
 msgid "Stop All Downloads"
@@ -1187,7 +1190,7 @@ msgstr "保存文件夹（无效）"
 msgid "Success"
 msgstr "成功"
 
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:523
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:527
 #, fuzzy
 msgid ""
 "The authors of Nickvision Parabolic are not responsible/liable for any "
@@ -1219,7 +1222,7 @@ msgid ""
 "Changing the value doesn't affect already running downloads."
 msgstr ""
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:103
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:102
 msgid "This may take a while"
 msgstr ""
 
@@ -1230,7 +1233,7 @@ msgid ""
 "action is irreversible."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "translator-credits"
 msgstr ""
 
@@ -1239,7 +1242,7 @@ msgstr ""
 msgid "Unable to disable keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:342
+#: ../../../Controllers/MainWindowController.cs:353
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1248,7 +1251,7 @@ msgstr ""
 msgid "Unable to reset keyring."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
+#: ../../../Controllers/MainWindowController.cs:284
 msgid "Unable to setup dependencies. Please restart the app and try again."
 msgstr ""
 
@@ -1257,7 +1260,7 @@ msgstr ""
 msgid "Undo Title Editing"
 msgstr "撤消标题编辑"
 
-#: ../../../Controllers/MainWindowController.cs:282
+#: ../../../Controllers/MainWindowController.cs:292
 msgid "Unlock Keyring"
 msgstr ""
 
@@ -1266,7 +1269,7 @@ msgstr ""
 msgid "Unset Cookies File"
 msgstr "选择 Cookie 文件"
 
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:294
 msgid "Update"
 msgstr ""
 
@@ -1315,7 +1318,7 @@ msgid "User Name (Empty)"
 msgstr "用户界面"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:223
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:50
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:52
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:278
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:72
@@ -1325,13 +1328,18 @@ msgid "Username"
 msgstr "用户界面"
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:368
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:54
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:41
 #: NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp:82
 msgid "Validate"
 msgstr "验证"
 
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:465
+#, fuzzy
+msgid "Validating"
+msgstr "验证"
+
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:397
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:527
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:521
 msgid "Video"
 msgstr "视频"
 
@@ -1349,7 +1357,7 @@ msgid "Waiting..."
 msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs:81
-#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:39
+#: ../../../../NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs:38
 msgid "Worst"
 msgstr "最差"
 
@@ -1362,10 +1370,10 @@ msgstr ""
 
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:257
 #: ../../../../NickvisionTubeConverter.GNOME/Views/KeyringDialog.cs:320
-#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:272
+#: ../../../../NickvisionTubeConverter.GNOME/Views/MainWindow.cs:276
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:177
 #: ../../../../NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs:254
-#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTubeConverter.WinUI/Views/SettingsDialog.xaml.cs:179
 msgid "Yes"
 msgstr ""

--- a/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in
+++ b/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.desktop.in
@@ -8,6 +8,7 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Network;
 Keywords=YouTube;Downloader;ytdlp;Nickvision;Tube;Converter;
+MimeType=text/x-uri
 X-GNOME-UsesNotifications=true
 StartupNotify=true
 # Translators: Do NOT translate or transliterate this text (these are enum types)!

--- a/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/NickvisionTubeConverter.Shared/org.nickvision.tubeconverter.metainfo.xml.in
@@ -53,6 +53,7 @@
     <release version="2023.11.0-beta1" date="2023-11-03">
       <description translatable="no">
         <p>- Parabolic is now available for Windows using Windows App SDK and WinUI 3</p>
+        <p>- A URL can now be passed to Parabolic via the command-line or the freedesktop application open protocol to trigger its validation of startup</p>
         <p>- Fixed an issue where aria's max connections per server preference was allowed to be greater than 16</p>
         <p>- Fixed an issue where enabling the "Download Specific Timeframe" advanced option would cause a crash for certain media downloads</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>

--- a/NickvisionTubeConverter.WinUI/App.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/App.xaml.cs
@@ -2,6 +2,7 @@
 using NickvisionTubeConverter.Shared.Controllers;
 using NickvisionTubeConverter.Shared.Models;
 using NickvisionTubeConverter.WinUI.Views;
+using System;
 
 namespace NickvisionTubeConverter.WinUI;
 
@@ -20,7 +21,7 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
-        _controller = new MainWindowController();
+        _controller = new MainWindowController(Array.Empty<string>());
         _controller.AppInfo.Changelog = @"- Parabolic is now available for Windows using Windows App SDK and WinUI 3
 - Fixed an issue where aria's max connections per server preference was allowed to be greater than 16
 - Fixed an issue where enabling the ""Download Specific Timeframe"" advanced option would cause a crash for certain media downloads

--- a/NickvisionTubeConverter.WinUI/Installer/InnoSetupScript.iss
+++ b/NickvisionTubeConverter.WinUI/Installer/InnoSetupScript.iss
@@ -33,16 +33,16 @@ SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=admin
 DirExistsWarning=no
+CloseApplications=force
+ChangesEnvironment=yes
 AlwaysRestart=yes
-; In case a user chooses to not restart
-ChangesEnvironment=yes 
 
 [Code]
 procedure SetupDotnet();
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\deps\dotnet-runtime-7.0.11-win-x64.exe'), '/install /quiet /norestart', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode)
+  if not Exec(ExpandConstant('{app}\deps\dotnet-runtime-7.0.11-win-x64.exe'), '/install /quiet /norestart', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   then
     MsgBox('Unable to install .NET . Please try again', mbError, MB_OK);
 end;
@@ -51,7 +51,7 @@ procedure SetupWinAppSDK();
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\deps\WindowsAppRuntimeInstall-x64.exe'), '--quiet', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode)
+  if not Exec(ExpandConstant('{app}\deps\WindowsAppRuntimeInstall-x64.exe'), '--quiet', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   then
     MsgBox('Unable to install Windows App SDK. Please try again', mbError, MB_OK);
 end;
@@ -60,9 +60,19 @@ procedure SetupPython();
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\deps\python-3.11.6-amd64.exe'), '/quiet InstallAllUsers=1 AppendPath=1 Include_test=0', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode)
+  if not Exec(ExpandConstant('{app}\deps\python-3.11.6-amd64.exe'), '/quiet InstallAllUsers=1 AppendPath=1 Include_test=0', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   then
-    MsgBox('Unable to install Python. Please try again', mbError, MB_OK);
+    MsgBox('Unable to install Python. Please try again. THE APP WILL NOT FUNCTION CORRECTLY.', mbError, MB_OK)
+  else begin
+    if not Exec(ExpandConstant('C:\Program Files\Python311\pythonw.exe'), '-m pip install -U psutil', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+    then
+      MsgBox('Unable to install psutil. Please try again. THE APP WILL NOT FUNCTION CORRECTLY.', mbError, MB_OK)
+    else begin
+      if not Exec(ExpandConstant('C:\Program Files\Python311\pythonw.exe'), '-m pip install -U yt-dlp', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+      then
+        MsgBox('Unable to install yt-dlp. Please try again. THE APP WILL NOT FUNCTION CORRECTLY.', mbError, MB_OK);
+    end;
+  end;
 end;
 
 [Languages]

--- a/NickvisionTubeConverter.WinUI/NickvisionTubeConverter.WinUI.csproj
+++ b/NickvisionTubeConverter.WinUI/NickvisionTubeConverter.WinUI.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.4.17" />
     <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.17" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.WinUI/NickvisionTubeConverter.WinUI.csproj
+++ b/NickvisionTubeConverter.WinUI/NickvisionTubeConverter.WinUI.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageReference Include="Vanara.PInvoke.Kernel32" Version="3.4.17" />
     <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.17" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.1" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml
+++ b/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml
@@ -36,7 +36,7 @@
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE12B;"/>
                                 </wct:SettingsCard.HeaderIcon>
 
-                                <TextBox x:Name="TxtUrl" MinWidth="300" MaxWidth="400" TextChanged="TxtUrl_TextChanged" KeyDown="TxtUrl_KeyDown"/>
+                                <TextBox x:Name="TxtUrl" MinWidth="300" MaxWidth="400" TextChanged="TxtUrl_TextChanged"/>
                             </wct:SettingsCard>
 
                             <wct:SettingsExpander x:Name="CardAuthenticate" IsExpanded="{x:Bind TglAuthenticate.IsOn, Mode=TwoWay}">
@@ -72,10 +72,6 @@
                                     </wct:SettingsCard>
                                 </wct:SettingsExpander.Items>
                             </wct:SettingsExpander>
-
-                            <ProgressRing x:Name="ProgRingUrl" Margin="0,6,0,6" Visibility="Collapsed"/>
-
-                            <Button x:Name="BtnValidate" HorizontalAlignment="Stretch" IsEnabled="False" Style="{ThemeResource AccentButtonStyle}" Click="Validate"/>
                         </StackPanel>
                     </nickvision:ViewStackPage>
 

--- a/NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml
+++ b/NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml
@@ -156,7 +156,7 @@
 
             <InfoBar x:Name="InfoBar" Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,6" CornerRadius="12">
                 <InfoBar.ActionButton>
-                    <Button x:Name="BtnInfoBarReset" HorizontalAlignment="Right" Visibility="Collapsed" Click="Reset"/>
+                    <Button x:Name="BtnReset" HorizontalAlignment="Right" Visibility="Collapsed" Click="Reset"/>
                 </InfoBar.ActionButton>
             </InfoBar>
         </Grid>

--- a/NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/KeyringDialog.xaml.cs
@@ -55,7 +55,7 @@ public sealed partial class KeyringDialog : ContentDialog
         TxtPassword.PlaceholderText = _("Enter password here");
         LblBtnAddCredential.Text = _("Add");
         LblBtnDeleteCredential.Text = _("Delete");
-        BtnInfoBarReset.Content = _("Reset");
+        BtnReset.Content = _("Reset");
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public sealed partial class KeyringDialog : ContentDialog
                 InfoBar.Severity = InfoBarSeverity.Warning;
                 InfoBar.IsClosable = false;
                 InfoBar.IsOpen = true;
-                BtnInfoBarReset.Visibility = Visibility.Visible;
+                BtnReset.Visibility = Visibility.Visible;
                 BtnEnable.IsEnabled = false;
             }
             else if (_controller.IsEnabled)
@@ -130,6 +130,7 @@ public sealed partial class KeyringDialog : ContentDialog
             InfoBar.Content = _("Failed to enable keyring.");
             InfoBar.Severity = InfoBarSeverity.Error;
             InfoBar.IsOpen = true;
+            BtnReset.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -160,6 +161,7 @@ public sealed partial class KeyringDialog : ContentDialog
             InfoBar.Content = _("Unable to disable keyring.");
             InfoBar.Severity = InfoBarSeverity.Error;
             InfoBar.IsOpen = true;
+            BtnReset.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -194,6 +196,7 @@ public sealed partial class KeyringDialog : ContentDialog
                 InfoBar.Content = _("Unable to reset keyring.");
                 InfoBar.Severity = InfoBarSeverity.Error;
                 InfoBar.IsOpen = true;
+                BtnReset.Visibility = Visibility.Collapsed;
             }
         }
     }

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml
@@ -218,12 +218,6 @@
                             <Image Width="128" Height="128" Source="../Resources/org.nickvision.tubeconverter.ico"/>
 
                             <ProgressRing />
-
-                            <StackPanel Orientation="Vertical" Spacing="12">
-                                <TextBlock x:Name="LblStartup" HorizontalAlignment="Center" Style="{ThemeResource NavigationViewItemHeaderTextStyle}"/>
-
-                                <TextBlock x:Name="LblStartup2" HorizontalAlignment="Center" Foreground="Gray"/>
-                            </StackPanel>
                         </StackPanel>
                     </nickvision:ViewStackPage>
 

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -156,7 +156,6 @@ public sealed partial class MainWindow : Window
             ViewStack.CurrentPageName = "Startup";
             var accent = (SolidColorBrush)Application.Current.Resources["AccentFillColorDefaultBrush"];
             _controller.TaskbarItem = TaskbarItem.ConnectWindows(_hwnd, new System.Drawing.SolidBrush(System.Drawing.Color.FromArgb(accent.Color.A, accent.Color.R, accent.Color.G, accent.Color.B)), MainGrid.ActualTheme == ElementTheme.Dark ? System.Drawing.Brushes.Black : System.Drawing.Brushes.White);
-            await Task.Delay(1); //Crash without this
             await _controller.StartupAsync();
             MainMenu.IsEnabled = true;
             ViewStack.CurrentPageName = "Home";

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.WinUI.Notifications;
 using Microsoft.UI;
-using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -534,7 +534,7 @@ public sealed partial class MainWindow : Window
         {
             XamlRoot = MainGrid.XamlRoot
         };
-        if (!_isContentDialogShowing)
+        if (!_isContentDialogShowing || !string.IsNullOrEmpty(url))
         {
             _isContentDialogShowing = true;
             var res = await addDialog.ShowAsync(url);

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -193,8 +193,7 @@ public sealed partial class MainWindow : Window
             var res = await dialog.ShowAsync();
             if (res == ContentDialogResult.Primary)
             {
-                _controller.DownloadManager.StopAllDownloads(true);
-                Close();
+                ForceExit(sender, new RoutedEventArgs());
             }
         }
         else

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -160,6 +160,40 @@ public sealed partial class MainWindow : Window
             MainMenu.IsEnabled = true;
             ViewStack.CurrentPageName = "Home";
             PreventSuspendWhenDownloadingChanged(null, EventArgs.Empty);
+            if(_controller.ShowDisclaimerOnStartup)
+            {
+                var chkShow = new CheckBox()
+                {
+                    Content = _("Don't show this message again")
+                };
+                var disclaimerDialog = new ContentDialog()
+                {
+                    Title = _("Disclaimer"),
+                    Content = new StackPanel()
+                    {
+                        Orientation = Orientation.Vertical,
+                        Spacing = 6,
+                        Children =
+                        {
+                            new TextBlock()
+                            {
+                                MaxWidth = 400,
+                                TextWrapping = TextWrapping.WrapWholeWords,
+                                Text = _("The authors of Nickvision Parabolic are not responsible/liable for any misuse of this program that may violate local copyright/DMCA laws. Users use this application at their own risk."),
+                            },
+                            chkShow
+                        }
+                    },
+                    CloseButtonText = _("OK"),
+                    DefaultButton = ContentDialogButton.Close,
+                    XamlRoot = MainGrid.XamlRoot
+                };
+                _isContentDialogShowing = true;
+                await disclaimerDialog.ShowAsync();
+                _isContentDialogShowing = false;
+                _controller.ShowDisclaimerOnStartup = !chkShow.IsChecked ?? true;
+                _controller.SaveConfig();
+            }
             _isOpened = true;
         }
     }

--- a/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/MainWindow.xaml.cs
@@ -98,8 +98,6 @@ public sealed partial class MainWindow : Window
         MenuReportABug.Text = _("Report a Bug");
         MenuDiscussions.Text = _("Discussions");
         MenuAbout.Text = _("About {0}", _controller.AppInfo.ShortName);
-        LblStartup.Text = _("Preparing required tools...");
-        LblStartup2.Text = _("This may take a while");
         StatusPageHome.Title = _("Download Media");
         StatusPageHome.Description = _("Add a video, audio, or playlist URL to start downloading");
         LblBtnHomeAddDownload.Text = _("Add Download");
@@ -158,6 +156,7 @@ public sealed partial class MainWindow : Window
             ViewStack.CurrentPageName = "Startup";
             var accent = (SolidColorBrush)Application.Current.Resources["AccentFillColorDefaultBrush"];
             _controller.TaskbarItem = TaskbarItem.ConnectWindows(_hwnd, new System.Drawing.SolidBrush(System.Drawing.Color.FromArgb(accent.Color.A, accent.Color.R, accent.Color.G, accent.Color.B)), MainGrid.ActualTheme == ElementTheme.Dark ? System.Drawing.Brushes.Black : System.Drawing.Brushes.White);
+            await Task.Delay(1); //Crash without this
             await _controller.StartupAsync();
             MainMenu.IsEnabled = true;
             ViewStack.CurrentPageName = "Home";


### PR DESCRIPTION
Closes #628

TODO:
- [x] GNOME - DBus Open Implementation
- [x] WinUI - Install psutil & yt-dlp from installer, not inside app

Better WinUI AddDownloadDialog:

- Validate button in dialog footer itself:
![image](https://github.com/NickvisionApps/Parabolic/assets/17648453/359d2cbf-a2f1-4057-b47b-3bd3e90d2f08)

- New wait for validation:
![image](https://github.com/NickvisionApps/Parabolic/assets/17648453/cac199a5-5e9c-4b95-89ee-4b521667e6f7)