### PR TITLE
Expand and modernize metainfo

### DIFF
--- a/resources/linux/org.nickvision.tubeconverter.desktop.in
+++ b/resources/linux/org.nickvision.tubeconverter.desktop.in
@@ -11,5 +11,3 @@ Keywords=YouTube;Downloader;ytdlp;Nickvision;Tube;Converter;audio;video;media;do
 MimeType=text/x-uri
 X-GNOME-UsesNotifications=true
 StartupNotify=@STARTUP_NOTIFY@
-# Translators: Do NOT translate or transliterate this text (these are enum types)!
-X-Purism-FormFactor=Workstation;Mobile;

--- a/resources/linux/org.nickvision.tubeconverter.metainfo.xml.in
+++ b/resources/linux/org.nickvision.tubeconverter.metainfo.xml.in
@@ -2,36 +2,55 @@
 <component type="desktop-application">
   <id>@PROJECT_NAME@</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>@DISPLAY_NAME@</name>
   <project_group>Nickvision</project_group>
-  <developer_name>Nickvision</developer_name>
+  <developer id="org.nickvision">
+    <name>Nickvision</name>
+  </developer>
   <summary>Download web video and audio</summary>
   <description>
-    <p>- A basic yt-dlp frontend</p>
-    <p>- Supports downloading videos in multiple formats (mp4, webm, mp3, opus, flac, and wav)</p>
-    <p>- Run multiple downloads at a time</p>
-    <p>- Supports downloading metadata and video subtitles</p>
+    <ul>
+      <li>A basic yt-dlp frontend</li>
+      <li>Supports downloading videos in multiple formats (mp4, webm, mp3, opus, flac, and wav)</li>
+      <li>Run multiple downloads at a time</li>
+      <li>Supports downloading metadata and video subtitles</li>
+    </ul>
   </description>
   <launchable type="desktop-id">@PROJECT_NAME@.desktop</launchable>
   <screenshots>
     <screenshot type="default">
+      <!-- Translators: Screenshot caption -->
+      <caption>Downloading files</caption>
       <image>https://raw.githubusercontent.com/NickvisionApps/@SHORT_NAME@/main/@OUTPUT_NAME@/screenshots/downloading.png</image>
     </screenshot>
     <screenshot>
+      <!-- Translators: Screenshot caption -->
+      <caption>Home page</caption>
       <image>https://raw.githubusercontent.com/NickvisionApps/@SHORT_NAME@/main/@OUTPUT_NAME@/screenshots/home.png</image>
     </screenshot>
     <screenshot>
+      <!-- Translators: Screenshot caption -->
+      <caption>Dark mode</caption>
       <image>https://raw.githubusercontent.com/NickvisionApps/@SHORT_NAME@/main/@OUTPUT_NAME@/screenshots/dark.png</image>
     </screenshot>
     <screenshot>
+      <!-- Translators: Screenshot caption -->
+      <caption>Adding a download</caption>
       <image>https://raw.githubusercontent.com/NickvisionApps/@SHORT_NAME@/main/@OUTPUT_NAME@/screenshots/add.png</image>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://github.com/NickvisionApps/@SHORT_NAME@</url>
+  <branding>
+    <color type="primary" scheme_preference="light">#ffc199</color>
+    <color type="primary" scheme_preference="dark">#ae0010</color>
+  </branding>
+  <url type="homepage">https://nickvision.org/@SHORT_NAME@.html</url>
   <url type="bugtracker">https://github.com/NickvisionApps/@SHORT_NAME@/issues</url>
   <url type="donation">https://github.com/sponsors/nlogozzo</url>
   <url type="translate">https://github.com/NickvisionApps/@SHORT_NAME@/blob/master/CONTRIBUTING.md#providing-translations</url>
+  <url type="contribute">https://github.com/NickvisionApps/@SHORT_NAME@/blob/main/CONTRIBUTING.md</url>
+  <url type="contact">https://matrix.to/#/#nickvision:matrix.org</url>
+  <url type="vcs-browser">https://github.com/NickvisionApps/@SHORT_NAME@</url>
   <provides>
     <binary>@PROJECT_NAME@</binary>
   </provides>
@@ -54,7 +73,4 @@
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>
-  <custom>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
 </component>


### PR DESCRIPTION
Hi again! This PR aims to improve how Parabolic is presented on Linux app stores.

- Replace deprecated `<developer_name>` with `<developer>`
- Convert description to markup list
- Add screenshot captions
- Add brand colors
- Add `contribute`, `contact`, and `vcs-browser` URLs
- Use correct `<project_license>`