### PR TITLE
Add windows releases to winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Nickvision.Parabolic
+          max-versions-to-keep: 5 # keep only latest 5 versions
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Hello @nlogozzo!

This is more of a feature request than a pull request. Recently, [I've taken the responsibility to add your app to Microsoft's winget repository](https://github.com/microsoft/winget-pkgs/pull/182928). It is quite convenient for me to install and update apps using [the winget tool](https://learn.microsoft.com/en-us/windows/package-manager/winget/). 

Here I suggest you to add the GitHub Action to create a PR to the winget repository after every next release. As an example, there is configuration for [the WinGet Releaser Action](https://github.com/vedantmgoyal9/winget-releaser) ([example of this PR](https://github.com/microsoft/winget-pkgs/pull/183437)), but if you like, you can choose another way to deploy, there are many of them ([dumplings](https://github.com/SpecterShell/Dumplings) for example or even manually). As for the WinGet Releaser, you additionally need to fork the [winget repository](https://github.com/microsoft/winget-pkgs) to your NickvisionApps organization according to their [get started instructions](https://github.com/vedantmgoyal9/winget-releaser?tab=readme-ov-file#getting-started-).

I hope you find this way of distributing your app useful. Thank you in advance for considering this suggestion!