### PR TITLE
Fix building on macOS with libsecret

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ set(SHORT_NAME "parabolic")
 set(DISPLAY_NAME "Parabolic")
 include(GNUInstallDirs)
 
+if(APPLE)
+    option(USE_LIBSECRET "Use libsecret on macOS instead of Apple keychain" OFF)
+endif()
+
 file(STRINGS "${CMAKE_SOURCE_DIR}/resources/po/POTFILES" TRANSLATE_FILES)
 file(STRINGS "${CMAKE_SOURCE_DIR}/resources/po/LINGUAS" LINGUAS)
 set(POT_FILE "${CMAKE_SOURCE_DIR}/resources/po/${SHORT_NAME}.pot")

--- a/libparabolic/CMakeLists.txt
+++ b/libparabolic/CMakeLists.txt
@@ -38,6 +38,9 @@ endif()
 
 find_package(libnick CONFIG REQUIRED)
 find_package(Boost REQUIRED COMPONENTS date_time)
+if(USE_LIBSECRET)
+    pkg_check_modules(libsecret REQUIRED IMPORTED_TARGET libsecret-1)
+endif()
 target_link_libraries(libparabolic PUBLIC libnick::libnick Boost::boost Boost::date_time)
 
 add_custom_target(shared_commands ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/__shared.h")


### PR DESCRIPTION
Verified to fix the build error both on Sonoma and on 10.6. Otherwise CMake fails to find `libsecret`.

P. S. How does it work on Linux though?