### PR TITLE
Use "numeric" style class for download progress

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -41,7 +41,7 @@ Adw.Bin _root {
           ellipsize: end;
           lines: 1;
 
-          styles ["caption", "dim-label"]
+          styles ["caption", "dim-label", "numeric"]
         }
       }
 


### PR DESCRIPTION
This is a small cosmetic change. Currently, the download progress label uses proportional figures. This makes it jump around as the numbers are updated. This PR adds the Adwaita style class "numeric" to use tabular numbers that have uniform width.

I have not been successful building the app on my machine, so I have not tested it in the context of the full app. However, I implemented this change to the Blueprint file in Workbench and it had the desired result.