### PR TITLE
Add and use display name variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 project("org.nickvision.tubeconverter" LANGUAGES C CXX VERSION 2024.10.0 DESCRIPTION "Download web video and audio.")
 set(SHORT_NAME "parabolic")
+set(DISPLAY_NAME "Parabolic")
 include(GNUInstallDirs)
 
 file(STRINGS "${CMAKE_SOURCE_DIR}/resources/po/POTFILES" TRANSLATE_FILES)

--- a/resources/linux/org.nickvision.tubeconverter.desktop.in
+++ b/resources/linux/org.nickvision.tubeconverter.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=Parabolic
+Name=@DISPLAY_NAME@
 Comment=Download web video and audio
 Exec=@CMAKE_INSTALL_FULL_LIBDIR@/@PROJECT_NAME@/@OUTPUT_NAME@
 Icon=@PROJECT_NAME@

--- a/resources/linux/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/resources/linux/org.nickvision.tubeconverter.metainfo.xml.in
@@ -3,7 +3,7 @@
   <id>@PROJECT_NAME@</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
-  <name>@SHORT_NAME@</name>
+  <name>@DISPLAY_NAME@</name>
   <project_group>Nickvision</project_group>
   <developer_name>Nickvision</developer_name>
   <summary>Download web video and audio</summary>


### PR DESCRIPTION
Parabolic is currently listed in all-lowercase as «parabolic» in app stores, which is not a particularly flattering look.

![Skjermbilde fra 2024-10-06 13-08-22](https://github.com/user-attachments/assets/7268087d-6dba-436d-8fc6-23850b62a9bf)

This PR adds a separate variable containing a «pretty» display version of the name. I'm not well-versed in CMake at all, but I suppose there isn't more that needs to be done for it to work.