### PR TITLE
fix: update flatpak dependencies

### DIFF
--- a/flatpak/org.nickvision.tubeconverter.json
+++ b/flatpak/org.nickvision.tubeconverter.json
@@ -67,8 +67,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/lexiforest/curl-impersonate/releases/download/v1.5.2/curl-impersonate-v1.5.2.x86_64-linux-gnu.tar.gz",
-                    "sha256": "29907d879bdc783fc46e5841585c2455d46fec5acdcfc2c65a3aa8485bb49850",
+                    "url": "https://github.com/lexiforest/curl-impersonate/releases/download/v1.5.6/curl-impersonate-v1.5.6.x86_64-linux-gnu.tar.gz",
+                    "sha256": "b60344f63b9ed8806f0e9f7fd357d9f6c9a82aca279ed1e9e257d544885dcbde",
                     "strip-components": 0,
                     "only-arches": [
                         "x86_64"
@@ -76,8 +76,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/lexiforest/curl-impersonate/releases/download/v1.5.2/curl-impersonate-v1.5.2.aarch64-linux-gnu.tar.gz",
-                    "sha256": "e7d3ef043b01caeea68246645eb43c3a55e6f7f0ac5895bc0ffd99a98b0702c5",
+                    "url": "https://github.com/lexiforest/curl-impersonate/releases/download/v1.5.6/curl-impersonate-v1.5.6.aarch64-linux-gnu.tar.gz",
+                    "sha256": "6766bc67fd3e8e2313875f32b36b5a3fab02beffe77e5f1cf7fc5da99731d403",
                     "strip-components": 0,
                     "only-arches": [
                         "aarch64"
@@ -94,16 +94,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/denoland/deno/releases/download/v2.8.0/deno-x86_64-unknown-linux-gnu.zip",
-                    "sha256": "be2c8b53c8ca1d66be76feb9b1a524419da708b00d4ca074cf5c633c81c1627b",
+                    "url": "https://github.com/denoland/deno/releases/download/v2.9.0/deno-x86_64-unknown-linux-gnu.zip",
+                    "sha256": "96c9c73fc05ea57603bc28d8071d41e861bd40bcf2a9f849dd5969ed1a2c8498",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/denoland/deno/releases/download/v2.8.0/deno-aarch64-unknown-linux-gnu.zip",
-                    "sha256": "933a6a7d2985957271cd2085a5a5a1832398aa221a354daab5635196cf2cbbae",
+                    "url": "https://github.com/denoland/deno/releases/download/v2.9.0/deno-aarch64-unknown-linux-gnu.zip",
+                    "sha256": "a0f266eb189af2f27db0c6dcf9eb2f68ba2e8bbff1442c969ace398463f8b2bf",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -119,16 +119,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-23-13-18/ffmpeg-n8.1.1-8-gb21e00eda5-linux64-gpl-8.1.tar.xz",
-                    "sha256": "8c36ed5ff4fa46f031622e3f8bebce356d0f8add7208ce1d020a301cf65255e2",
+                    "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz",
+                    "sha256": "91ee951df43dad3ae357dbcd544cb625c8f6d4329564d4028d5eb68706140eb2",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-23-13-18/ffmpeg-n8.1.1-8-gb21e00eda5-linuxarm64-gpl-8.1.tar.xz",
-                    "sha256": "21dbd7a2bf52454d0eb5ecebbbed44cf24ac259a40148c1c240d1b08b9aa5a36",
+                    "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linuxarm64-gpl-8.1.tar.xz",
+                    "sha256": "5f10913fe244ea876f7a62cd434ed2e2766b147e30953619eeef4c08b7044b69",
                     "only-arches": [
                         "aarch64"
                     ]


### PR DESCRIPTION
Update necessary Flatpak dependencies so that the GitHub Action can successfully build the package