### PR TITLE
fix: Thumbnail crop

### DIFF
--- a/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
+++ b/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
@@ -326,14 +326,14 @@ public class YtdlpExecutableService : DependencyExecutableService, IYtdlpExecuta
                     arguments.Add("--exec");
                     arguments.Add("before_dl:del %(thumbnails.-1.filepath)q");
                     arguments.Add("--exec");
-                    arguments.Add("before_dl:move \"%(thumbnails.-1.filepath)s.tmp.jpg\" %(thumbnails.-1.filepath)q");
+                    arguments.Add("before_dl:move %(thumbnails.-1.filepath)q.tmp.jpg %(thumbnails.-1.filepath)q");
                 }
                 else
                 {
                     arguments.Add("--exec");
                     arguments.Add("before_dl:rm %(thumbnails.-1.filepath)q");
                     arguments.Add("--exec");
-                    arguments.Add("before_dl:mv \"%(thumbnails.-1.filepath)s.tmp.jpg\" %(thumbnails.-1.filepath)q");
+                    arguments.Add("before_dl:mv %(thumbnails.-1.filepath)q.tmp.jpg %(thumbnails.-1.filepath)q");
                 }
             }
         }

--- a/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
+++ b/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
@@ -320,7 +320,7 @@ public class YtdlpExecutableService : DependencyExecutableService, IYtdlpExecuta
             if (_configurationService.CropAudioThumbnails && downloadOptions.FileType.IsAudio)
             {
                 arguments.Add("--exec");
-                arguments.Add($"before_dl:\"{Desktop.System.Environment.FindDependency("ffmpeg") ?? "ffmpeg"}\" -i %(thumbnails.-1.filepath)q -vf crop=\"'if(gt(ih,iw),iw,ih)':'if(gt(iw,ih),ih,iw)'\" \"%(thumbnails.-1.filepath)s.tmp.jpg\"");
+                arguments.Add($"before_dl:\"{Desktop.System.Environment.FindDependency("ffmpeg") ?? "ffmpeg"}\" -i %(thumbnails.-1.filepath)q -vf crop=\"'if(gt(ih,iw),iw,ih)':'if(gt(iw,ih),ih,iw)'\" %(thumbnails.-1.filepath)q.tmp.jpg");
                 if (OperatingSystem.IsWindows())
                 {
                     arguments.Add("--exec");


### PR DESCRIPTION
Fixing thumbnail crop error by changing "%(s)" Conversion to "%(q)" as described in 
https://github.com/NickvisionApps/Parabolic/issues/1910
https://github.com/NickvisionApps/Parabolic/issues/1913
https://github.com/NickvisionApps/Parabolic/issues/1907

This fix has already been tested my myself and does work.